### PR TITLE
Extended tooltip framework to Row/ListRow subclasses

### DIFF
--- a/src/com/trollworks/gcs/advantage/Advantage.java
+++ b/src/com/trollworks/gcs/advantage/Advantage.java
@@ -1084,4 +1084,14 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
     protected String getCategoryID() {
         return ID_CATEGORY;
     }
+
+    @Override
+    public boolean alwaysShowToolTip(Column column) {
+        return AdvantageColumn.values()[column.getID()].showToolTip();
+    }
+
+    @Override
+    public String getToolTip(Column column) {
+        return AdvantageColumn.values()[column.getID()].getToolTip(this);
+    }
 }

--- a/src/com/trollworks/gcs/advantage/AdvantageColumn.java
+++ b/src/com/trollworks/gcs/advantage/AdvantageColumn.java
@@ -333,4 +333,13 @@ public enum AdvantageColumn {
             }
         }
     }
+
+    public boolean showToolTip() {
+        return false;
+    }
+
+    public String getToolTip(Advantage advantage) {
+        return getToolTip();
+    }
+
 }

--- a/src/com/trollworks/gcs/equipment/Equipment.java
+++ b/src/com/trollworks/gcs/equipment/Equipment.java
@@ -732,4 +732,14 @@ public class Equipment extends ListRow implements HasSourceReference {
     protected String getCategoryID() {
         return ID_CATEGORY;
     }
+
+    @Override
+    public boolean alwaysShowToolTip(Column column) {
+        return EquipmentColumn.values()[column.getID()].showToolTip();
+    }
+
+    @Override
+    public String getToolTip(Column column) {
+        return EquipmentColumn.values()[column.getID()].getToolTip(this);
+    }
 }

--- a/src/com/trollworks/gcs/equipment/EquipmentColumn.java
+++ b/src/com/trollworks/gcs/equipment/EquipmentColumn.java
@@ -621,4 +621,12 @@ public enum EquipmentColumn {
         }
         return weight;
     }
+
+    public boolean showToolTip() {
+        return false;
+    }
+
+    public String getToolTip(Equipment equipment) {
+        return getToolTip();
+    }
 }

--- a/src/com/trollworks/gcs/skill/Skill.java
+++ b/src/com/trollworks/gcs/skill/Skill.java
@@ -939,4 +939,14 @@ public class Skill extends ListRow implements HasSourceReference {
     public Skill getDefaultSkill() {
         return getBaseSkill(getCharacter(), mDefaultedFrom);
     }
+
+    @Override
+    public boolean alwaysShowToolTip(Column column) {
+        return SkillColumn.values()[column.getID()].showToolTip();
+    }
+
+    @Override
+    public String getToolTip(Column column) {
+        return SkillColumn.values()[column.getID()].getToolTip(this);
+    }
 }

--- a/src/com/trollworks/gcs/skill/SkillColumn.java
+++ b/src/com/trollworks/gcs/skill/SkillColumn.java
@@ -449,4 +449,12 @@ public enum SkillColumn {
             }
         }
     }
+
+    public boolean showToolTip() {
+        return false;
+    }
+
+    public String getToolTip(Skill skill) {
+        return getToolTip();
+    }
 }

--- a/src/com/trollworks/gcs/spell/Spell.java
+++ b/src/com/trollworks/gcs/spell/Spell.java
@@ -842,4 +842,14 @@ public class Spell extends ListRow implements HasSourceReference {
     protected String getCategoryID() {
         return ID_CATEGORY;
     }
+
+    @Override
+    public boolean alwaysShowToolTip(Column column) {
+        return SpellColumn.values()[column.getID()].showToolTip();
+    }
+
+    @Override
+    public String getToolTip(Column column) {
+        return SpellColumn.values()[column.getID()].getToolTip(this);
+    }
 }

--- a/src/com/trollworks/gcs/spell/SpellColumn.java
+++ b/src/com/trollworks/gcs/spell/SpellColumn.java
@@ -524,4 +524,12 @@ public enum SpellColumn {
             }
         }
     }
+
+    public boolean showToolTip() {
+        return false;
+    }
+
+    public String getToolTip(Spell spell) {
+        return getToolTip();
+    }
 }

--- a/src/com/trollworks/gcs/weapon/WeaponColumn.java
+++ b/src/com/trollworks/gcs/weapon/WeaponColumn.java
@@ -583,4 +583,12 @@ public enum WeaponColumn {
             }
         }
     }
+
+    public boolean showToolTip() {
+        return false;
+    }
+
+    public String getToolTip(WeaponDisplayRow weapon) {
+        return getToolTip();
+    }
 }

--- a/src/com/trollworks/gcs/weapon/WeaponDisplayRow.java
+++ b/src/com/trollworks/gcs/weapon/WeaponDisplayRow.java
@@ -62,4 +62,15 @@ public class WeaponDisplayRow extends Row {
     public void setData(Column column, Object data) {
         // Not used
     }
+
+    @Override
+    public boolean alwaysShowToolTip(Column column) {
+        return WeaponColumn.values()[column.getID()].showToolTip();
+    }
+
+    @Override
+    public String getToolTip(Column column) {
+        return WeaponColumn.values()[column.getID()].getToolTip(this);
+    }
+
 }


### PR DESCRIPTION
The next step to extending tooltips.   Subclasses of Row (Advantage, Equipment, Skill, Spell and WeaponDisplayRow) now override the Row behavior and ask their respective columns if they should be showing a tooltip for that column (default is false), and if so, what tooltip to show based on the Row element (default to the generic tooltip for that column).
