### PR TITLE
Added brackets and curly braces to text output

### DIFF
--- a/src/com/trollworks/gcs/character/TextTemplate.java
+++ b/src/com/trollworks/gcs/character/TextTemplate.java
@@ -239,6 +239,8 @@ public class TextTemplate {
     private static final String KEY_STATE                             = "STATE";
     private static final String KEY_STYLE_INDENT_WARNING              = "STYLE_INDENT_WARNING";
     private static final String KEY_SUFFIX_PAREN                      = "_PAREN";
+    private static final String KEY_SUFFIX_BRACKETS                   = "_BRACKET";
+    private static final String KEY_SUFFIX_CURLY                      = "_CURLY";
     private static final String KEY_SWING                             = "SWING";
     private static final String KEY_TASTE_SMELL                       = "TASTE_SMELL";
     private static final String KEY_THRUST                            = "THRUST";
@@ -971,14 +973,21 @@ public class TextTemplate {
 
     private void writeXMLTextWithOptionalParens(String key, BufferedWriter out, String text) throws IOException {
         if (text.length() > 0) {
-            boolean parenVersion = key.endsWith(KEY_SUFFIX_PAREN);
-            if (parenVersion) {
-                out.write(" (");
+            String pre  = "";
+            String post = "";
+            if (key.endsWith(KEY_SUFFIX_PAREN)) {
+                pre  = " (";
+                post = ")";
+            } else if (key.endsWith(KEY_SUFFIX_BRACKETS)) {
+                pre  = " [";
+                post = "]";
+            } else if (key.endsWith(KEY_SUFFIX_CURLY)) {
+                pre  = " {";
+                post = "}";
             }
+            out.write(pre);
             writeEncodedText(out, text);
-            if (parenVersion) {
-                out.write(')');
-            }
+            out.write(post);
         }
     }
 

--- a/src/com/trollworks/gcs/character/TextTemplate.java
+++ b/src/com/trollworks/gcs/character/TextTemplate.java
@@ -239,7 +239,7 @@ public class TextTemplate {
     private static final String KEY_STATE                             = "STATE";
     private static final String KEY_STYLE_INDENT_WARNING              = "STYLE_INDENT_WARNING";
     private static final String KEY_SUFFIX_PAREN                      = "_PAREN";
-    private static final String KEY_SUFFIX_BRACKETS                   = "_BRACKET";
+    private static final String KEY_SUFFIX_BRACKET                    = "_BRACKET";
     private static final String KEY_SUFFIX_CURLY                      = "_CURLY";
     private static final String KEY_SWING                             = "SWING";
     private static final String KEY_TASTE_SMELL                       = "TASTE_SMELL";
@@ -978,7 +978,7 @@ public class TextTemplate {
             if (key.endsWith(KEY_SUFFIX_PAREN)) {
                 pre  = " (";
                 post = ")";
-            } else if (key.endsWith(KEY_SUFFIX_BRACKETS)) {
+            } else if (key.endsWith(KEY_SUFFIX_BRACKET)) {
                 pre  = " [";
                 post = "]";
             } else if (key.endsWith(KEY_SUFFIX_CURLY)) {


### PR DESCRIPTION
Simple addition to the text output routine to also allow [ ] and { } around descriptive notes and modifiers.  I have already updated the web branch (and PR) with the additional information.