### PR TITLE
Added tooltips for Spells & Weapon Damage

### DIFF
--- a/src/com/trollworks/gcs/app/GCS.java
+++ b/src/com/trollworks/gcs/app/GCS.java
@@ -48,6 +48,8 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.StringTokenizer;
 
+import javax.swing.ToolTipManager;
+
 /** The main entry point for the character sheet. */
 public class GCS {
     @Localize("GURPS Character Sheet")
@@ -233,6 +235,9 @@ public class GCS {
         Fonts.loadFromPreferences();
         App.setAboutPanel(AboutPanel.class);
         registerFileTypes(new GCSFileProxyCreator());
+
+        // Increase TooTip time so the user has time to read the skill modifiers
+        ToolTipManager.sharedInstance().setDismissDelay(60000);
     }
 
     /** @return The path to the GCS library files. */

--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -2689,7 +2689,7 @@ public class GURPSCharacter extends DataFile {
      * @param specializationQualifier The specialization qualifier.
      * @return The bonuses.
      */
-    public ArrayList<WeaponBonus> getWeaponComparedBonusesFor(String id, String nameQualifier, String specializationQualifier) {
+    public ArrayList<WeaponBonus> getWeaponComparedBonusesFor(String id, String nameQualifier, String specializationQualifier, StringBuilder toolTip) {
         ArrayList<WeaponBonus> bonuses = new ArrayList<>();
         int                    rsl     = Integer.MIN_VALUE;
 
@@ -2709,6 +2709,7 @@ public class GURPSCharacter extends DataFile {
                         WeaponBonus bonus = (WeaponBonus) feature;
                         if (bonus.getNameCriteria().matches(nameQualifier) && bonus.getSpecializationCriteria().matches(specializationQualifier) && bonus.getLevelCriteria().matches(rsl)) {
                             bonuses.add(bonus);
+                            bonus.addToToolTip(toolTip);
                         }
                     }
                 }
@@ -2756,7 +2757,7 @@ public class GURPSCharacter extends DataFile {
      * @param qualifier The qualifier.
      * @return The bonus.
      */
-    public int getSpellComparedIntegerBonusFor(String id, String qualifier) {
+    public int getSpellComparedIntegerBonusFor(String id, String qualifier, StringBuilder toolTip) {
         int                total = 0;
         ArrayList<Feature> list  = mFeatureMap.get(id.toLowerCase());
         if (list != null) {
@@ -2765,6 +2766,7 @@ public class GURPSCharacter extends DataFile {
                     SpellBonus bonus = (SpellBonus) feature;
                     if (bonus.getNameCriteria().matches(qualifier)) {
                         total += bonus.getAmount().getIntegerAdjustedAmount();
+                        bonus.addToToolTip(toolTip);
                     }
                 }
             }

--- a/src/com/trollworks/gcs/character/PrerequisitesThread.java
+++ b/src/com/trollworks/gcs/character/PrerequisitesThread.java
@@ -182,11 +182,15 @@ public class PrerequisitesThread extends Thread implements NotifierTarget {
                 Advantage advantage = (Advantage) row;
                 for (Bonus bonus : advantage.getCRAdj().getBonuses(advantage.getCR())) {
                     processFeature(map, 0, bonus);
+                    bonus.setParent(row);
                 }
                 for (Modifier modifier : advantage.getModifiers()) {
                     if (modifier.isEnabled()) {
                         for (Feature feature : modifier.getFeatures()) {
                             processFeature(map, modifier.getLevels(), feature);
+                            if (feature instanceof Bonus) {
+                                ((Bonus) feature).setParent(row);
+                            }
                         }
                     }
                 }

--- a/src/com/trollworks/gcs/spell/SpellColumn.java
+++ b/src/com/trollworks/gcs/spell/SpellColumn.java
@@ -232,6 +232,16 @@ public enum SpellColumn {
             }
             return Numbers.format(level);
         }
+
+        @Override
+        public boolean showToolTip() {
+            return true;
+        }
+
+        @Override
+        public String getToolTip(Spell spell) {
+            return spell.getLevelToolTip();
+        }
     },
     /** The relative spell level. */
     RELATIVE_LEVEL {
@@ -283,6 +293,16 @@ public enum SpellColumn {
                 return spell.getAttribute().toString() + Numbers.formatWithForcedSign(level);
             }
             return ""; //$NON-NLS-1$
+        }
+
+        @Override
+        public boolean showToolTip() {
+            return true;
+        }
+
+        @Override
+        public String getToolTip(Spell spell) {
+            return spell.getLevelToolTip();
         }
     },
     /** The points spent in the spell. */

--- a/src/com/trollworks/gcs/weapon/WeaponColumn.java
+++ b/src/com/trollworks/gcs/weapon/WeaponColumn.java
@@ -201,6 +201,17 @@ public enum WeaponColumn {
         public String getDataAsText(WeaponStats weapon) {
             return weapon.getResolvedDamage();
         }
+
+        @Override
+        public boolean showToolTip() {
+            return true;
+        }
+
+        @Override
+        public String getToolTip(WeaponDisplayRow weapon) {
+            return weapon.getDamageToolTip();
+        }
+
     },
     /** The weapon reach. */
     REACH {

--- a/src/com/trollworks/gcs/weapon/WeaponDisplayRow.java
+++ b/src/com/trollworks/gcs/weapon/WeaponDisplayRow.java
@@ -73,4 +73,7 @@ public class WeaponDisplayRow extends Row {
         return WeaponColumn.values()[column.getID()].getToolTip(this);
     }
 
+    public String getDamageToolTip() {
+        return mWeapon.getDamageToolTip();
+    }
 }

--- a/src/com/trollworks/gcs/weapon/WeaponStats.java
+++ b/src/com/trollworks/gcs/weapon/WeaponStats.java
@@ -22,10 +22,12 @@ import com.trollworks.gcs.skill.SkillDefault;
 import com.trollworks.gcs.skill.SkillDefaultType;
 import com.trollworks.gcs.spell.Spell;
 import com.trollworks.gcs.widgets.outline.ListRow;
+import com.trollworks.toolkit.annotation.Localize;
 import com.trollworks.toolkit.io.xml.XMLNodeType;
 import com.trollworks.toolkit.io.xml.XMLReader;
 import com.trollworks.toolkit.io.xml.XMLWriter;
 import com.trollworks.toolkit.utility.Dice;
+import com.trollworks.toolkit.utility.Localization;
 import com.trollworks.toolkit.utility.text.Numbers;
 
 import java.io.IOException;
@@ -54,6 +56,21 @@ public abstract class WeaponStats {
     private String                  mStrength;
     private String                  mUsage;
     private ArrayList<SkillDefault> mDefaults;
+
+    @Localize("Includes modifiers from")
+    @Localize(locale = "de", value = "Enthält Modifikatoren von")
+    @Localize(locale = "ru", value = "Включает в себя модификаторы из")
+    @Localize(locale = "es", value = "Incluye modificadores de")
+    static String                   INCLUDES;
+    @Localize("No additional modifiers")
+    @Localize(locale = "de", value = "Keine zusätzlichen Modifikatoren")
+    @Localize(locale = "ru", value = "Никаких дополнительных модификаторов")
+    @Localize(locale = "es", value = "No hay modificadores adicionales")
+    static String                   NO_MODIFIERS;
+
+    static {
+        Localization.initialize();
+    }
 
     /**
      * Creates a new weapon.
@@ -217,6 +234,17 @@ public abstract class WeaponStats {
 
     /** @return The damage, fully resolved for the user's sw or thr, if possible. */
     public String getResolvedDamage() {
+        return getResolvedDamage(null);
+    }
+
+    public String getDamageToolTip() {
+        StringBuilder toolTip = new StringBuilder();
+        getResolvedDamage(toolTip);
+        return toolTip.length() > 0 ? INCLUDES + toolTip.toString() : NO_MODIFIERS;
+    }
+
+    /** @return The damage, fully resolved for the user's sw or thr, if possible. */
+    public String getResolvedDamage(StringBuilder toolTip) {
         DataFile df     = mOwner.getDataFile();
         String   damage = mDamage;
 
@@ -226,8 +254,8 @@ public abstract class WeaponStats {
 
             for (SkillDefault one : getDefaults()) {
                 if (one.getType().isSkillBased()) {
-                    bonuses.addAll(character.getWeaponComparedBonusesFor(Skill.ID_NAME + "*", one.getName(), one.getSpecialization())); //$NON-NLS-1$
-                    bonuses.addAll(character.getWeaponComparedBonusesFor(Skill.ID_NAME + "/" + one.getName(), one.getName(), one.getSpecialization())); //$NON-NLS-1$
+                    bonuses.addAll(character.getWeaponComparedBonusesFor(Skill.ID_NAME + "*", one.getName(), one.getSpecialization(), toolTip)); //$NON-NLS-1$
+                    bonuses.addAll(character.getWeaponComparedBonusesFor(Skill.ID_NAME + "/" + one.getName(), one.getName(), one.getSpecialization(), toolTip)); //$NON-NLS-1$
                 }
             }
             damage = resolveDamage(damage, bonuses);


### PR DESCRIPTION
This adds tooltips for Weapon Damage and Spells.   It is a slightly bigger PR than before, but it follows the same pattern as Skill.

1.  I had to increase the tooltip time so that the user has time to actually read the bonuses.   I wasn't certain where you would want that kind of change, so I put it in GCS.java.

2.  The other GURPSCharacter "get*Bonus*" methods had to be updated to include the tooltip.

3.  In the previous PR, I did not completely update the PrerequisitesThread class.   I missed a few places where the parent needed to be set.

4.  Similar to the Skill PR, Spell's now use an instance of SkillLevel to maintain their level and relative level.   Also, the Spell calculation methods needed to be updated with tooltips.

5.  SpellColumn now shows tooltips for the Level and Relative Level columns.

6.  WeaponColumn now shows tooltips for the Damage column.

7.  WeaponDisplayRow and WeaponStats have been updated to calculate a tooltip while determining damage.



