### PR TITLE
Converted Skill to use SkillLevel

### DIFF
--- a/src/com/trollworks/gcs/skill/Skill.java
+++ b/src/com/trollworks/gcs/skill/Skill.java
@@ -53,6 +53,21 @@ public class Skill extends ListRow implements HasSourceReference {
     @Localize(locale = "ru", value = "По умолчанию: ")
     @Localize(locale = "es", value = "Valore por defecto: ")
     static String DEFAULTED_FROM;
+    @Localize("Encumbrance ")
+    @Localize(locale = "de", value = "Belastung ")
+    @Localize(locale = "ru", value = "Oбременение ")
+    @Localize(locale = "es", value = "Entumecimiento ")
+    static String ENCUMBRANCE;
+    @Localize("Includes modifiers from")
+    @Localize(locale = "de", value = "Enthält Modifikatoren von")
+    @Localize(locale = "ru", value = "Включает в себя модификаторы из")
+    @Localize(locale = "es", value = "Incluye modificadores de")
+    static String INCLUDES;
+    @Localize("No additional modifiers")
+    @Localize(locale = "de", value = "Keine zusätzlichen Modifikatoren")
+    @Localize(locale = "ru", value = "Никаких дополнительных модификаторов")
+    @Localize(locale = "es", value = "No hay modificadores adicionales")
+    static String NO_MODIFIERS;
 
     static {
         Localization.initialize();
@@ -106,8 +121,7 @@ public class Skill extends ListRow implements HasSourceReference {
     private String                 mName;
     private String                 mSpecialization;
     private String                 mTechLevel;
-    private int                    mLevel;
-    private int                    mRelativeLevel;
+    private SkillLevel             mLevel;
     private SkillAttribute         mAttribute;
     private SkillDifficulty        mDifficulty;
     /** The points spent. */
@@ -223,18 +237,16 @@ public class Skill extends ListRow implements HasSourceReference {
         }
         if (obj instanceof Skill && getClass() == obj.getClass() && super.isEquivalentTo(obj)) {
             Skill row = (Skill) obj;
-            if (mLevel == row.mLevel) {
+            if (mLevel.isSameLevelAs(row.mLevel)) {
                 if (mPoints == row.mPoints) {
                     if (mEncumbrancePenaltyMultiplier == row.mEncumbrancePenaltyMultiplier) {
-                        if (mRelativeLevel == row.mRelativeLevel) {
-                            if (mAttribute == row.mAttribute) {
-                                if (mDifficulty == row.mDifficulty) {
-                                    if (mName.equals(row.mName)) {
-                                        if (mTechLevel == null ? row.mTechLevel == null : mTechLevel.equals(row.mTechLevel)) {
-                                            if (mSpecialization.equals(row.mSpecialization)) {
-                                                if (mReference.equals(row.mReference)) {
-                                                    return mWeapons.equals(row.mWeapons);
-                                                }
+                        if (mAttribute == row.mAttribute) {
+                            if (mDifficulty == row.mDifficulty) {
+                                if (mName.equals(row.mName)) {
+                                    if (mTechLevel == null ? row.mTechLevel == null : mTechLevel.equals(row.mTechLevel)) {
+                                        if (mSpecialization.equals(row.mSpecialization)) {
+                                            if (mReference.equals(row.mReference)) {
+                                                return mWeapons.equals(row.mWeapons);
                                             }
                                         }
                                     }
@@ -381,12 +393,16 @@ public class Skill extends ListRow implements HasSourceReference {
 
     /** @return The level. */
     public int getLevel() {
-        return mLevel;
+        return mLevel.getLevel();
     }
 
     /** @return The relative level. */
     public int getRelativeLevel() {
-        return mRelativeLevel;
+        return mLevel.getRelativeLevel();
+    }
+
+    public String getLevelToolTip() {
+        return mLevel.getToolTip();
     }
 
     /** @return The name. */
@@ -479,19 +495,15 @@ public class Skill extends ListRow implements HasSourceReference {
      * @param notify Whether or not a notification should be issued on a change.
      */
     public void updateLevel(boolean notify) {
-        int        savedLevel         = mLevel;
-        int        savedRelativeLevel = mRelativeLevel;
-        SkillLevel level              = calculateLevelSelf();
-
-        mLevel         = level.mLevel;
-        mRelativeLevel = level.mRelativeLevel;
+        SkillLevel savedLevel = mLevel;
+        mLevel = calculateLevelSelf();
 
         if (notify) {
             startNotify();
-            if (savedLevel != mLevel) {
+            if (savedLevel.isDifferentLevelThan(mLevel)) {
                 notify(ID_LEVEL, this);
             }
-            if (savedRelativeLevel != mRelativeLevel) {
+            if (savedLevel.isDifferentRelativeLevelThan(mLevel)) {
                 notify(ID_RELATIVE_LEVEL, this);
             }
             endNotify();

--- a/src/com/trollworks/gcs/skill/SkillLevel.java
+++ b/src/com/trollworks/gcs/skill/SkillLevel.java
@@ -14,13 +14,19 @@ package com.trollworks.gcs.skill;
 /** Provides simple storage for the skill level/relative level pair. */
 public class SkillLevel {
     /** The skill level. */
-    public int mLevel;
+    public int    mLevel;
     /** The relative skill level. */
-    public int mRelativeLevel;
+    public int    mRelativeLevel;
+    /** The tooltip describing how this level was calculated. */
+    public String mToolTip;
+
+    public String getToolTip() {
+        return mToolTip == null ? "" : mToolTip;
+    }
 
     /**
      * Creates a new {@link SkillLevel}.
-     * 
+     *
      * @param level         The skill level.
      * @param relativeLevel The relative skill level.
      */
@@ -28,4 +34,40 @@ public class SkillLevel {
         mLevel         = level;
         mRelativeLevel = relativeLevel;
     }
+
+    /**
+     * Creates a new {@link SkillLevel}.
+     *
+     * @param level         The skill level.
+     * @param relativeLevel The relative skill level.
+     * @param tip           The tooltip to display for this skill.
+     */
+    public SkillLevel(int level, int relativeLevel, String toolTip) {
+        mLevel         = level;
+        mRelativeLevel = relativeLevel;
+        mToolTip       = toolTip;
+    }
+
+    /** @return The level. */
+    public int getLevel() {
+        return mLevel;
+    }
+
+    /** @return The relativeLevel. */
+    public int getRelativeLevel() {
+        return mRelativeLevel;
+    }
+
+    public boolean isDifferentLevelThan(SkillLevel other) {
+        return mLevel != other.mLevel;
+    }
+
+    public boolean isDifferentRelativeLevelThan(SkillLevel other) {
+        return mRelativeLevel != other.mRelativeLevel;
+    }
+
+    public boolean isSameLevelAs(SkillLevel other) {
+        return mLevel == other.mLevel && mRelativeLevel == other.mRelativeLevel;
+    }
+
 }


### PR DESCRIPTION
The main feature of this PR is that Skill will now use an instance of SkillLevel to store level and relative level, instead of using ints.    

You had a question about performance, so I did some math, and even with hundreds of skills, I don't think that will be a problem.   SkillLevel is a very light class (2 ints and a String).   Which uses 16 bytes for the object header, 8 bytes per int, 8 bytes for String pointer.   And then you have to add in the usage for the tooltip string itself, which averages out to "length of string * 6" bytes (a rough calculation of the number of bytes necessary to hold a string, obtained from research I did a few years ago).   

A Skill with no modifiers will have a tooltip of approx 25 characters/150 bytes (it reports "no additional modifiers").  On average, each additional modifier to a skill will be another 25 characters/150 bytes, give or take, depending on the length of the contributing advantage, etc.

For 1000 skills, each with 2 modifiers per skill, the heap usages will be:

40 bytes per Skill Level
~450 bytes per tooltip string

Approx 490KB.   I don't know what settings you have for the JVM in terms of heap/eden space, but 1/2 MB shouldn't cause too much trouble, so I think this should be safe.   

Unfortunately, I included a few extra things in this PR, namely the internationalized strings that I will be using in a later PR.  Since they really aren't affecting anything, I left them in, I hope that is ok.