### PR TITLE
Added Category filtering to Spell Bonuses

### DIFF
--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -2756,8 +2756,9 @@ public class GURPSCharacter extends DataFile {
     }
 
     /**
-     * @param id        The feature ID to search for.
-     * @param qualifier The qualifier. #param categories The categories qualifier
+     * @param id         The feature ID to search for.
+     * @param qualifier  The qualifier.
+     * @param categories The categories qualifier
      * @return The bonus.
      */
     public int getSpellComparedIntegerBonusFor(String id, String qualifier, Set<String> categories, StringBuilder toolTip) {

--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -2757,17 +2757,17 @@ public class GURPSCharacter extends DataFile {
 
     /**
      * @param id        The feature ID to search for.
-     * @param qualifier The qualifier.
+     * @param qualifier The qualifier. #param categories The categories qualifier
      * @return The bonus.
      */
-    public int getSpellComparedIntegerBonusFor(String id, String qualifier, StringBuilder toolTip) {
+    public int getSpellComparedIntegerBonusFor(String id, String qualifier, Set<String> categories, StringBuilder toolTip) {
         int                total = 0;
         ArrayList<Feature> list  = mFeatureMap.get(id.toLowerCase());
         if (list != null) {
             for (Feature feature : list) {
                 if (feature instanceof SpellBonus) {
                     SpellBonus bonus = (SpellBonus) feature;
-                    if (bonus.getNameCriteria().matches(qualifier)) {
+                    if (bonus.getNameCriteria().matches(qualifier) && bonus.matchesCategories(categories)) {
                         total += bonus.getAmount().getIntegerAdjustedAmount();
                         bonus.addToToolTip(toolTip);
                     }

--- a/src/com/trollworks/gcs/feature/SpellBonus.java
+++ b/src/com/trollworks/gcs/feature/SpellBonus.java
@@ -48,7 +48,7 @@ public class SpellBonus extends Bonus {
         super(1);
         mAllColleges      = true;
         mMatchType        = TAG_COLLEGE_NAME;
-        mNameCriteria     = new StringCriteria(StringCompareType.IS, ""); //$NON-NLS-1$
+        mNameCriteria     = new StringCriteria(StringCompareType.IS, EMPTY);
         mCategoryCriteria = new StringCriteria(StringCompareType.IS_ANYTHING, EMPTY);
     }
 

--- a/src/com/trollworks/gcs/feature/SpellBonusEditor.java
+++ b/src/com/trollworks/gcs/feature/SpellBonusEditor.java
@@ -47,6 +47,11 @@ public class SpellBonusEditor extends FeatureEditor {
     @Localize(locale = "ru", value = "источнику силы, чьё название")
     @Localize(locale = "es", value = "a la fuente de poder cuyo nombre sea")
     private static String POWER_SOURCE_NAME;
+    @Localize("and category ")
+    @Localize(locale = "de", value = "und Kategorie ")
+    @Localize(locale = "ru", value = "и категория ")
+    @Localize(locale = "es", value = "y categoria ")
+    private static String CATEGORY;
 
     static {
         Localization.initialize();
@@ -88,6 +93,13 @@ public class SpellBonusEditor extends FeatureEditor {
             row.add(new FlexSpacer(0, 0, true, false));
         }
         grid.add(row, 1, 0);
+
+        row = new FlexRow();
+        row.setInsets(new Insets(0, 20, 0, 0));
+        StringCriteria criteria = bonus.getCategoryCriteria();
+        row.add(addStringCompareCombo(criteria, CATEGORY));
+        row.add(addStringCompareField(criteria));
+        grid.add(row, 2, 0);
     }
 
     private static String getMatchText(boolean allColleges, String matchType) {

--- a/src/com/trollworks/gcs/spell/Spell.java
+++ b/src/com/trollworks/gcs/spell/Spell.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /** A GURPS Spell. */
 public class Spell extends ListRow implements HasSourceReference {
@@ -448,6 +449,11 @@ public class Spell extends ListRow implements HasSourceReference {
         return mLevel.getRelativeLevel();
     }
 
+    /** @return The calculated spell skill level. */
+    private SkillLevel calculateLevelSelf() {
+        return calculateLevel(getCharacter(), mPoints, mAttribute, mIsVeryHard, mCollege, mPowerSource, mName, getCategories());
+    }
+
     /**
      * Call to force an update of the level and relative level for this spell.
      *
@@ -455,7 +461,7 @@ public class Spell extends ListRow implements HasSourceReference {
      */
     public void updateLevel(boolean notify) {
         SkillLevel savedLevel = mLevel;
-        mLevel = calculateLevel(getCharacter(), mPoints, mAttribute, mIsVeryHard, mCollege, mPowerSource, mName);
+        mLevel = calculateLevelSelf();
 
         if (notify && (savedLevel.isDifferentLevelThan(mLevel) || savedLevel.isDifferentRelativeLevelThan(mLevel))) {
             notify(ID_LEVEL, this);
@@ -473,7 +479,7 @@ public class Spell extends ListRow implements HasSourceReference {
      * @param name        The name of the spell.
      * @return The calculated spell level.
      */
-    public static SkillLevel calculateLevel(GURPSCharacter character, int points, SkillAttribute attribute, boolean isVeryHard, String college, String powerSource, String name) {
+    public static SkillLevel calculateLevel(GURPSCharacter character, int points, SkillAttribute attribute, boolean isVeryHard, String college, String powerSource, String name, Set<String> categories) {
         StringBuilder toolTip       = new StringBuilder();
         int           relativeLevel = isVeryHard ? -3 : -2;
         int           level;
@@ -492,9 +498,9 @@ public class Spell extends ListRow implements HasSourceReference {
             }
 
             if (level != -1) {
-                relativeLevel += getSpellBonusesFor(character, ID_COLLEGE, college, toolTip);
-                relativeLevel += getSpellBonusesFor(character, ID_POWER_SOURCE, powerSource, toolTip);
-                relativeLevel += getSpellBonusesFor(character, ID_NAME, name, toolTip);
+                relativeLevel += getSpellBonusesFor(character, ID_COLLEGE, college, categories, toolTip);
+                relativeLevel += getSpellBonusesFor(character, ID_POWER_SOURCE, powerSource, categories, toolTip);
+                relativeLevel += getSpellBonusesFor(character, ID_NAME, name, categories, toolTip);
                 level         += relativeLevel;
             }
         } else {
@@ -504,10 +510,10 @@ public class Spell extends ListRow implements HasSourceReference {
         return new SkillLevel(level, relativeLevel, toolTip);
     }
 
-    private static int getSpellBonusesFor(GURPSCharacter character, String id, String qualifier, StringBuilder toolTip) {
+    private static int getSpellBonusesFor(GURPSCharacter character, String id, String qualifier, Set<String> categories, StringBuilder toolTip) {
         int level = character.getIntegerBonusFor(id, toolTip);
         level += character.getIntegerBonusFor(id + '/' + qualifier.toLowerCase(), toolTip);
-        level += character.getSpellComparedIntegerBonusFor(id + '*', qualifier, toolTip);
+        level += character.getSpellComparedIntegerBonusFor(id + '*', qualifier, categories, toolTip);
         return level;
     }
 

--- a/src/com/trollworks/gcs/spell/SpellEditor.java
+++ b/src/com/trollworks/gcs/spell/SpellEditor.java
@@ -19,6 +19,7 @@ import com.trollworks.gcs.skill.SkillLevel;
 import com.trollworks.gcs.weapon.MeleeWeaponEditor;
 import com.trollworks.gcs.weapon.RangedWeaponEditor;
 import com.trollworks.gcs.weapon.WeaponStats;
+import com.trollworks.gcs.widgets.outline.ListRow;
 import com.trollworks.gcs.widgets.outline.RowEditor;
 import com.trollworks.toolkit.annotation.Localize;
 import com.trollworks.toolkit.ui.UIUtilities;
@@ -581,7 +582,7 @@ public class SpellEditor extends RowEditor<Spell> implements ActionListener, Doc
     private void recalculateLevel() {
         if (mLevelField != null) {
             SkillAttribute attribute = getAttribute();
-            SkillLevel     level     = Spell.calculateLevel(mRow.getCharacter(), getSpellPoints(), attribute, isVeryHard(), mCollegeField.getText(), mPowerSourceField.getText(), mNameField.getText());
+            SkillLevel     level     = Spell.calculateLevel(mRow.getCharacter(), getSpellPoints(), attribute, isVeryHard(), mCollegeField.getText(), mPowerSourceField.getText(), mNameField.getText(), ListRow.createCategoriesList(mCategoriesField.getText()));
             mLevelField.setText(getDisplayLevel(attribute, level.mLevel, level.mRelativeLevel));
             mLevelField.setToolTipText(Text.wrapPlainTextForToolTip(EDITOR_LEVEL_TOOLTIP + ".\n" + level.getToolTip()));  //$NON-NLS-1$
         }


### PR DESCRIPTION
This builds off of (and partially copies) the Skill categories code.   The biggest issue here was the multiple ways you could add a spell bonus (by college, by name, by Power, etc.).

I built a large testcase that created bonuses for all of the combinations of college/power/name and category, to verify that the code works (and doesn't interfere with previous bonuses).  So on this, you will have to trust me ;-)  

![image](https://user-images.githubusercontent.com/8931036/61586959-e8ea2000-ab4d-11e9-9ac2-63cfa672d0d7.png)

The final PR will contain the code to support weapon bonuses by category.