### PR TITLE
Added tooltips to Skill/Spell editors

### DIFF
--- a/src/com/trollworks/gcs/skill/SkillEditor.java
+++ b/src/com/trollworks/gcs/skill/SkillEditor.java
@@ -340,7 +340,7 @@ public class SkillEditor extends RowEditor<Skill> implements ActionListener, Doc
         mPointsField.addActionListener(this);
 
         if (forCharacter) {
-            mLevelField = createField(parent, parent, EDITOR_LEVEL, Skill.getSkillDisplayLevel(mRow.getLevel(), mRow.getRelativeLevel(), mRow.getAttribute(), mRow.canHaveChildren()), EDITOR_LEVEL_TOOLTIP, 8);
+            mLevelField = createField(parent, parent, EDITOR_LEVEL, Skill.getSkillDisplayLevel(mRow.getLevel(), mRow.getRelativeLevel(), mRow.getAttribute(), mRow.canHaveChildren()), EDITOR_LEVEL_TOOLTIP + ".\n" + mRow.getLevelToolTip(), 8);
             mLevelField.setEnabled(false);
         }
     }
@@ -440,6 +440,7 @@ public class SkillEditor extends RowEditor<Skill> implements ActionListener, Doc
             SkillAttribute attribute = getSkillAttribute();
             SkillLevel     level     = mRow.calculateLevel(mRow.getCharacter(), mNameField.getText(), mSpecializationField.getText(), mDefaults.getDefaults(), attribute, getSkillDifficulty(), getSkillPoints(), new HashSet<String>(), getEncumbrancePenaltyMultiplier());
             mLevelField.setText(Skill.getSkillDisplayLevel(level.mLevel, level.mRelativeLevel, attribute, false));
+            mLevelField.setToolTipText(Text.wrapPlainTextForToolTip(EDITOR_LEVEL_TOOLTIP + ".\n" + level.getToolTip()));  //$NON-NLS-1$
         }
     }
 

--- a/src/com/trollworks/gcs/spell/SpellEditor.java
+++ b/src/com/trollworks/gcs/spell/SpellEditor.java
@@ -462,7 +462,7 @@ public class SpellEditor extends RowEditor<Spell> implements ActionListener, Doc
             mPointsField.addActionListener(this);
 
             if (forCharacter) {
-                mLevelField = createField(panel, panel, EDITOR_LEVEL, getDisplayLevel(mRow.getAttribute(), mRow.getLevel(), mRow.getRelativeLevel()), EDITOR_LEVEL_TOOLTIP, 7);
+                mLevelField = createField(panel, panel, EDITOR_LEVEL, getDisplayLevel(mRow.getAttribute(), mRow.getLevel(), mRow.getRelativeLevel()), EDITOR_LEVEL_TOOLTIP + ".\n" + mRow.getLevelToolTip(), 7);  //$NON-NLS-1$
                 mLevelField.setEnabled(false);
             }
         }
@@ -583,6 +583,7 @@ public class SpellEditor extends RowEditor<Spell> implements ActionListener, Doc
             SkillAttribute attribute = getAttribute();
             SkillLevel     level     = Spell.calculateLevel(mRow.getCharacter(), getSpellPoints(), attribute, isVeryHard(), mCollegeField.getText(), mPowerSourceField.getText(), mNameField.getText());
             mLevelField.setText(getDisplayLevel(attribute, level.mLevel, level.mRelativeLevel));
+            mLevelField.setToolTipText(Text.wrapPlainTextForToolTip(EDITOR_LEVEL_TOOLTIP + ".\n" + level.getToolTip()));  //$NON-NLS-1$
         }
     }
 


### PR DESCRIPTION
The final PR for tooltips (well, for now, at least).   Added the tooltip to the read only level field in the Skill/Spell editors (so you can see why the Skill/Spell is what it is while you are trying to decide how many points to put into it).