### PR TITLE
Fixed spelling of literal, and minor enhancement TextOutput

### DIFF
--- a/src/com/trollworks/gcs/character/TextTemplate.java
+++ b/src/com/trollworks/gcs/character/TextTemplate.java
@@ -173,7 +173,7 @@ public class TextTemplate {
     private static final String KEY_IQ_POINTS                         = "IQ_POINTS";
     private static final String KEY_LANGUAGES_LOOP_END                = "LANGUAGES_LOOP_END";
     private static final String KEY_LANGUAGES_LOOP_START              = "LANGUAGES_LOOP_START";
-    private static final String KEY_LEGAILITY_CLASS                   = "LEGALITY_CLASS";
+    private static final String KEY_LEGALITY_CLASS                    = "LEGALITY_CLASS";
     private static final String KEY_LEVEL                             = "LEVEL";
     private static final String KEY_LEVEL_ONLY                        = "LEVEL_ONLY";
     private static final String KEY_LOCATION                          = "LOCATION";
@@ -868,10 +868,17 @@ public class TextTemplate {
                             // Assume Vitals uses the same equipment as Torso
                             locationKey = HitLocation.TORSO.getKey();
                         }
+                        boolean showEquipment = ((DRBonus) feature).getLocation() == com.trollworks.gcs.feature.HitLocation.FULL_BODY;
+                        if (((DRBonus) feature).getLocation() == com.trollworks.gcs.feature.HitLocation.FULL_BODY_EXCEPT_EYES) {
+                            showEquipment = !locationKey.equals(HitLocation.EYE.getKey());
+                        }
                         if (locationKey.endsWith(((DRBonus) feature).getLocation().name())) {
                             // HUGE Kludge. Only way I could equate the 2
                             // different HitLocations. I know that one is derived
                             // from the other, so this check will ALWAYS work.
+                            showEquipment = true;
+                        }
+                        if (showEquipment) {
                             if (!first) {
                                 sb.append("\n");
                             }
@@ -1280,7 +1287,7 @@ public class TextTemplate {
                     writeEncodedText(out, Numbers.format(equipment.getValue()));
                 }
                 break;
-            case KEY_LEGAILITY_CLASS:
+            case KEY_LEGALITY_CLASS:
                 if (equipment != null) {
                     writeEncodedText(out, equipment.getLegalityClass());
                 }
@@ -1626,7 +1633,7 @@ public class TextTemplate {
                                 case KEY_TL:
                                     writeEncodedText(out, equipment.getTechLevel());
                                     break;
-                                case KEY_LEGAILITY_CLASS:
+                                case KEY_LEGALITY_CLASS:
                                     writeEncodedText(out, equipment.getDisplayLegalityClass());
                                     break;
                                 case KEY_CARRIED_STATUS:

--- a/src/com/trollworks/gcs/character/TextTemplate.java
+++ b/src/com/trollworks/gcs/character/TextTemplate.java
@@ -173,7 +173,7 @@ public class TextTemplate {
     private static final String KEY_IQ_POINTS                         = "IQ_POINTS";
     private static final String KEY_LANGUAGES_LOOP_END                = "LANGUAGES_LOOP_END";
     private static final String KEY_LANGUAGES_LOOP_START              = "LANGUAGES_LOOP_START";
-    private static final String KEY_LEGALITY_CLASS                    = "LEGALITY_CLASS";
+    private static final String KEY_LEGAILITY_CLASS                   = "LEGALITY_CLASS";
     private static final String KEY_LEVEL                             = "LEVEL";
     private static final String KEY_LEVEL_ONLY                        = "LEVEL_ONLY";
     private static final String KEY_LOCATION                          = "LOCATION";
@@ -868,17 +868,10 @@ public class TextTemplate {
                             // Assume Vitals uses the same equipment as Torso
                             locationKey = HitLocation.TORSO.getKey();
                         }
-                        boolean showEquipment = ((DRBonus) feature).getLocation() == com.trollworks.gcs.feature.HitLocation.FULL_BODY;
-                        if (((DRBonus) feature).getLocation() == com.trollworks.gcs.feature.HitLocation.FULL_BODY_EXCEPT_EYES) {
-                            showEquipment = !locationKey.equals(HitLocation.EYE.getKey());
-                        }
                         if (locationKey.endsWith(((DRBonus) feature).getLocation().name())) {
                             // HUGE Kludge. Only way I could equate the 2
                             // different HitLocations. I know that one is derived
                             // from the other, so this check will ALWAYS work.
-                            showEquipment = true;
-                        }
-                        if (showEquipment) {
                             if (!first) {
                                 sb.append("\n");
                             }
@@ -1287,7 +1280,7 @@ public class TextTemplate {
                     writeEncodedText(out, Numbers.format(equipment.getValue()));
                 }
                 break;
-            case KEY_LEGALITY_CLASS:
+            case KEY_LEGAILITY_CLASS:
                 if (equipment != null) {
                     writeEncodedText(out, equipment.getLegalityClass());
                 }
@@ -1633,7 +1626,7 @@ public class TextTemplate {
                                 case KEY_TL:
                                     writeEncodedText(out, equipment.getTechLevel());
                                     break;
-                                case KEY_LEGALITY_CLASS:
+                                case KEY_LEGAILITY_CLASS:
                                     writeEncodedText(out, equipment.getDisplayLegalityClass());
                                     break;
                                 case KEY_CARRIED_STATUS:

--- a/src/com/trollworks/gcs/widgets/outline/MultiCell.java
+++ b/src/com/trollworks/gcs/widgets/outline/MultiCell.java
@@ -205,10 +205,22 @@ public class MultiCell implements Cell {
         return Cursor.getDefaultCursor();
     }
 
+    /** Allow a satified row to display a tooltip */
     @Override
     public String getToolTipText(Outline outline, MouseEvent event, Rectangle bounds, Row row, Column column) {
         ListRow theRow = (ListRow) row;
-        return theRow.isSatisfied() ? null : theRow.getReasonForUnsatisfied();
+        if (theRow.isSatisfied()) {
+            return getToolTip(row, column);
+        } else {
+            return theRow.getReasonForUnsatisfied();
+        }
+    }
+
+    protected String getToolTip(Row row, Column column) {
+        if (row != null) {
+            return row.getToolTip(column);
+        }
+        return null;
     }
 
     @Override

--- a/src/com/trollworks/gcs/widgets/outline/MultiCell.java
+++ b/src/com/trollworks/gcs/widgets/outline/MultiCell.java
@@ -205,15 +205,11 @@ public class MultiCell implements Cell {
         return Cursor.getDefaultCursor();
     }
 
-    /** Allow a satified row to display a tooltip */
+    /** Allow a satisfied row to display a tooltip */
     @Override
     public String getToolTipText(Outline outline, MouseEvent event, Rectangle bounds, Row row, Column column) {
         ListRow theRow = (ListRow) row;
-        if (theRow.isSatisfied()) {
-            return getToolTip(row, column);
-        } else {
-            return theRow.getReasonForUnsatisfied();
-        }
+        return theRow.isSatisfied() ? getToolTip(row, column) : theRow.getReasonForUnsatisfied();
     }
 
     protected String getToolTip(Row row, Column column) {


### PR DESCRIPTION
#2 (in a series).

This fixes the spelling error on the literal, and updates the code that determines which piece of equipment provides the DR bonus during the text output to support armor that covers "Full Body" or "Full Body except the eyes".