### PR TITLE
Fixed skill containers affecting skill defaults

### DIFF
--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -2485,11 +2485,13 @@ public class GURPSCharacter extends DataFile {
 		ArrayList<Skill> skills = new ArrayList<>();
 		boolean checkSpecialization = specialization != null && specialization.length() > 0;
 		for (Skill skill : getSkillsIterator()) {
-			if (excludes == null || !excludes.contains(skill.toString())) {
-				if (!requirePoints || skill.getPoints() > 0) {
-					if (skill.getName().equalsIgnoreCase(name)) {
-						if (!checkSpecialization || skill.getSpecialization().equalsIgnoreCase(specialization)) {
-							skills.add(skill);
+			if (!skill.canHaveChildren()) {
+				if (excludes == null || !excludes.contains(skill.toString())) {
+					if (!requirePoints || skill.getPoints() > 0) {
+						if (skill.getName().equalsIgnoreCase(name)) {
+							if (!checkSpecialization || skill.getSpecialization().equalsIgnoreCase(specialization)) {
+								skills.add(skill);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Because of my change for skill containers (to show sum of all underlying skills) they are sometimes being used as valid skill defaults.
Kalos reported this bug on discord.
https://i.gyazo.com/6fb5161c2f4b40d8114bd0c3a361a2b2.png