### PR TITLE
Spelling and standardization fixes to match GURPS Magic

### DIFF
--- a/Library/Spells/Magic.spl
+++ b/Library/Spells/Magic.spl
@@ -1505,7 +1505,7 @@
 		</prereq_list>
 	</spell>
 	<spell version="2">
-		<name>Bless Plant</name>
+		<name>Bless Plants</name>
 		<college>Plant</college>
 		<power_source>Arcane</power_source>
 		<spell_class>Area</spell_class>
@@ -1868,7 +1868,7 @@
 		</prereq_list>
 	</spell>
 	<spell version="2" very_hard="yes">
-		<name>Body of Shadows</name>
+		<name>Body of Shadow</name>
 		<college>Light &amp; Darkness</college>
 		<power_source>Arcane</power_source>
 		<spell_class>Regular/R-HT</spell_class>
@@ -4132,7 +4132,7 @@
 		</prereq_list>
 	</spell>
 	<spell version="2">
-		<name>Create Plants</name>
+		<name>Create Plant</name>
 		<college>Plant</college>
 		<power_source>Arcane</power_source>
 		<spell_class>Area</spell_class>
@@ -5607,7 +5607,7 @@
 		</prereq_list>
 	</spell>
 	<spell version="2" very_hard="yes">
-		<name>Doppleganger</name>
+		<name>Doppelganger</name>
 		<college>Enchantment</college>
 		<power_source>Arcane</power_source>
 		<spell_class>Enchantment</spell_class>
@@ -14199,7 +14199,7 @@
 		</prereq_list>
 	</spell>
 	<spell version="2">
-		<name>Rain Ice Daggers</name>
+		<name>Rain of Ice Daggers</name>
 		<college>Water</college>
 		<power_source>Arcane</power_source>
 		<spell_class>Area</spell_class>
@@ -14948,7 +14948,7 @@
 		</prereq_list>
 	</spell>
 	<spell version="2">
-		<name>Remove Enchant</name>
+		<name>Remove Enchantment</name>
 		<college>Enchantment</college>
 		<power_source>Arcane</power_source>
 		<spell_class>Enchantment</spell_class>
@@ -15908,7 +15908,7 @@
 		</prereq_list>
 	</spell>
 	<spell version="2">
-		<name>Rooted Feed</name>
+		<name>Rooted Feet</name>
 		<college>Body Control</college>
 		<power_source>Arcane</power_source>
 		<spell_class>Regular</spell_class>
@@ -18851,7 +18851,7 @@
 		</prereq_list>
 	</spell>
 	<spell version="2">
-		<name>Steel Wraith</name>
+		<name>Steelwraith</name>
 		<college>Earth</college>
 		<power_source>Arcane</power_source>
 		<spell_class>Regular</spell_class>


### PR DESCRIPTION
There are several spells in Magic.spl that don't actually match the names used
in GURPS Magic. This changes them to match. I don't know if you necessarily want this -- for some of these I could believe this is a ~difference in your style guide, and even for the others I don't know if this breaks things for existing characters (looks like no?). Anyway, I was trying to merge information from the GCS spell list and another one and ran across these discrepancies, so figured I'd submit this. (Also, sorry if PR's are the wrong way to suggest changes. Since I had a patch, I figured this might be the easiest.)

Summary of changes:
- Change plural/non-plural status of spells
- "Rain Ice Daggers" is "Rain of Ice Daggers"
- "Remove Enchant" is "Remove Enchantment"
- "Steel Wraith" is "Steelwraith"
- "Rooted Feed" should be "Feet"