### PR TITLE
Encumbrance penalty for fencing weapon

### DIFF
--- a/src/com/trollworks/gcs/weapon/MeleeWeaponStats.java
+++ b/src/com/trollworks/gcs/weapon/MeleeWeaponStats.java
@@ -175,7 +175,7 @@ public class MeleeWeaponStats extends WeaponStats {
                                 }
                                 skillLevel = best != Integer.MIN_VALUE ? best : 0;
                             }
-                            num = Numbers.format(skillLevel + (neg ? -modifier : modifier));
+                            num = Numbers.format(skillLevel + (neg ? -modifier : modifier) + (token.contains("F") ? character.getEncumbranceLevel().getEncumbrancePenalty() : 0)); //$NON-NLS-1$
                             if (i < max) {
                                 buffer.append(num);
                                 token = token.substring(i);

--- a/src/com/trollworks/gcs/weapon/WeaponStats.java
+++ b/src/com/trollworks/gcs/weapon/WeaponStats.java
@@ -435,9 +435,14 @@ public abstract class WeaponStats {
             int minST = getMinStrengthValue() - (character.getStrength() + character.getStrikingStrengthBonus());
             if (minST > 0) {
                 best -= minST;
-                if (best < 0) {
-                    best = 0;
+            }
+            if (this instanceof MeleeWeaponStats) {
+                if (((MeleeWeaponStats) this).getParry().contains("F")) { //$NON-NLS-1$
+                    best += character.getEncumbranceLevel().getEncumbrancePenalty();
                 }
+            }
+            if (best < 0) {
+                best = 0;
             }
         } else {
             best = 0;


### PR DESCRIPTION
GURPS B208: Fencing weapons getting a penalty equal to the encumbrance
level to attacks and parries