### PR TITLE
Allow skills and spells to be based on 10 rather then any attribute.

### DIFF
--- a/src/com/trollworks/gcs/skill/SkillAttribute.java
+++ b/src/com/trollworks/gcs/skill/SkillAttribute.java
@@ -88,6 +88,18 @@ public enum SkillAttribute {
 		public int getBaseSkillLevel(GURPSCharacter character) {
 			return character != null ? character.getPerception() : Integer.MIN_VALUE;
 		}
+	},
+	/** Just 10 instead of the actual attribute. */
+	Base10 {
+		@Override
+		public String toString() {
+			return BASE_10_TITLE;
+		}
+
+		@Override
+		public int getBaseSkillLevel(GURPSCharacter character) {
+			return 10;
+		}
 	};
 
 	@Localize("ST")
@@ -119,6 +131,8 @@ public enum SkillAttribute {
 	@Localize(locale = "de", value = "WN")
 	@Localize(locale = "ru", value = "Восп")
 	static String	PER_TITLE;
+	@Localize("10")
+	static String	BASE_10_TITLE;
 
 	static {
 		Localization.initialize();

--- a/src/com/trollworks/gcs/skill/SkillDefaultType.java
+++ b/src/com/trollworks/gcs/skill/SkillDefaultType.java
@@ -204,6 +204,18 @@ public enum SkillDefaultType {
 		public boolean isSkillBased() {
 			return true;
 		}
+	},
+	/** The type for 10-based defaults. */
+	Base10 {
+		@Override
+		public String toString() {
+			return BASE_10_TITLE;
+		}
+
+		@Override
+		public int getSkillLevelFast(GURPSCharacter character, SkillDefault skillDefault, HashSet<String> excludes) {
+			return finalLevel(skillDefault, SkillAttribute.Base10.getBaseSkillLevel(character));
+		}
 	};
 
 	@Localize("ST")
@@ -251,6 +263,8 @@ public enum SkillDefaultType {
 	@Localize(locale = "ru", value = "Название умения блока")
 	@Localize(locale = "es", value = "Habilidad de bloqueo llamada")
 	static String	BLOCK_SKILL_NAMED;
+	@Localize("10")
+	static String	BASE_10_TITLE;
 
 	static {
 		Localization.initialize();


### PR DESCRIPTION
Partially solves https://gurpscharactersheet.atlassian.net/browse/GCS-25

While this simple change doesn't allow to directly choose advantage for `10+<advantage name>` format, it can be solved by making advantage to add its level to all required skills (which Magery already does). So, better than nothing, I guess?