### PR TITLE
Categories for Weapons Bonuses

### DIFF
--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -2688,9 +2688,10 @@ public class GURPSCharacter extends DataFile {
      * @param id                      The feature ID to search for.
      * @param nameQualifier           The name qualifier.
      * @param specializationQualifier The specialization qualifier.
+     * @param categoriesQualifier     The categories qualifier.
      * @return The bonuses.
      */
-    public ArrayList<WeaponBonus> getWeaponComparedBonusesFor(String id, String nameQualifier, String specializationQualifier, StringBuilder toolTip) {
+    public ArrayList<WeaponBonus> getWeaponComparedBonusesFor(String id, String nameQualifier, String specializationQualifier, Set<String> categoriesQualifier, StringBuilder toolTip) {
         ArrayList<WeaponBonus> bonuses = new ArrayList<>();
         int                    rsl     = Integer.MIN_VALUE;
 
@@ -2708,7 +2709,7 @@ public class GURPSCharacter extends DataFile {
                 for (Feature feature : list) {
                     if (feature instanceof WeaponBonus) {
                         WeaponBonus bonus = (WeaponBonus) feature;
-                        if (bonus.getNameCriteria().matches(nameQualifier) && bonus.getSpecializationCriteria().matches(specializationQualifier) && bonus.getLevelCriteria().matches(rsl)) {
+                        if (bonus.getNameCriteria().matches(nameQualifier) && bonus.getSpecializationCriteria().matches(specializationQualifier) && bonus.getLevelCriteria().matches(rsl) && bonus.matchesCategories(categoriesQualifier)) {
                             bonuses.add(bonus);
                             bonus.addToToolTip(toolTip);
                         }

--- a/src/com/trollworks/gcs/feature/WeaponBonus.java
+++ b/src/com/trollworks/gcs/feature/WeaponBonus.java
@@ -23,6 +23,7 @@ import com.trollworks.toolkit.io.xml.XMLWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
 
 /** A weapon bonus. */
 public class WeaponBonus extends Bonus {
@@ -31,10 +32,12 @@ public class WeaponBonus extends Bonus {
     private static final String TAG_NAME           = "name"; //$NON-NLS-1$
     private static final String TAG_SPECIALIZATION = "specialization"; //$NON-NLS-1$
     private static final String TAG_LEVEL          = "level"; //$NON-NLS-1$
+    private static final String TAG_CATEGORY       = "category"; //$NON-NLS-1$
     private static final String EMPTY              = ""; //$NON-NLS-1$
     private StringCriteria      mNameCriteria;
     private StringCriteria      mSpecializationCriteria;
     private IntegerCriteria     mLevelCriteria;
+    private StringCriteria      mCategoryCriteria;
 
     /** Creates a new skill bonus. */
     public WeaponBonus() {
@@ -42,6 +45,7 @@ public class WeaponBonus extends Bonus {
         mNameCriteria           = new StringCriteria(StringCompareType.IS, EMPTY);
         mSpecializationCriteria = new StringCriteria(StringCompareType.IS_ANYTHING, EMPTY);
         mLevelCriteria          = new IntegerCriteria(NumericCompareType.AT_LEAST, 0);
+        mCategoryCriteria       = new StringCriteria(StringCompareType.IS_ANYTHING, EMPTY);
     }
 
     /**
@@ -64,6 +68,7 @@ public class WeaponBonus extends Bonus {
         mNameCriteria           = new StringCriteria(other.mNameCriteria);
         mSpecializationCriteria = new StringCriteria(other.mSpecializationCriteria);
         mLevelCriteria          = new IntegerCriteria(other.mLevelCriteria);
+        mCategoryCriteria       = new StringCriteria(other.mCategoryCriteria);
     }
 
     @Override
@@ -93,13 +98,25 @@ public class WeaponBonus extends Bonus {
         StringBuffer buffer = new StringBuffer();
 
         buffer.append(Skill.ID_NAME);
-        if (mNameCriteria.getType() == StringCompareType.IS && mSpecializationCriteria.getType() == StringCompareType.IS_ANYTHING) {
+        if (mNameCriteria.isTypeIs() && mSpecializationCriteria.isTypeAnything() && mCategoryCriteria.isTypeAnything()) {
             buffer.append('/');
             buffer.append(mNameCriteria.getQualifier());
         } else {
             buffer.append("*"); //$NON-NLS-1$
         }
         return buffer.toString();
+    }
+
+    public boolean matchesCategories(Set<String> categories) {
+        if (categories == null) {
+            return mCategoryCriteria.isTypeAnything();
+        }
+        for (String category : categories) {
+            if (mCategoryCriteria.matches(category)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -110,6 +127,8 @@ public class WeaponBonus extends Bonus {
             mSpecializationCriteria.load(reader);
         } else if (TAG_LEVEL.equals(reader.getName())) {
             mLevelCriteria.load(reader);
+        } else if (TAG_CATEGORY.equals(reader.getName())) {
+            mCategoryCriteria.load(reader);
         } else {
             super.loadSelf(reader);
         }
@@ -126,6 +145,7 @@ public class WeaponBonus extends Bonus {
         mNameCriteria.save(out, TAG_NAME);
         mSpecializationCriteria.save(out, TAG_SPECIALIZATION);
         mLevelCriteria.save(out, TAG_LEVEL);
+        mCategoryCriteria.save(out, TAG_CATEGORY);
         saveBase(out);
         out.endTagEOL(TAG_ROOT, true);
     }
@@ -145,16 +165,23 @@ public class WeaponBonus extends Bonus {
         return mLevelCriteria;
     }
 
+    /** @return The category criteria. */
+    public StringCriteria getCategoryCriteria() {
+        return mCategoryCriteria;
+    }
+
     @Override
     public void fillWithNameableKeys(HashSet<String> set) {
         ListRow.extractNameables(set, mNameCriteria.getQualifier());
         ListRow.extractNameables(set, mSpecializationCriteria.getQualifier());
+        ListRow.extractNameables(set, mCategoryCriteria.getQualifier());
     }
 
     @Override
     public void applyNameableKeys(HashMap<String, String> map) {
         mNameCriteria.setQualifier(ListRow.nameNameables(map, mNameCriteria.getQualifier()));
         mSpecializationCriteria.setQualifier(ListRow.nameNameables(map, mSpecializationCriteria.getQualifier()));
+        mCategoryCriteria.setQualifier(ListRow.nameNameables(map, mCategoryCriteria.getQualifier()));
     }
 
     @Override

--- a/src/com/trollworks/gcs/feature/WeaponBonusEditor.java
+++ b/src/com/trollworks/gcs/feature/WeaponBonusEditor.java
@@ -39,6 +39,11 @@ public class WeaponBonusEditor extends FeatureEditor {
     @Localize(locale = "ru", value = "и специализация ")
     @Localize(locale = "es", value = "y especialización ")
     private static String SPECIALIZATION;
+    @Localize("and category ")
+    @Localize(locale = "de", value = "und Kategorie ")
+    @Localize(locale = "ru", value = "и категория ")
+    @Localize(locale = "es", value = "y categoria ")
+    private static String CATEGORY;
 
     static {
         Localization.initialize();
@@ -87,5 +92,13 @@ public class WeaponBonusEditor extends FeatureEditor {
         row.add(addNumericCompareField(levelCriteria, -999, 999, true));
         row.add(new FlexSpacer(0, 0, true, false));
         grid.add(row, 3, 0);
+
+        row = new FlexRow();
+        row.setInsets(new Insets(0, 20, 0, 0));
+        criteria = bonus.getCategoryCriteria();
+        row.add(addStringCompareCombo(criteria, CATEGORY));
+        row.add(addStringCompareField(criteria));
+        row.add(new FlexSpacer(0, 0, true, false));
+        grid.add(row, 4, 0);
     }
 }

--- a/src/com/trollworks/gcs/weapon/WeaponStats.java
+++ b/src/com/trollworks/gcs/weapon/WeaponStats.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /** The stats for a weapon. */
 public abstract class WeaponStats {
@@ -249,13 +250,14 @@ public abstract class WeaponStats {
         String   damage = mDamage;
 
         if (df instanceof GURPSCharacter) {
-            GURPSCharacter       character = (GURPSCharacter) df;
-            HashSet<WeaponBonus> bonuses   = new HashSet<>();
+            GURPSCharacter       character  = (GURPSCharacter) df;
+            HashSet<WeaponBonus> bonuses    = new HashSet<>();
+            Set<String>          categories = getOwner() instanceof Equipment ? ((Equipment) getOwner()).getCategories() : null;
 
             for (SkillDefault one : getDefaults()) {
                 if (one.getType().isSkillBased()) {
-                    bonuses.addAll(character.getWeaponComparedBonusesFor(Skill.ID_NAME + "*", one.getName(), one.getSpecialization(), toolTip)); //$NON-NLS-1$
-                    bonuses.addAll(character.getWeaponComparedBonusesFor(Skill.ID_NAME + "/" + one.getName(), one.getName(), one.getSpecialization(), toolTip)); //$NON-NLS-1$
+                    bonuses.addAll(character.getWeaponComparedBonusesFor(Skill.ID_NAME + "*", one.getName(), one.getSpecialization(), getCategories(), toolTip)); //$NON-NLS-1$
+                    bonuses.addAll(character.getWeaponComparedBonusesFor(Skill.ID_NAME + "/" + one.getName(), one.getName(), one.getSpecialization(), getCategories(), toolTip)); //$NON-NLS-1$
                 }
             }
             damage = resolveDamage(damage, bonuses);
@@ -530,6 +532,10 @@ public abstract class WeaponStats {
     /** @return The owner. */
     public ListRow getOwner() {
         return mOwner;
+    }
+
+    public Set<String> getCategories() {
+        return mOwner.getCategories();
     }
 
     /**


### PR DESCRIPTION
The last of the "categories" change sets.   This adds category filtering to weapons bonuses.    The only real difference is that the "owner" of a WeaponStat could be something other than Equipment, and if so, we won't know what categories it belongs to (so we send null).   And we had to protect the WeaponBonus matchesCategories() method in case the categories were null.