### PR TITLE
Added tooltip for Skill level calculation

### DIFF
--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -2660,12 +2660,23 @@ public class GURPSCharacter extends DataFile {
      * @return The bonus.
      */
     public int getIntegerBonusFor(String id) {
+        return getIntegerBonusFor(id, null);
+    }
+
+    /**
+     * @param id      The feature ID to search for.
+     * @param toolTip The toolTip being built.
+     * @return The bonus.
+     */
+    public int getIntegerBonusFor(String id, StringBuilder toolTip) {
         int                total = 0;
         ArrayList<Feature> list  = mFeatureMap.get(id.toLowerCase());
         if (list != null) {
             for (Feature feature : list) {
                 if (feature instanceof Bonus && !(feature instanceof WeaponBonus)) {
-                    total += ((Bonus) feature).getAmount().getIntegerAdjustedAmount();
+                    Bonus bonus = (Bonus) feature;
+                    total += bonus.getAmount().getIntegerAdjustedAmount();
+                    bonus.addToToolTip(toolTip);
                 }
             }
         }
@@ -2713,6 +2724,17 @@ public class GURPSCharacter extends DataFile {
      * @return The bonus.
      */
     public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier) {
+        return getSkillComparedIntegerBonusFor(id, nameQualifier, specializationQualifier, null);
+    }
+
+    /**
+     * @param id                      The feature ID to search for.
+     * @param nameQualifier           The name qualifier.
+     * @param specializationQualifier The specialization qualifier.
+     * @param toolTip                 The toolTip being built
+     * @return The bonus.
+     */
+    public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier, StringBuilder toolTip) {
         int                total = 0;
         ArrayList<Feature> list  = mFeatureMap.get(id.toLowerCase());
         if (list != null) {
@@ -2721,6 +2743,7 @@ public class GURPSCharacter extends DataFile {
                     SkillBonus bonus = (SkillBonus) feature;
                     if (bonus.getNameCriteria().matches(nameQualifier) && bonus.getSpecializationCriteria().matches(specializationQualifier)) {
                         total += bonus.getAmount().getIntegerAdjustedAmount();
+                        bonus.addToToolTip(toolTip);
                     }
                 }
             }

--- a/src/com/trollworks/gcs/character/PrerequisitesThread.java
+++ b/src/com/trollworks/gcs/character/PrerequisitesThread.java
@@ -174,6 +174,9 @@ public class PrerequisitesThread extends Thread implements NotifierTarget {
             }
             for (Feature feature : row.getFeatures()) {
                 processFeature(map, row instanceof Advantage ? ((Advantage) row).getLevels() : 0, feature);
+                if (feature instanceof Bonus) {
+                    ((Bonus) feature).setParent(row);
+                }
             }
             if (row instanceof Advantage) {
                 Advantage advantage = (Advantage) row;

--- a/src/com/trollworks/gcs/feature/Bonus.java
+++ b/src/com/trollworks/gcs/feature/Bonus.java
@@ -11,6 +11,8 @@
 
 package com.trollworks.gcs.feature;
 
+import com.trollworks.gcs.widgets.outline.ListRow;
+import com.trollworks.toolkit.annotation.Localize;
 import com.trollworks.toolkit.io.xml.XMLNodeType;
 import com.trollworks.toolkit.io.xml.XMLReader;
 import com.trollworks.toolkit.io.xml.XMLWriter;
@@ -23,11 +25,20 @@ import java.util.HashSet;
 public abstract class Bonus implements Feature {
     /** The "amount" tag. */
     public static final String TAG_AMOUNT = "amount"; //$NON-NLS-1$
+
+    @Localize("Unknown")
+    @Localize(locale = "de", value = "Unbekannte")
+    @Localize(locale = "ru", value = "неизвестный")
+    @Localize(locale = "es", value = "Desconocido")
+    private static String      UNKNOWN;
+
     private LeveledAmount      mAmount;
+    // The "parent" item that is providing this particular bonus (for information only).
+    private ListRow            mParent;
 
     /**
      * Creates a new bonus.
-     * 
+     *
      * @param amount The initial amount.
      */
     public Bonus(double amount) {
@@ -36,7 +47,7 @@ public abstract class Bonus implements Feature {
 
     /**
      * Creates a new bonus.
-     * 
+     *
      * @param amount The initial amount.
      */
     public Bonus(int amount) {
@@ -45,7 +56,7 @@ public abstract class Bonus implements Feature {
 
     /**
      * Creates a clone of the specified bonus.
-     * 
+     *
      * @param other The bonus to clone.
      */
     public Bonus(Bonus other) {
@@ -92,7 +103,7 @@ public abstract class Bonus implements Feature {
 
     /**
      * Saves the bonus base information.
-     * 
+     *
      * @param out The XML writer to use..
      */
     public void saveBase(XMLWriter out) {
@@ -112,5 +123,32 @@ public abstract class Bonus implements Feature {
     @Override
     public void applyNameableKeys(HashMap<String, String> map) {
         // Nothing to do.
+    }
+
+    public void setParent(ListRow parent) {
+        mParent = parent;
+    }
+
+    public ListRow getParent() {
+        return mParent;
+    }
+
+    public String getParentName() {
+        return mParent == null ? UNKNOWN : mParent.toString();
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " (" + getToolTipAmount() + ", parent:" + mParent + ")";  //$NON-NLS-1$
+    }
+
+    public void addToToolTip(StringBuilder toolTip) {
+        if (toolTip != null) {
+            toolTip.append("\n").append(getParentName()).append(" [").append(getToolTipAmount()).append("]"); //$NON-NLS-1$
+        }
+    }
+
+    public String getToolTipAmount() {
+        return getAmount().getAmountAsString();
     }
 }

--- a/src/com/trollworks/gcs/skill/Skill.java
+++ b/src/com/trollworks/gcs/skill/Skill.java
@@ -401,6 +401,7 @@ public class Skill extends ListRow implements HasSourceReference {
         return mLevel.getRelativeLevel();
     }
 
+    /** @return The tooltTip to describe how the level was calculated */
     public String getLevelToolTip() {
         return mLevel.getToolTip();
     }
@@ -716,8 +717,9 @@ public class Skill extends ListRow implements HasSourceReference {
      * @return The calculated skill level.
      */
     public SkillLevel calculateLevel(GURPSCharacter character, String name, String specialization, List<SkillDefault> defaults, SkillAttribute attribute, SkillDifficulty difficulty, int points, HashSet<String> excludes, int encPenaltyMult) {
-        int relativeLevel = difficulty.getBaseRelativeLevel();
-        int level         = attribute.getBaseSkillLevel(character);
+        StringBuilder toolTip       = new StringBuilder();
+        int           relativeLevel = difficulty.getBaseRelativeLevel();
+        int           level         = attribute.getBaseSkillLevel(character);
         if (level != Integer.MIN_VALUE) {
             if (difficulty != SkillDifficulty.W) {
                 if (mDefaultedFrom != null && mDefaultedFrom.getPoints() > 0) {
@@ -744,17 +746,21 @@ public class Skill extends ListRow implements HasSourceReference {
                     }
                 }
                 if (character != null) {
-                    int bonus = character.getSkillComparedIntegerBonusFor(ID_NAME + ASTERISK, name, specialization);
+                    int bonus = character.getSkillComparedIntegerBonusFor(ID_NAME + ASTERISK, name, specialization, toolTip);
                     level         += bonus;
                     relativeLevel += bonus;
-                    bonus          = character.getIntegerBonusFor(ID_NAME + SLASH + name.toLowerCase());
+                    bonus          = character.getIntegerBonusFor(ID_NAME + SLASH + name.toLowerCase(), toolTip);
                     level         += bonus;
                     relativeLevel += bonus;
-                    level         += character.getEncumbranceLevel().getEncumbrancePenalty() * encPenaltyMult;
+                    bonus          = character.getEncumbranceLevel().getEncumbrancePenalty() * encPenaltyMult;
+                    level         += bonus;
+                    if (bonus != 0) {
+                        toolTip.append("\n").append(ENCUMBRANCE).append(" [").append(bonus).append("]");  //$NON-NLS-1$
+                    }
                 }
             }
         }
-        return new SkillLevel(level, relativeLevel);
+        return new SkillLevel(level, relativeLevel, toolTip);
     }
 
     /**

--- a/src/com/trollworks/gcs/skill/SkillColumn.java
+++ b/src/com/trollworks/gcs/skill/SkillColumn.java
@@ -143,6 +143,16 @@ public enum SkillColumn {
             }
             return Numbers.format(level);
         }
+
+        @Override
+        public boolean showToolTip() {
+            return true;
+        }
+
+        @Override
+        public String getToolTip(Skill skill) {
+            return skill.getLevelToolTip();
+        }
     },
     /** The relative skill level. */
     RELATIVE_LEVEL {
@@ -228,6 +238,16 @@ public enum SkillColumn {
                 return builder.toString();
             }
             return ""; //$NON-NLS-1$
+        }
+
+        @Override
+        public boolean showToolTip() {
+            return true;
+        }
+
+        @Override
+        public String getToolTip(Skill skill) {
+            return skill.getLevelToolTip();
         }
     },
     /** The points spent in the skill. */

--- a/src/com/trollworks/gcs/skill/SkillLevel.java
+++ b/src/com/trollworks/gcs/skill/SkillLevel.java
@@ -11,8 +11,26 @@
 
 package com.trollworks.gcs.skill;
 
+import com.trollworks.toolkit.annotation.Localize;
+import com.trollworks.toolkit.utility.Localization;
+
 /** Provides simple storage for the skill level/relative level pair. */
 public class SkillLevel {
+    @Localize("Includes modifiers from")
+    @Localize(locale = "de", value = "Enthält Modifikatoren von")
+    @Localize(locale = "ru", value = "Включает в себя модификаторы из")
+    @Localize(locale = "es", value = "Incluye modificadores de")
+    static String INCLUDES;
+    @Localize("No additional modifiers")
+    @Localize(locale = "de", value = "Keine zusätzlichen Modifikatoren")
+    @Localize(locale = "ru", value = "Никаких дополнительных модификаторов")
+    @Localize(locale = "es", value = "No hay modificadores adicionales")
+    static String NO_MODIFIERS;
+
+    static {
+        Localization.initialize();
+    }
+
     /** The skill level. */
     public int    mLevel;
     /** The relative skill level. */
@@ -21,7 +39,7 @@ public class SkillLevel {
     public String mToolTip;
 
     public String getToolTip() {
-        return mToolTip == null ? "" : mToolTip;
+        return mToolTip;
     }
 
     /**
@@ -33,6 +51,7 @@ public class SkillLevel {
     public SkillLevel(int level, int relativeLevel) {
         mLevel         = level;
         mRelativeLevel = relativeLevel;
+        mToolTip       = NO_MODIFIERS;
     }
 
     /**
@@ -40,12 +59,15 @@ public class SkillLevel {
      *
      * @param level         The skill level.
      * @param relativeLevel The relative skill level.
-     * @param tip           The tooltip to display for this skill.
+     * @param toolTip       The tooltip to display for this skill.
      */
-    public SkillLevel(int level, int relativeLevel, String toolTip) {
+    public SkillLevel(int level, int relativeLevel, StringBuilder toolTip) {
         mLevel         = level;
         mRelativeLevel = relativeLevel;
-        mToolTip       = toolTip;
+        mToolTip       = NO_MODIFIERS;
+        if (toolTip != null && toolTip.length() > 0) {
+            mToolTip = INCLUDES + toolTip.toString();
+        }
     }
 
     /** @return The level. */

--- a/src/com/trollworks/gcs/skill/Technique.java
+++ b/src/com/trollworks/gcs/skill/Technique.java
@@ -72,8 +72,9 @@ public class Technique extends Skill {
      * @return The calculated technique level.
      */
     public static SkillLevel calculateTechniqueLevel(GURPSCharacter character, String name, String specialization, SkillDefault def, SkillDifficulty difficulty, int points, boolean limited, int limitModifier) {
-        int relativeLevel = 0;
-        int level         = Integer.MIN_VALUE;
+        StringBuilder toolTip       = new StringBuilder();
+        int           relativeLevel = 0;
+        int           level         = Integer.MIN_VALUE;
         if (character != null) {
             level = getBaseLevel(character, def);
             if (level != Integer.MIN_VALUE) {
@@ -86,7 +87,7 @@ public class Technique extends Skill {
                     relativeLevel = points;
                 }
                 if (level != Integer.MIN_VALUE) {
-                    level += relativeLevel + character.getIntegerBonusFor(ID_NAME + "/" + name.toLowerCase()) + character.getSkillComparedIntegerBonusFor(ID_NAME + "*", name, specialization); //$NON-NLS-1$ //$NON-NLS-2$
+                    level += relativeLevel + character.getIntegerBonusFor(ID_NAME + "/" + name.toLowerCase(), toolTip) + character.getSkillComparedIntegerBonusFor(ID_NAME + "*", name, specialization, toolTip); //$NON-NLS-1$ //$NON-NLS-2$
                 }
                 if (limited) {
                     int max = baseLevel + limitModifier;
@@ -97,7 +98,7 @@ public class Technique extends Skill {
                 }
             }
         }
-        return new SkillLevel(level, relativeLevel);
+        return new SkillLevel(level, relativeLevel, toolTip);
     }
 
     private static int getBaseLevel(GURPSCharacter character, SkillDefault def) {


### PR DESCRIPTION
This is the first of a few tooltip PRs.  I just did Skill (and Technique) in this PR so you can see how it is done.   Future PRs will cover Spells and WeaponDamage.

1.  Bonus received a "parent" variable.   This is the ListRow subclass that is providing the aforementioned bonus.  This variable is in essence, transient, since it is not read in from or streamed out to XML.

2.  PrerequisitesThread now stores the "parent" into the Bonus as it is being added to the character's feature map.

3.  SkillLevel was modified to accept a StringBuilder as its toolTip parameter, instead of a String (but it still only stores the String).   This allowed me to refactor the internationalized strings so they only exist in the SkillLevel class, instead of the ListRow subclasses.

4.  GURPSCharacter was modified to accept the toolTip StringBuilder for a few of the "get*Bonus*" methods.  If the bonus applies to the criteria, it will add itself to the toolTip.   

5.  Skill was modified to create the toolTip StringBuilder while calculating its level and pass it to the GURPSCharacter "get*Bonus*" methods.

6.  And finally, SkillColumn was modified to allow a "level" tooltip for the LEVEL and RELATIVE_LEVEL columns.

If you accept all of these changes, you will see toolTips appear on a Skill, over the SL and RSL columns.
![image](https://user-images.githubusercontent.com/8931036/61023175-cfd7b700-a376-11e9-96e3-796ef2a0e005.png)
