### PR TITLE
Added bonus/feature by category for Skills

### DIFF
--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -66,6 +66,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
 
 /** A GURPS character. */
 public class GURPSCharacter extends DataFile {
@@ -2722,10 +2723,10 @@ public class GURPSCharacter extends DataFile {
      * @param id                      The feature ID to search for.
      * @param nameQualifier           The name qualifier.
      * @param specializationQualifier The specialization qualifier.
-     * @parem categoryQualifier The categories qualifier
+     * @param categoryQualifier       The categories qualifier
      * @return The bonus.
      */
-    public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier, String categoryQualifier) {
+    public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier, Set<String> categoryQualifier) {
         return getSkillComparedIntegerBonusFor(id, nameQualifier, specializationQualifier, categoryQualifier, null);
     }
 
@@ -2733,11 +2734,11 @@ public class GURPSCharacter extends DataFile {
      * @param id                      The feature ID to search for.
      * @param nameQualifier           The name qualifier.
      * @param specializationQualifier The specialization qualifier.
-     * @parem categoryQualifier The categories qualifier
-     * @param toolTip The toolTip being built
+     * @param categoryQualifier       The categories qualifier
+     * @param toolTip                 The toolTip being built
      * @return The bonus.
      */
-    public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier, String categoryQualifier, StringBuilder toolTip) {
+    public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier, Set<String> categoryQualifier, StringBuilder toolTip) {
         int                total = 0;
         ArrayList<Feature> list  = mFeatureMap.get(id.toLowerCase());
         if (list != null) {

--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -2722,17 +2722,19 @@ public class GURPSCharacter extends DataFile {
      * @param id                      The feature ID to search for.
      * @param nameQualifier           The name qualifier.
      * @param specializationQualifier The specialization qualifier.
+     * @parem categoryQualifier The categories qualifier
      * @return The bonus.
      */
     public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier, String categoryQualifier) {
-        return getSkillComparedIntegerBonusFor(id, nameQualifier, specializationQualifier, null);
+        return getSkillComparedIntegerBonusFor(id, nameQualifier, specializationQualifier, categoryQualifier, null);
     }
 
     /**
      * @param id                      The feature ID to search for.
      * @param nameQualifier           The name qualifier.
      * @param specializationQualifier The specialization qualifier.
-     * @param toolTip                 The toolTip being built
+     * @parem categoryQualifier The categories qualifier
+     * @param toolTip The toolTip being built
      * @return The bonus.
      */
     public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier, String categoryQualifier, StringBuilder toolTip) {

--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -2724,7 +2724,7 @@ public class GURPSCharacter extends DataFile {
      * @param specializationQualifier The specialization qualifier.
      * @return The bonus.
      */
-    public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier) {
+    public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier, String categoryQualifier) {
         return getSkillComparedIntegerBonusFor(id, nameQualifier, specializationQualifier, null);
     }
 
@@ -2735,14 +2735,14 @@ public class GURPSCharacter extends DataFile {
      * @param toolTip                 The toolTip being built
      * @return The bonus.
      */
-    public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier, StringBuilder toolTip) {
+    public int getSkillComparedIntegerBonusFor(String id, String nameQualifier, String specializationQualifier, String categoryQualifier, StringBuilder toolTip) {
         int                total = 0;
         ArrayList<Feature> list  = mFeatureMap.get(id.toLowerCase());
         if (list != null) {
             for (Feature feature : list) {
                 if (feature instanceof SkillBonus) {
                     SkillBonus bonus = (SkillBonus) feature;
-                    if (bonus.getNameCriteria().matches(nameQualifier) && bonus.getSpecializationCriteria().matches(specializationQualifier)) {
+                    if (bonus.getNameCriteria().matches(nameQualifier) && bonus.getSpecializationCriteria().matches(specializationQualifier) && bonus.matchesCategories(categoryQualifier)) {
                         total += bonus.getAmount().getIntegerAdjustedAmount();
                         bonus.addToToolTip(toolTip);
                     }

--- a/src/com/trollworks/gcs/criteria/StringCompareType.java
+++ b/src/com/trollworks/gcs/criteria/StringCompareType.java
@@ -27,6 +27,11 @@ public enum StringCompareType {
         public boolean matches(String qualifier, String data) {
             return true;
         }
+
+        @Override
+        public boolean isTypeAnything() {
+            return true;
+        }
     },
     /** The comparison for "is". */
     IS {
@@ -38,6 +43,11 @@ public enum StringCompareType {
         @Override
         public boolean matches(String qualifier, String data) {
             return data.equalsIgnoreCase(qualifier);
+        }
+
+        @Override
+        public boolean isTypeIs() {
+            return true;
         }
     },
     /** The comparison for "is not". */
@@ -196,4 +206,12 @@ public enum StringCompareType {
      * @return Whether the data matches the criteria or not.
      */
     public abstract boolean matches(String qualifier, String data);
+
+    public boolean isTypeIs() {
+        return false;
+    }
+
+    public boolean isTypeAnything() {
+        return false;
+    }
 }

--- a/src/com/trollworks/gcs/criteria/StringCriteria.java
+++ b/src/com/trollworks/gcs/criteria/StringCriteria.java
@@ -111,4 +111,14 @@ public class StringCriteria {
     public String toString() {
         return mType.describe(mQualifier);
     }
+
+    /** @return Is this criteria for an exact match? */
+    public boolean isTypeIs() {
+        return mType.isTypeIs();
+    }
+
+    /** @return Is this criteria for any match? */
+    public boolean isTypeAnything() {
+        return mType.isTypeAnything();
+    }
 }

--- a/src/com/trollworks/gcs/feature/SkillBonus.java
+++ b/src/com/trollworks/gcs/feature/SkillBonus.java
@@ -21,6 +21,7 @@ import com.trollworks.toolkit.io.xml.XMLWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
 
 /** A skill bonus. */
 public class SkillBonus extends Bonus {
@@ -103,8 +104,13 @@ public class SkillBonus extends Bonus {
         return buffer.toString();
     }
 
-    public boolean matchesCategories(String categories) {
-        return ListRow.matchesCategories(mCategoryCriteria, categories);
+    public boolean matchesCategories(Set<String> categories) {
+        for (String category : categories) {
+            if (mCategoryCriteria.matches(category)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/com/trollworks/gcs/feature/SkillBonus.java
+++ b/src/com/trollworks/gcs/feature/SkillBonus.java
@@ -104,13 +104,7 @@ public class SkillBonus extends Bonus {
     }
 
     public boolean matchesCategories(String categories) {
-        String[] cats = categories.split(COMMA);
-        for (String category : cats) {
-            if (mCategoryCriteria.matches(category.trim())) {
-                return true;
-            }
-        }
-        return false;
+        return ListRow.matchesCategories(mCategoryCriteria, categories);
     }
 
     @Override

--- a/src/com/trollworks/gcs/feature/SkillBonus.java
+++ b/src/com/trollworks/gcs/feature/SkillBonus.java
@@ -28,20 +28,24 @@ public class SkillBonus extends Bonus {
     public static final String  TAG_ROOT           = "skill_bonus"; //$NON-NLS-1$
     private static final String TAG_NAME           = "name"; //$NON-NLS-1$
     private static final String TAG_SPECIALIZATION = "specialization"; //$NON-NLS-1$
+    private static final String TAG_CATEGORY       = "category"; //$NON-NLS-1$
     private static final String EMPTY              = ""; //$NON-NLS-1$
+    private static final String COMMA              = ","; //$NON-NLS-1$
     private StringCriteria      mNameCriteria;
     private StringCriteria      mSpecializationCriteria;
+    private StringCriteria      mCategoryCriteria;
 
     /** Creates a new skill bonus. */
     public SkillBonus() {
         super(1);
         mNameCriteria           = new StringCriteria(StringCompareType.IS, EMPTY);
         mSpecializationCriteria = new StringCriteria(StringCompareType.IS_ANYTHING, EMPTY);
+        mCategoryCriteria       = new StringCriteria(StringCompareType.IS_ANYTHING, EMPTY);
     }
 
     /**
      * Loads a {@link SkillBonus}.
-     * 
+     *
      * @param reader The XML reader to use.
      */
     public SkillBonus(XMLReader reader) throws IOException {
@@ -51,13 +55,14 @@ public class SkillBonus extends Bonus {
 
     /**
      * Creates a clone of the specified bonus.
-     * 
+     *
      * @param other The bonus to clone.
      */
     public SkillBonus(SkillBonus other) {
         super(other);
         mNameCriteria           = new StringCriteria(other.mNameCriteria);
         mSpecializationCriteria = new StringCriteria(other.mSpecializationCriteria);
+        mCategoryCriteria       = new StringCriteria(other.mCategoryCriteria);
     }
 
     @Override
@@ -68,7 +73,7 @@ public class SkillBonus extends Bonus {
         if (obj instanceof SkillBonus && super.equals(obj)) {
             SkillBonus sb = (SkillBonus) obj;
             if (mNameCriteria.equals(sb.mNameCriteria)) {
-                return mSpecializationCriteria.equals(sb.mSpecializationCriteria);
+                return mNameCriteria.equals(sb.mNameCriteria) && mSpecializationCriteria.equals(sb.mSpecializationCriteria) && mCategoryCriteria.equals(sb.mCategoryCriteria);
             }
         }
         return false;
@@ -89,13 +94,23 @@ public class SkillBonus extends Bonus {
         StringBuffer buffer = new StringBuffer();
 
         buffer.append(Skill.ID_NAME);
-        if (mNameCriteria.getType() == StringCompareType.IS && mSpecializationCriteria.getType() == StringCompareType.IS_ANYTHING) {
+        if (mNameCriteria.isTypeIs() && mSpecializationCriteria.isTypeAnything() && mCategoryCriteria.isTypeAnything()) {
             buffer.append('/');
             buffer.append(mNameCriteria.getQualifier());
         } else {
             buffer.append("*"); //$NON-NLS-1$
         }
         return buffer.toString();
+    }
+
+    public boolean matchesCategories(String categories) {
+        String[] cats = categories.split(COMMA);
+        for (String category : cats) {
+            if (mCategoryCriteria.matches(category.trim())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -105,6 +120,8 @@ public class SkillBonus extends Bonus {
             mNameCriteria.load(reader);
         } else if (TAG_SPECIALIZATION.equals(name)) {
             mSpecializationCriteria.load(reader);
+        } else if (TAG_CATEGORY.equals(name)) {
+            mCategoryCriteria.load(reader);
         } else {
             super.loadSelf(reader);
         }
@@ -112,7 +129,7 @@ public class SkillBonus extends Bonus {
 
     /**
      * Saves the bonus.
-     * 
+     *
      * @param out The XML writer to use.
      */
     @Override
@@ -120,6 +137,7 @@ public class SkillBonus extends Bonus {
         out.startSimpleTagEOL(TAG_ROOT);
         mNameCriteria.save(out, TAG_NAME);
         mSpecializationCriteria.save(out, TAG_SPECIALIZATION);
+        mCategoryCriteria.save(out, TAG_CATEGORY);
         saveBase(out);
         out.endTagEOL(TAG_ROOT, true);
     }
@@ -134,15 +152,22 @@ public class SkillBonus extends Bonus {
         return mSpecializationCriteria;
     }
 
+    /** @return The category criteria. */
+    public StringCriteria getCategoryCriteria() {
+        return mCategoryCriteria;
+    }
+
     @Override
     public void fillWithNameableKeys(HashSet<String> set) {
         ListRow.extractNameables(set, mNameCriteria.getQualifier());
         ListRow.extractNameables(set, mSpecializationCriteria.getQualifier());
+        ListRow.extractNameables(set, mCategoryCriteria.getQualifier());
     }
 
     @Override
     public void applyNameableKeys(HashMap<String, String> map) {
         mNameCriteria.setQualifier(ListRow.nameNameables(map, mNameCriteria.getQualifier()));
         mSpecializationCriteria.setQualifier(ListRow.nameNameables(map, mSpecializationCriteria.getQualifier()));
+        mCategoryCriteria.setQualifier(ListRow.nameNameables(map, mCategoryCriteria.getQualifier()));
     }
 }

--- a/src/com/trollworks/gcs/feature/SkillBonusEditor.java
+++ b/src/com/trollworks/gcs/feature/SkillBonusEditor.java
@@ -33,6 +33,11 @@ public class SkillBonusEditor extends FeatureEditor {
     @Localize(locale = "ru", value = "и специализация ")
     @Localize(locale = "es", value = "y especialización ")
     private static String SPECIALIZATION;
+    @Localize("and category ")
+    @Localize(locale = "de", value = "und Kategorie ")
+    @Localize(locale = "ru", value = "и категория ")
+    @Localize(locale = "es", value = "y categoria ")
+    private static String CATEGORY;
 
     static {
         Localization.initialize();
@@ -73,5 +78,12 @@ public class SkillBonusEditor extends FeatureEditor {
         row.add(addStringCompareCombo(criteria, SPECIALIZATION));
         row.add(addStringCompareField(criteria));
         grid.add(row, 2, 0);
+
+        row = new FlexRow();
+        row.setInsets(new Insets(0, 20, 0, 0));
+        criteria = bonus.getCategoryCriteria();
+        row.add(addStringCompareCombo(criteria, CATEGORY));
+        row.add(addStringCompareField(criteria));
+        grid.add(row, 3, 0);
     }
 }

--- a/src/com/trollworks/gcs/skill/Skill.java
+++ b/src/com/trollworks/gcs/skill/Skill.java
@@ -868,8 +868,9 @@ public class Skill extends ListRow implements HasSourceReference {
                     if (!skillDefault.equals(excludedDefault) && !isInDefaultChain(this, skillDefault, new HashSet<>())) {
                         int level = skillDefault.getType().getSkillLevel(character, skillDefault, excludes);
                         if (skillDefault.getType().isSkillBased()) {
-                            String name = skillDefault.getName();
-                            level -= character.getSkillComparedIntegerBonusFor(ID_NAME + ASTERISK, name, skillDefault.getSpecialization(), "");  //$NON-NLS-1$
+                            String name  = skillDefault.getName();
+                            Skill  skill = character.getBestSkillNamed(name, skillDefault.getSpecialization(), true, excludes);
+                            level -= character.getSkillComparedIntegerBonusFor(ID_NAME + ASTERISK, name, skillDefault.getSpecialization(), skill.getCategoriesAsString());
                             level -= character.getIntegerBonusFor(ID_NAME + SLASH + name.toLowerCase());
                         }
                         if (level > best) {

--- a/src/com/trollworks/gcs/skill/Skill.java
+++ b/src/com/trollworks/gcs/skill/Skill.java
@@ -514,7 +514,7 @@ public class Skill extends ListRow implements HasSourceReference {
     /** @return The calculated skill level. */
     protected SkillLevel calculateLevelSelf() {
         mDefaultedFrom = getBestDefaultWithPoints();
-        return calculateLevel(getCharacter(), getName(), getSpecialization(), getDefaults(), getAttribute(), getDifficulty(), getPoints(), new HashSet<String>(), getEncumbrancePenaltyMultiplier());
+        return calculateLevel(getCharacter(), getName(), getSpecialization(), getCategoriesAsString(), getDefaults(), getAttribute(), getDifficulty(), getPoints(), new HashSet<String>(), getEncumbrancePenaltyMultiplier());
     }
 
     /**
@@ -522,7 +522,7 @@ public class Skill extends ListRow implements HasSourceReference {
      * @return The calculated level.
      */
     public int getLevel(HashSet<String> excludes) {
-        return calculateLevel(getCharacter(), getName(), getSpecialization(), getDefaults(), getAttribute(), getDifficulty(), getPoints(), excludes, getEncumbrancePenaltyMultiplier()).mLevel;
+        return calculateLevel(getCharacter(), getName(), getSpecialization(), getCategoriesAsString(), getDefaults(), getAttribute(), getDifficulty(), getPoints(), excludes, getEncumbrancePenaltyMultiplier()).mLevel;
     }
 
     /** @return The attribute. */
@@ -716,7 +716,7 @@ public class Skill extends ListRow implements HasSourceReference {
      * @param encPenaltyMult The encumbrance penalty multiplier.
      * @return The calculated skill level.
      */
-    public SkillLevel calculateLevel(GURPSCharacter character, String name, String specialization, List<SkillDefault> defaults, SkillAttribute attribute, SkillDifficulty difficulty, int points, HashSet<String> excludes, int encPenaltyMult) {
+    public SkillLevel calculateLevel(GURPSCharacter character, String name, String specialization, String categories, List<SkillDefault> defaults, SkillAttribute attribute, SkillDifficulty difficulty, int points, HashSet<String> excludes, int encPenaltyMult) {
         StringBuilder toolTip       = new StringBuilder();
         int           relativeLevel = difficulty.getBaseRelativeLevel();
         int           level         = attribute.getBaseSkillLevel(character);
@@ -746,7 +746,7 @@ public class Skill extends ListRow implements HasSourceReference {
                     }
                 }
                 if (character != null) {
-                    int bonus = character.getSkillComparedIntegerBonusFor(ID_NAME + ASTERISK, name, specialization, toolTip);
+                    int bonus = character.getSkillComparedIntegerBonusFor(ID_NAME + ASTERISK, name, specialization, categories, toolTip);
                     level         += bonus;
                     relativeLevel += bonus;
                     bonus          = character.getIntegerBonusFor(ID_NAME + SLASH + name.toLowerCase(), toolTip);
@@ -869,7 +869,7 @@ public class Skill extends ListRow implements HasSourceReference {
                         int level = skillDefault.getType().getSkillLevel(character, skillDefault, excludes);
                         if (skillDefault.getType().isSkillBased()) {
                             String name = skillDefault.getName();
-                            level -= character.getSkillComparedIntegerBonusFor(ID_NAME + ASTERISK, name, skillDefault.getSpecialization());
+                            level -= character.getSkillComparedIntegerBonusFor(ID_NAME + ASTERISK, name, skillDefault.getSpecialization(), "");  //$NON-NLS-1$
                             level -= character.getIntegerBonusFor(ID_NAME + SLASH + name.toLowerCase());
                         }
                         if (level > best) {

--- a/src/com/trollworks/gcs/skill/Skill.java
+++ b/src/com/trollworks/gcs/skill/Skill.java
@@ -514,7 +514,7 @@ public class Skill extends ListRow implements HasSourceReference {
     /** @return The calculated skill level. */
     protected SkillLevel calculateLevelSelf() {
         mDefaultedFrom = getBestDefaultWithPoints();
-        return calculateLevel(getCharacter(), getName(), getSpecialization(), getCategoriesAsString(), getDefaults(), getAttribute(), getDifficulty(), getPoints(), new HashSet<String>(), getEncumbrancePenaltyMultiplier());
+        return calculateLevel(getCharacter(), getName(), getSpecialization(), getCategories(), getDefaults(), getAttribute(), getDifficulty(), getPoints(), new HashSet<String>(), getEncumbrancePenaltyMultiplier());
     }
 
     /**
@@ -522,7 +522,7 @@ public class Skill extends ListRow implements HasSourceReference {
      * @return The calculated level.
      */
     public int getLevel(HashSet<String> excludes) {
-        return calculateLevel(getCharacter(), getName(), getSpecialization(), getCategoriesAsString(), getDefaults(), getAttribute(), getDifficulty(), getPoints(), excludes, getEncumbrancePenaltyMultiplier()).mLevel;
+        return calculateLevel(getCharacter(), getName(), getSpecialization(), getCategories(), getDefaults(), getAttribute(), getDifficulty(), getPoints(), excludes, getEncumbrancePenaltyMultiplier()).mLevel;
     }
 
     /** @return The attribute. */
@@ -716,7 +716,7 @@ public class Skill extends ListRow implements HasSourceReference {
      * @param encPenaltyMult The encumbrance penalty multiplier.
      * @return The calculated skill level.
      */
-    public SkillLevel calculateLevel(GURPSCharacter character, String name, String specialization, String categories, List<SkillDefault> defaults, SkillAttribute attribute, SkillDifficulty difficulty, int points, HashSet<String> excludes, int encPenaltyMult) {
+    public SkillLevel calculateLevel(GURPSCharacter character, String name, String specialization, Set<String> categories, List<SkillDefault> defaults, SkillAttribute attribute, SkillDifficulty difficulty, int points, HashSet<String> excludes, int encPenaltyMult) {
         StringBuilder toolTip       = new StringBuilder();
         int           relativeLevel = difficulty.getBaseRelativeLevel();
         int           level         = attribute.getBaseSkillLevel(character);
@@ -870,7 +870,7 @@ public class Skill extends ListRow implements HasSourceReference {
                         if (skillDefault.getType().isSkillBased()) {
                             String name  = skillDefault.getName();
                             Skill  skill = character.getBestSkillNamed(name, skillDefault.getSpecialization(), true, excludes);
-                            level -= character.getSkillComparedIntegerBonusFor(ID_NAME + ASTERISK, name, skillDefault.getSpecialization(), skill.getCategoriesAsString());
+                            level -= character.getSkillComparedIntegerBonusFor(ID_NAME + ASTERISK, name, skillDefault.getSpecialization(), skill.getCategories());
                             level -= character.getIntegerBonusFor(ID_NAME + SLASH + name.toLowerCase());
                         }
                         if (level > best) {

--- a/src/com/trollworks/gcs/skill/SkillEditor.java
+++ b/src/com/trollworks/gcs/skill/SkillEditor.java
@@ -438,7 +438,7 @@ public class SkillEditor extends RowEditor<Skill> implements ActionListener, Doc
     private void recalculateLevel() {
         if (mLevelField != null) {
             SkillAttribute attribute = getSkillAttribute();
-            SkillLevel     level     = mRow.calculateLevel(mRow.getCharacter(), mNameField.getText(), mSpecializationField.getText(), mDefaults.getDefaults(), attribute, getSkillDifficulty(), getSkillPoints(), new HashSet<String>(), getEncumbrancePenaltyMultiplier());
+            SkillLevel     level     = mRow.calculateLevel(mRow.getCharacter(), mNameField.getText(), mSpecializationField.getText(), mCategoriesField.getText(), mDefaults.getDefaults(), attribute, getSkillDifficulty(), getSkillPoints(), new HashSet<String>(), getEncumbrancePenaltyMultiplier());
             mLevelField.setText(Skill.getSkillDisplayLevel(level.mLevel, level.mRelativeLevel, attribute, false));
             mLevelField.setToolTipText(Text.wrapPlainTextForToolTip(EDITOR_LEVEL_TOOLTIP + ".\n" + level.getToolTip()));  //$NON-NLS-1$
         }

--- a/src/com/trollworks/gcs/skill/SkillEditor.java
+++ b/src/com/trollworks/gcs/skill/SkillEditor.java
@@ -17,6 +17,7 @@ import com.trollworks.gcs.prereq.PrereqsPanel;
 import com.trollworks.gcs.weapon.MeleeWeaponEditor;
 import com.trollworks.gcs.weapon.RangedWeaponEditor;
 import com.trollworks.gcs.weapon.WeaponStats;
+import com.trollworks.gcs.widgets.outline.ListRow;
 import com.trollworks.gcs.widgets.outline.RowEditor;
 import com.trollworks.toolkit.annotation.Localize;
 import com.trollworks.toolkit.ui.UIUtilities;
@@ -438,7 +439,7 @@ public class SkillEditor extends RowEditor<Skill> implements ActionListener, Doc
     private void recalculateLevel() {
         if (mLevelField != null) {
             SkillAttribute attribute = getSkillAttribute();
-            SkillLevel     level     = mRow.calculateLevel(mRow.getCharacter(), mNameField.getText(), mSpecializationField.getText(), mCategoriesField.getText(), mDefaults.getDefaults(), attribute, getSkillDifficulty(), getSkillPoints(), new HashSet<String>(), getEncumbrancePenaltyMultiplier());
+            SkillLevel     level     = mRow.calculateLevel(mRow.getCharacter(), mNameField.getText(), mSpecializationField.getText(), ListRow.createCategoriesList(mCategoriesField.getText()), mDefaults.getDefaults(), attribute, getSkillDifficulty(), getSkillPoints(), new HashSet<String>(), getEncumbrancePenaltyMultiplier());
             mLevelField.setText(Skill.getSkillDisplayLevel(level.mLevel, level.mRelativeLevel, attribute, false));
             mLevelField.setToolTipText(Text.wrapPlainTextForToolTip(EDITOR_LEVEL_TOOLTIP + ".\n" + level.getToolTip()));  //$NON-NLS-1$
         }

--- a/src/com/trollworks/gcs/skill/Technique.java
+++ b/src/com/trollworks/gcs/skill/Technique.java
@@ -71,7 +71,7 @@ public class Technique extends Skill {
      * @param limitModifier  The maximum bonus the technique can grant.
      * @return The calculated technique level.
      */
-    public static SkillLevel calculateTechniqueLevel(GURPSCharacter character, String name, String specialization, SkillDefault def, SkillDifficulty difficulty, int points, boolean limited, int limitModifier) {
+    public static SkillLevel calculateTechniqueLevel(GURPSCharacter character, String name, String specialization, String categories, SkillDefault def, SkillDifficulty difficulty, int points, boolean limited, int limitModifier) {
         StringBuilder toolTip       = new StringBuilder();
         int           relativeLevel = 0;
         int           level         = Integer.MIN_VALUE;
@@ -87,7 +87,7 @@ public class Technique extends Skill {
                     relativeLevel = points;
                 }
                 if (level != Integer.MIN_VALUE) {
-                    level += relativeLevel + character.getIntegerBonusFor(ID_NAME + "/" + name.toLowerCase(), toolTip) + character.getSkillComparedIntegerBonusFor(ID_NAME + "*", name, specialization, toolTip); //$NON-NLS-1$ //$NON-NLS-2$
+                    level += relativeLevel + character.getIntegerBonusFor(ID_NAME + "/" + name.toLowerCase(), toolTip) + character.getSkillComparedIntegerBonusFor(ID_NAME + "*", name, specialization, categories, toolTip); //$NON-NLS-1$ //$NON-NLS-2$
                 }
                 if (limited) {
                     int max = baseLevel + limitModifier;
@@ -266,7 +266,7 @@ public class Technique extends Skill {
 
     @Override
     protected SkillLevel calculateLevelSelf() {
-        return calculateTechniqueLevel(getCharacter(), getName(), getSpecialization(), getDefault(), getDifficulty(), getPoints(), isLimited(), getLimitModifier());
+        return calculateTechniqueLevel(getCharacter(), getName(), getSpecialization(), getCategoriesAsString(), getDefault(), getDifficulty(), getPoints(), isLimited(), getLimitModifier());
     }
 
     @Override

--- a/src/com/trollworks/gcs/skill/Technique.java
+++ b/src/com/trollworks/gcs/skill/Technique.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
 
 /** A GURPS Technique. */
 public class Technique extends Skill {
@@ -71,7 +72,7 @@ public class Technique extends Skill {
      * @param limitModifier  The maximum bonus the technique can grant.
      * @return The calculated technique level.
      */
-    public static SkillLevel calculateTechniqueLevel(GURPSCharacter character, String name, String specialization, String categories, SkillDefault def, SkillDifficulty difficulty, int points, boolean limited, int limitModifier) {
+    public static SkillLevel calculateTechniqueLevel(GURPSCharacter character, String name, String specialization, Set<String> categories, SkillDefault def, SkillDifficulty difficulty, int points, boolean limited, int limitModifier) {
         StringBuilder toolTip       = new StringBuilder();
         int           relativeLevel = 0;
         int           level         = Integer.MIN_VALUE;
@@ -266,7 +267,7 @@ public class Technique extends Skill {
 
     @Override
     protected SkillLevel calculateLevelSelf() {
-        return calculateTechniqueLevel(getCharacter(), getName(), getSpecialization(), getCategoriesAsString(), getDefault(), getDifficulty(), getPoints(), isLimited(), getLimitModifier());
+        return calculateTechniqueLevel(getCharacter(), getName(), getSpecialization(), getCategories(), getDefault(), getDifficulty(), getPoints(), isLimited(), getLimitModifier());
     }
 
     @Override

--- a/src/com/trollworks/gcs/skill/TechniqueEditor.java
+++ b/src/com/trollworks/gcs/skill/TechniqueEditor.java
@@ -398,7 +398,7 @@ public class TechniqueEditor extends RowEditor<Technique> implements ActionListe
         mPointsField.addActionListener(this);
 
         if (forCharacter) {
-            mLevelField = createField(parent, parent, EDITOR_LEVEL, Technique.getTechniqueDisplayLevel(mRow.getLevel(), mRow.getRelativeLevel(), mRow.getDefault().getModifier()), EDITOR_LEVEL_TOOLTIP, 6);
+            mLevelField = createField(parent, parent, EDITOR_LEVEL, Technique.getTechniqueDisplayLevel(mRow.getLevel(), mRow.getRelativeLevel(), mRow.getDefault().getModifier()), EDITOR_LEVEL_TOOLTIP + ".\n" + mRow.getLevelToolTip(), 6); //$NON-NLS-1$
             mLevelField.setEnabled(false);
         }
     }
@@ -427,9 +427,9 @@ public class TechniqueEditor extends RowEditor<Technique> implements ActionListe
 
     private void recalculateLevel() {
         if (mLevelField != null) {
-            SkillLevel level = Technique.calculateTechniqueLevel(mRow.getCharacter(), mNameField.getText(), getSpecialization(), createNewDefault(), getSkillDifficulty(), getPoints(), mLimitCheckbox.isSelected(), getLimitModifier());
-
+            SkillLevel level = Technique.calculateTechniqueLevel(mRow.getCharacter(), mNameField.getText(), getSpecialization(), mCategoriesField.getText(), createNewDefault(), getSkillDifficulty(), getPoints(), mLimitCheckbox.isSelected(), getLimitModifier());
             mLevelField.setText(Technique.getTechniqueDisplayLevel(level.mLevel, level.mRelativeLevel, getDefaultModifier()));
+            mLevelField.setToolTipText(Text.wrapPlainTextForToolTip(EDITOR_LEVEL_TOOLTIP + ".\n" + level.getToolTip()));  //$NON-NLS-1$
         }
     }
 

--- a/src/com/trollworks/gcs/skill/TechniqueEditor.java
+++ b/src/com/trollworks/gcs/skill/TechniqueEditor.java
@@ -17,6 +17,7 @@ import com.trollworks.gcs.prereq.PrereqsPanel;
 import com.trollworks.gcs.weapon.MeleeWeaponEditor;
 import com.trollworks.gcs.weapon.RangedWeaponEditor;
 import com.trollworks.gcs.weapon.WeaponStats;
+import com.trollworks.gcs.widgets.outline.ListRow;
 import com.trollworks.gcs.widgets.outline.RowEditor;
 import com.trollworks.toolkit.annotation.Localize;
 import com.trollworks.toolkit.ui.UIUtilities;
@@ -427,7 +428,7 @@ public class TechniqueEditor extends RowEditor<Technique> implements ActionListe
 
     private void recalculateLevel() {
         if (mLevelField != null) {
-            SkillLevel level = Technique.calculateTechniqueLevel(mRow.getCharacter(), mNameField.getText(), getSpecialization(), mCategoriesField.getText(), createNewDefault(), getSkillDifficulty(), getPoints(), mLimitCheckbox.isSelected(), getLimitModifier());
+            SkillLevel level = Technique.calculateTechniqueLevel(mRow.getCharacter(), mNameField.getText(), getSpecialization(), ListRow.createCategoriesList(mCategoriesField.getText()), createNewDefault(), getSkillDifficulty(), getPoints(), mLimitCheckbox.isSelected(), getLimitModifier());
             mLevelField.setText(Technique.getTechniqueDisplayLevel(level.mLevel, level.mRelativeLevel, getDefaultModifier()));
             mLevelField.setToolTipText(Text.wrapPlainTextForToolTip(EDITOR_LEVEL_TOOLTIP + ".\n" + level.getToolTip()));  //$NON-NLS-1$
         }

--- a/src/com/trollworks/gcs/widgets/outline/ListRow.java
+++ b/src/com/trollworks/gcs/widgets/outline/ListRow.java
@@ -14,7 +14,6 @@ package com.trollworks.gcs.widgets.outline;
 import com.trollworks.gcs.character.GURPSCharacter;
 import com.trollworks.gcs.common.DataFile;
 import com.trollworks.gcs.common.LoadState;
-import com.trollworks.gcs.criteria.StringCriteria;
 import com.trollworks.gcs.feature.AttributeBonus;
 import com.trollworks.gcs.feature.ContainedWeightReduction;
 import com.trollworks.gcs.feature.CostReduction;
@@ -119,21 +118,17 @@ public abstract class ListRow extends Row {
         return buffer.toString();
     }
 
+    public static Set<String> createCategoriesList(String categories) {
+        TreeSet cats = new TreeSet();
+        for (String category : createList(categories)) {
+            cats.add(category);
+        }
+        return cats;
+    }
+
     // This is the decompose method that works with the compose method (getCategoriesAsString())
     private static Collection<String> createList(String categories) {
         return Arrays.asList(categories.split(COMMA));
-    }
-
-    /* Static method to determine if a string criteria matches against one of the categories
-     * stored in the categories string.   The ListRow class knows how to compose and decompose
-     * categories as strings. */
-    public static boolean matchesCategories(StringCriteria criteria, String categories) {
-        for (String category : createList(categories)) {
-            if (criteria.matches(category)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/src/com/trollworks/gcs/widgets/outline/ListRow.java
+++ b/src/com/trollworks/gcs/widgets/outline/ListRow.java
@@ -14,6 +14,7 @@ package com.trollworks.gcs.widgets.outline;
 import com.trollworks.gcs.character.GURPSCharacter;
 import com.trollworks.gcs.common.DataFile;
 import com.trollworks.gcs.common.LoadState;
+import com.trollworks.gcs.criteria.StringCriteria;
 import com.trollworks.gcs.feature.AttributeBonus;
 import com.trollworks.gcs.feature.ContainedWeightReduction;
 import com.trollworks.gcs.feature.CostReduction;
@@ -51,6 +52,8 @@ public abstract class ListRow extends Row {
     private static final String     TAG_NOTES      = "notes"; //$NON-NLS-1$
     private static final String     TAG_CATEGORIES = "categories"; //$NON-NLS-1$
     private static final String     TAG_CATEGORY   = "category"; //$NON-NLS-1$
+    private static final String     COMMA          = ","; //$NON-NLS-1$
+    private static final String     SPACE          = " "; //$NON-NLS-1$
     /** The data file the row is associated with. */
     protected DataFile              mDataFile;
     private ArrayList<Feature>      mFeatures;
@@ -114,6 +117,23 @@ public abstract class ListRow extends Row {
         }
         buffer.append(data);
         return buffer.toString();
+    }
+
+    // This is the decompose method that works with the compose method (getCategoriesAsString())
+    private static Collection<String> createList(String categories) {
+        return Arrays.asList(categories.split(COMMA));
+    }
+
+    /* Static method to determine if a string criteria matches against one of the categories
+     * stored in the categories string.   The ListRow class knows how to compose and decompose
+     * categories as strings. */
+    public static boolean matchesCategories(StringCriteria criteria, String categories) {
+        for (String category : createList(categories)) {
+            if (criteria.matches(category)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -495,7 +515,8 @@ public abstract class ListRow extends Row {
         StringBuilder buffer = new StringBuilder();
         for (String category : mCategories) {
             if (buffer.length() > 0) {
-                buffer.append(", "); //$NON-NLS-1$
+                buffer.append(COMMA);
+                buffer.append(SPACE);
             }
             buffer.append(category);
         }
@@ -549,7 +570,7 @@ public abstract class ListRow extends Row {
      * @return Whether there was a change or not.
      */
     public final boolean setCategories(String categories) {
-        return setCategories(Arrays.asList(categories.split(","))); //$NON-NLS-1$
+        return setCategories(createList(categories));
     }
 
     /**


### PR DESCRIPTION
Added bonuses by category for Skills.   This one is kind of messy because of the necessity of passing the categories around.

1.  The "get*Bonus*" methods in GURPSCharacter now accept a category string (actually, a single string of all categories separated by commas), and when they are comparing the bonus to see if it matches, they now also check the category criteria.

2.  To shorten some of the criteria checking code, they can now respond directly if they are "an exact match" kind of criteria (Is), or an "anything goes" kind (isAnything).

3.  SkillBonus gained a category criteria and all of the internal methods were updated to include it (object creation, copy, XML read/write, etc.).   Also, a SkillBonus can now determine if it matchesCategories().

4.  The SkillBonusEditor gained a category criteria row.

5.  Skill was updated to include its category in all of its level calculation methods.

6.  And the SkillEditor was modified to pass in the category when determining level.

7.  And finally, Technique and the TechniqueEditor were modified to include the categories as well, since they subclass from Skill.

7a.   And I forgot a tooltip method on the TechniqueEditor, so it will show tooltips just like the SkillEditor.

I am sorry this one is hairier than the previous PRs.   I tried to whittle out as much as possible, but except for #2 and #7a (above), everything is necessary to make this work.

And unfortunately, the following PRs (for Spells and WeaponDamage) are going to be about the same.