### PR TITLE
Added a User Description to Advantage

### DIFF
--- a/src/com/trollworks/gcs/advantage/Advantage.java
+++ b/src/com/trollworks/gcs/advantage/Advantage.java
@@ -112,6 +112,8 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
     public static final String         ID_WEAPON_STATUS_CHANGED   = PREFIX + "WeaponStatus"; //$NON-NLS-1$
     /** The field ID for when the advantage gets Modifiers. */
     public static final String         ID_MODIFIER_STATUS_CHANGED = PREFIX + "Modifier"; //$NON-NLS-1$
+    /** The field ID for user description changes. */
+    public static final String         ID_USER_DESC               = PREFIX + "UserDesc"; //$NON-NLS-1$
     /** The type mask for mental advantages. */
     public static final int            TYPE_MASK_MENTAL           = 1 << 0;
     /** The type mask for physical advantages. */
@@ -463,8 +465,13 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
         return mUserDesc;
     }
 
-    public void setUserDesc(String desc) {
-        mUserDesc = desc;
+    public boolean setUserDesc(String desc) {
+        if (!mUserDesc.equals(desc)) {
+            mUserDesc = desc;
+            notifySingle(ID_USER_DESC);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/com/trollworks/gcs/advantage/Advantage.java
+++ b/src/com/trollworks/gcs/advantage/Advantage.java
@@ -184,7 +184,7 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
         mDisabled        = advantage.mDisabled;
         mReference       = advantage.mReference;
         mContainerType   = advantage.mContainerType;
-        mUserDesc        = advantage.mUserDesc;
+        mUserDesc        = dataFile instanceof GURPSCharacter ? advantage.mUserDesc : "";  //$NON-NLS-1$
         mWeapons         = new ArrayList<>(advantage.mWeapons.size());
         for (WeaponStats weapon : advantage.mWeapons) {
             if (weapon instanceof MeleeWeaponStats) {
@@ -293,7 +293,9 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
         } else if (Modifier.TAG_MODIFIER.equals(name)) {
             mModifiers.add(new Modifier(getDataFile(), reader, state));
         } else if (TAG_USER_DESC.equals(name)) {
-            mUserDesc = Text.standardizeLineEndings(reader.readText());
+            if (getDataFile() instanceof GURPSCharacter) {
+                mUserDesc = Text.standardizeLineEndings(reader.readText());
+            }
         } else if (!canHaveChildren()) {
             if (TAG_TYPE.equals(name)) {
                 mType = getTypeFromText(reader.readText());
@@ -411,7 +413,9 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
         for (Modifier modifier : mModifiers) {
             modifier.save(out, forUndo);
         }
-        out.simpleTagNotEmpty(TAG_USER_DESC, mUserDesc);
+        if (getDataFile() instanceof GURPSCharacter) {
+            out.simpleTagNotEmpty(TAG_USER_DESC, mUserDesc);
+        }
         out.simpleTagNotEmpty(TAG_REFERENCE, mReference);
     }
 

--- a/src/com/trollworks/gcs/advantage/Advantage.java
+++ b/src/com/trollworks/gcs/advantage/Advantage.java
@@ -35,6 +35,7 @@ import com.trollworks.toolkit.ui.widget.outline.Column;
 import com.trollworks.toolkit.ui.widget.outline.Row;
 import com.trollworks.toolkit.utility.Localization;
 import com.trollworks.toolkit.utility.text.Enums;
+import com.trollworks.toolkit.utility.text.Text;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,6 +70,7 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
     private static final String        TAG_TYPE                   = "type"; //$NON-NLS-1$
     private static final String        TAG_NAME                   = "name"; //$NON-NLS-1$
     private static final String        TAG_CR                     = "cr"; //$NON-NLS-1$
+    private static final String        TAG_USER_DESC              = "userdesc"; //$NON-NLS-1$
     private static final String        TYPE_MENTAL                = "Mental"; //$NON-NLS-1$
     private static final String        TYPE_PHYSICAL              = "Physical"; //$NON-NLS-1$
     private static final String        TYPE_SOCIAL                = "Social"; //$NON-NLS-1$
@@ -136,6 +138,7 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
     private ArrayList<Modifier>        mModifiers;
     private boolean                    mRoundCostDown;
     private boolean                    mDisabled;
+    private String                     mUserDesc;
 
     /**
      * Creates a new advantage.
@@ -154,6 +157,7 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
         mContainerType = AdvantageContainerType.GROUP;
         mWeapons       = new ArrayList<>();
         mModifiers     = new ArrayList<>();
+        mUserDesc      = ""; //$NON-NLS-1$
     }
 
     /**
@@ -178,6 +182,7 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
         mDisabled        = advantage.mDisabled;
         mReference       = advantage.mReference;
         mContainerType   = advantage.mContainerType;
+        mUserDesc        = advantage.mUserDesc;
         mWeapons         = new ArrayList<>(advantage.mWeapons.size());
         for (WeaponStats weapon : advantage.mWeapons) {
             if (weapon instanceof MeleeWeaponStats) {
@@ -256,6 +261,7 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
         mOldPointsString = null;
         mWeapons         = new ArrayList<>();
         mModifiers       = new ArrayList<>();
+        mUserDesc        = "";//$NON-NLS-1$
     }
 
     @Override
@@ -284,6 +290,8 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
             addChild(new Advantage(mDataFile, reader, state));
         } else if (Modifier.TAG_MODIFIER.equals(name)) {
             mModifiers.add(new Modifier(getDataFile(), reader, state));
+        } else if (TAG_USER_DESC.equals(name)) {
+            mUserDesc = Text.standardizeLineEndings(reader.readText());
         } else if (!canHaveChildren()) {
             if (TAG_TYPE.equals(name)) {
                 mType = getTypeFromText(reader.readText());
@@ -401,6 +409,7 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
         for (Modifier modifier : mModifiers) {
             modifier.save(out, forUndo);
         }
+        out.simpleTagNotEmpty(TAG_USER_DESC, mUserDesc);
         out.simpleTagNotEmpty(TAG_REFERENCE, mReference);
     }
 
@@ -448,6 +457,14 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
     /** @return The name. */
     public String getName() {
         return mName;
+    }
+
+    public String getUserDesc() {
+        return mUserDesc;
+    }
+
+    public void setUserDesc(String desc) {
+        mUserDesc = desc;
     }
 
     /**

--- a/src/com/trollworks/gcs/advantage/Advantage.java
+++ b/src/com/trollworks/gcs/advantage/Advantage.java
@@ -1122,4 +1122,8 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
     public String getToolTip(Column column) {
         return AdvantageColumn.values()[column.getID()].getToolTip(this);
     }
+
+    public String getDescriptionToolTip() {
+        return SheetPreferences.showUserDescAsTooltip() ? getUserDesc() : null;
+    }
 }

--- a/src/com/trollworks/gcs/advantage/AdvantageColumn.java
+++ b/src/com/trollworks/gcs/advantage/AdvantageColumn.java
@@ -81,6 +81,16 @@ public enum AdvantageColumn {
             }
             return builder.toString();
         }
+
+        @Override
+        public boolean showToolTip() {
+            return true;
+        }
+
+        @Override
+        public String getToolTip(Advantage advantage) {
+            return advantage.getDescriptionToolTip();
+        }
     },
     /** The points spent in the advantage. */
     POINTS {

--- a/src/com/trollworks/gcs/character/CharacterSheet.java
+++ b/src/com/trollworks/gcs/character/CharacterSheet.java
@@ -242,7 +242,7 @@ public class CharacterSheet extends JPanel implements ChangeListener, Scrollable
         if (!GraphicsUtilities.inHeadlessPrintMode()) {
             setDropTarget(new DropTarget(this, this));
         }
-        Preferences.getInstance().getNotifier().add(this, SheetPreferences.OPTIONAL_DICE_RULES_PREF_KEY, Fonts.FONT_NOTIFICATION_KEY, SheetPreferences.WEIGHT_UNITS_PREF_KEY, SheetPreferences.GURPS_METRIC_RULES_PREF_KEY, SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY, SheetPreferences.OPTIONAL_REDUCED_SWING_PREF_KEY, OutputPreferences.BLOCK_LAYOUT_PREF_KEY);
+        Preferences.getInstance().getNotifier().add(this, SheetPreferences.OPTIONAL_DICE_RULES_PREF_KEY, Fonts.FONT_NOTIFICATION_KEY, SheetPreferences.WEIGHT_UNITS_PREF_KEY, SheetPreferences.GURPS_METRIC_RULES_PREF_KEY, SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY, SheetPreferences.OPTIONAL_REDUCED_SWING_PREF_KEY, OutputPreferences.BLOCK_LAYOUT_PREF_KEY, SheetPreferences.OPTIONAL_THRUST_DAMAGE_PREF_KEY);
     }
 
     /** Call when the sheet is no longer in use. */
@@ -844,7 +844,7 @@ public class CharacterSheet extends JPanel implements ChangeListener, Scrollable
 
     @Override
     public void handleNotification(Object producer, String type, Object data) {
-        if (SheetPreferences.OPTIONAL_DICE_RULES_PREF_KEY.equals(type) || Fonts.FONT_NOTIFICATION_KEY.equals(type) || SheetPreferences.WEIGHT_UNITS_PREF_KEY.equals(type) || SheetPreferences.GURPS_METRIC_RULES_PREF_KEY.equals(type) || Profile.ID_BODY_TYPE.equals(type) || SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY.equals(type) || SheetPreferences.OPTIONAL_REDUCED_SWING_PREF_KEY.equals(type) || OutputPreferences.BLOCK_LAYOUT_PREF_KEY.equals(type)) {
+        if (SheetPreferences.OPTIONAL_DICE_RULES_PREF_KEY.equals(type) || Fonts.FONT_NOTIFICATION_KEY.equals(type) || SheetPreferences.WEIGHT_UNITS_PREF_KEY.equals(type) || SheetPreferences.GURPS_METRIC_RULES_PREF_KEY.equals(type) || Profile.ID_BODY_TYPE.equals(type) || SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY.equals(type) || SheetPreferences.OPTIONAL_REDUCED_SWING_PREF_KEY.equals(type) || OutputPreferences.BLOCK_LAYOUT_PREF_KEY.equals(type) || SheetPreferences.OPTIONAL_THRUST_DAMAGE_PREF_KEY.equals(type)) {
             markForRebuild();
         } else {
             if (type.startsWith(Advantage.PREFIX)) {

--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -1132,6 +1132,11 @@ public class GURPSCharacter extends DataFile {
      * @return The basic thrusting damage.
      */
     public static Dice getThrust(int strength) {
+        if (SheetPreferences.areOptionalThrustDamageUsed()) {
+            Dice dice = getSwing(strength);
+            dice.add(-2);
+            return dice;
+        }
         if (SheetPreferences.areOptionalReducedSwingUsed()) {
             if (strength < 19) {
                 return new Dice(1, -(6 - (strength - 1) / 2));

--- a/src/com/trollworks/gcs/character/PrerequisitesThread.java
+++ b/src/com/trollworks/gcs/character/PrerequisitesThread.java
@@ -96,7 +96,7 @@ public class PrerequisitesThread extends Thread implements NotifierTarget {
         mCharacter  = sheet.getCharacter();
         mNeedUpdate = true;
         mCharacter.addTarget(this, Profile.ID_TECH_LEVEL, GURPSCharacter.ID_STRENGTH, GURPSCharacter.ID_DEXTERITY, GURPSCharacter.ID_INTELLIGENCE, GURPSCharacter.ID_HEALTH, GURPSCharacter.ID_WILL, GURPSCharacter.ID_PERCEPTION, Spell.ID_NAME, Spell.ID_COLLEGE, Spell.ID_POINTS, Spell.ID_LIST_CHANGED, Skill.ID_NAME, Skill.ID_SPECIALIZATION, Skill.ID_LEVEL, Skill.ID_RELATIVE_LEVEL, Skill.ID_ENCUMBRANCE_PENALTY, Skill.ID_POINTS, Skill.ID_TECH_LEVEL, Skill.ID_LIST_CHANGED, Advantage.ID_NAME, Advantage.ID_LEVELS, Advantage.ID_LIST_CHANGED, Equipment.ID_EXTENDED_WEIGHT, Equipment.ID_STATE, Equipment.ID_QUANTITY, Equipment.ID_LIST_CHANGED);
-        Preferences.getInstance().getNotifier().add(this, SheetPreferences.OPTIONAL_IQ_RULES_PREF_KEY, SheetPreferences.OPTIONAL_MODIFIER_RULES_PREF_KEY, SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY);
+        Preferences.getInstance().getNotifier().add(this, SheetPreferences.OPTIONAL_IQ_RULES_PREF_KEY, SheetPreferences.OPTIONAL_MODIFIER_RULES_PREF_KEY, SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY, SheetPreferences.OPTIONAL_THRUST_DAMAGE_PREF_KEY);
         synchronized (MAP) {
             MAP.put(mCharacter, this);
         }
@@ -258,6 +258,8 @@ public class PrerequisitesThread extends Thread implements NotifierTarget {
         } else if (SheetPreferences.OPTIONAL_MODIFIER_RULES_PREF_KEY.equals(type)) {
             mCharacter.notifySingle(Advantage.ID_LIST_CHANGED, null);
         } else if (SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY.equals(type)) {
+            mCharacter.notifySingle(type, data);
+        } else if (SheetPreferences.OPTIONAL_THRUST_DAMAGE_PREF_KEY.equals(type)) {
             mCharacter.notifySingle(type, data);
         }
         markForUpdate();

--- a/src/com/trollworks/gcs/character/TextTemplate.java
+++ b/src/com/trollworks/gcs/character/TextTemplate.java
@@ -938,7 +938,7 @@ public class TextTemplate {
                                         writeEncodedText(out, advantage.getUserDesc());
                                         break;
                                     case KEY_DESCRIPTION_USER_FORMATTED:
-                                        if (advantage.getUserDesc().isEmpty()) {
+                                        if (!advantage.getUserDesc().isEmpty()) {
                                             writeEncodedText(out, PARAGRAPH_START + advantage.getUserDesc().replace(NEWLINE, PARAGRAPH_END + NEWLINE + PARAGRAPH_START) + PARAGRAPH_END);
                                         }
                                         break;

--- a/src/com/trollworks/gcs/character/TextTemplate.java
+++ b/src/com/trollworks/gcs/character/TextTemplate.java
@@ -123,6 +123,8 @@ public class TextTemplate {
     private static final String KEY_DESCRIPTION_MODIFIER_NOTES        = "DESCRIPTION_MODIFIER_NOTES";
     private static final String KEY_DESCRIPTION_NOTES                 = "DESCRIPTION_NOTES";
     private static final String KEY_DESCRIPTION_PRIMARY               = "DESCRIPTION_PRIMARY";
+    private static final String KEY_DESCRIPTION_USER                  = "DESCRIPTION_USER";
+    private static final String KEY_DESCRIPTION_USER_FORMATTED        = "DESCRIPTION_USER_FORMATTED";
     private static final String KEY_DIFFICULTY                        = "DIFFICULTY";
     private static final String KEY_DISADVANTAGE_POINTS               = "DISADVANTAGE_POINTS";
     private static final String KEY_DISADVANTAGES_ALL_LOOP_END        = "DISADVANTAGES_ALL_LOOP_END";
@@ -845,7 +847,10 @@ public class TextTemplate {
                             writeEncodedText(out, hitLocationEquipment(entry).replace(NEWLINE, COMMA_SEPARATOR));
                             break;
                         case KEY_EQUIPMENT_FORMATTED:
-                            writeEncodedText(out, PARAGRAPH_START + hitLocationEquipment(entry).replace(NEWLINE, PARAGRAPH_END + NEWLINE + PARAGRAPH_START) + PARAGRAPH_END);
+                            String loc = hitLocationEquipment(entry);
+                            if (!loc.isEmpty()) {
+                                writeEncodedText(out, PARAGRAPH_START + loc.replace(NEWLINE, PARAGRAPH_END + NEWLINE + PARAGRAPH_START) + PARAGRAPH_END);
+                            }
                             break;
                         default:
                             writeEncodedText(out, String.format(UNIDENTIFIED_KEY, key));
@@ -928,6 +933,14 @@ public class TextTemplate {
                                         break;
                                     case KEY_TYPE:
                                         writeEncodedText(out, advantage.canHaveChildren() ? advantage.getContainerType().name() : ITEM);
+                                        break;
+                                    case KEY_DESCRIPTION_USER:
+                                        writeEncodedText(out, advantage.getUserDesc());
+                                        break;
+                                    case KEY_DESCRIPTION_USER_FORMATTED:
+                                        if (advantage.getUserDesc().isEmpty()) {
+                                            writeEncodedText(out, PARAGRAPH_START + advantage.getUserDesc().replace(NEWLINE, PARAGRAPH_END + NEWLINE + PARAGRAPH_START) + PARAGRAPH_END);
+                                        }
                                         break;
                                     default:
                                         /* Allows the access to notes on modifiers.  Currently only used in the 'Language' loop.
@@ -1715,7 +1728,9 @@ public class TextTemplate {
                                 writeEncodedText(out, note.getDescription());
                                 break;
                             case KEY_NOTE_FORMATTED:
-                                writeEncodedText(out, PARAGRAPH_START + note.getDescription().replace(NEWLINE, PARAGRAPH_END + NEWLINE + PARAGRAPH_START) + PARAGRAPH_END);
+                                if (!note.getDescription().isEmpty()) {
+                                    writeEncodedText(out, PARAGRAPH_START + note.getDescription().replace(NEWLINE, PARAGRAPH_END + NEWLINE + PARAGRAPH_START) + PARAGRAPH_END);
+                                }
                                 break;
                             case KEY_ID:
                                 writeEncodedText(out, Integer.toString(counter));

--- a/src/com/trollworks/gcs/notes/NoteEditor.java
+++ b/src/com/trollworks/gcs/notes/NoteEditor.java
@@ -13,6 +13,7 @@ package com.trollworks.gcs.notes;
 
 import com.trollworks.gcs.widgets.outline.RowEditor;
 import com.trollworks.toolkit.annotation.Localize;
+import com.trollworks.toolkit.ui.image.StdImage;
 import com.trollworks.toolkit.ui.layout.ColumnLayout;
 import com.trollworks.toolkit.ui.layout.RowDistribution;
 import com.trollworks.toolkit.utility.Localization;
@@ -35,6 +36,24 @@ public class NoteEditor extends RowEditor<Note> {
         Localization.initialize();
     }
 
+    public static JTextArea addContentTo(JPanel parent, String description, StdImage image, boolean editable) {
+        JPanel    content = new JPanel(new ColumnLayout(2, RowDistribution.GIVE_EXCESS_TO_LAST));
+        JLabel    icon    = new JLabel(image);
+
+        JTextArea editor  = new JTextArea(description);
+        editor.setLineWrap(true);
+        editor.setWrapStyleWord(true);
+        editor.setEnabled(editable);
+        JScrollPane scroller = new JScrollPane(editor, ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS, ScrollPaneConstants.HORIZONTAL_SCROLLBAR_ALWAYS);
+        scroller.setMinimumSize(new Dimension(400, 300));
+        icon.setVerticalAlignment(SwingConstants.TOP);
+        icon.setAlignmentY(-1f);
+        content.add(icon);
+        content.add(scroller);
+        parent.add(content);
+        return editor;
+    }
+
     private JTextArea mEditor;
 
     /**
@@ -44,21 +63,7 @@ public class NoteEditor extends RowEditor<Note> {
      */
     public NoteEditor(Note note) {
         super(note);
-
-        JPanel content = new JPanel(new ColumnLayout(2, RowDistribution.GIVE_EXCESS_TO_LAST));
-        JLabel icon    = new JLabel(note.getIcon(true));
-
-        mEditor = new JTextArea(note.getDescription());
-        mEditor.setLineWrap(true);
-        mEditor.setWrapStyleWord(true);
-        mEditor.setEnabled(mIsEditable);
-        JScrollPane scroller = new JScrollPane(mEditor, ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS, ScrollPaneConstants.HORIZONTAL_SCROLLBAR_ALWAYS);
-        scroller.setMinimumSize(new Dimension(400, 300));
-        icon.setVerticalAlignment(SwingConstants.TOP);
-        icon.setAlignmentY(-1f);
-        content.add(icon);
-        content.add(scroller);
-        add(content);
+        mEditor = addContentTo(this, note.getDescription(), note.getIcon(true), mIsEditable);
     }
 
     @Override

--- a/src/com/trollworks/gcs/preferences/SheetPreferences.java
+++ b/src/com/trollworks/gcs/preferences/SheetPreferences.java
@@ -140,6 +140,8 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     private static String OPTIONAL_DICE_RULES;
     @Localize("Use optional strength rules from the \"Knowing Your Own Strength\" Pyramid article")
     private static String OPTIONAL_STRENGTH_RULES;
+    @Localize("Use optional Thrust damage (Thrust = Swing -2)")
+    private static String OPTIONAL_THRUST_DAMAGE;
     @Localize("Use optional Reduced Swing rules from the  \"Adjusting Swing Damage in Dungeon Fantasy\" No School Grognard article")
     private static String OPTIONAL_REDUCED_SWING;
     @Localize("for the initial scale when opening character sheets, templates and lists")
@@ -279,6 +281,10 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     public static final String       AUTO_NAME_PREF_KEY                 = Preferences.getModuleKey(MODULE, AUTO_NAME_KEY);
     private static final boolean     DEFAULT_AUTO_NAME                  = true;
     private static final String      LENGTH_UNITS_KEY                   = "LengthUnits"; //$NON-NLS-1$
+    /** The optional Thrust Damage rules preference key. */
+    private static final String      OPTIONAL_THRUST_DAMAGE_KEY         = "UseOptionalThurstDamage"; //$NON-NLS-1$
+    public static final String       OPTIONAL_THRUST_DAMAGE_PREF_KEY    = Preferences.getModuleKey(MODULE, OPTIONAL_THRUST_DAMAGE_KEY);
+    private static final boolean     DEFAULT_OPTIONAL_THRUST_DAMAGE     = false;
     /** The default length units preference key. */
     public static final String       LENGTH_UNITS_PREF_KEY              = Preferences.getModuleKey(MODULE, LENGTH_UNITS_KEY);
     private static final LengthUnits DEFAULT_LENGTH_UNITS               = LengthUnits.FT_IN;
@@ -319,6 +325,7 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     private JCheckBox                mUseGurpsMetricRules;
     private JCheckBox                mAutoName;
     private JCheckBox                mShowUserDescAsToolTips;
+    private JCheckBox                mUseOptionalThrustDamage;
 
     /** Initializes the services controlled by these preferences. */
     public static void initialize() {
@@ -359,6 +366,11 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     /** @return Whether the optional strength rules (KYOS) are in use. */
     public static boolean areOptionalStrengthRulesUsed() {
         return Preferences.getInstance().getBooleanValue(MODULE, OPTIONAL_STRENGTH_RULES_KEY, DEFAULT_OPTIONAL_STRENGTH_RULES);
+    }
+
+    /** @return Whether the optional thrust damage (sw-2) rules are in use. */
+    public static boolean areOptionalThrustDamageUsed() {
+        return Preferences.getInstance().getBooleanValue(MODULE, OPTIONAL_THRUST_DAMAGE_KEY, DEFAULT_OPTIONAL_THRUST_DAMAGE);
     }
 
     /**
@@ -472,6 +484,9 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
 
         mUseOptionalReducedSwing = createCheckBox(OPTIONAL_REDUCED_SWING, null, areOptionalReducedSwingUsed());
         column.add(mUseOptionalReducedSwing);
+
+        mUseOptionalThrustDamage = createCheckBox(OPTIONAL_THRUST_DAMAGE, null, areOptionalThrustDamageUsed());
+        column.add(mUseOptionalThrustDamage);
 
         mIncludeUnspentPointsInTotal = createCheckBox(TOTAL_POINTS_INCLUDES_UNSPENT_POINTS, null, shouldIncludeUnspentPointsInTotalPointDisplay());
         column.add(mIncludeUnspentPointsInTotal);
@@ -595,6 +610,7 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
         mUseOptionalIQRules.setSelected(DEFAULT_OPTIONAL_IQ_RULES);
         mUseOptionalModifierRules.setSelected(DEFAULT_OPTIONAL_MODIFIER_RULES);
         mUseOptionalStrengthRules.setSelected(DEFAULT_OPTIONAL_STRENGTH_RULES);
+        mUseOptionalThrustDamage.setSelected(DEFAULT_OPTIONAL_THRUST_DAMAGE);
         mUseOptionalReducedSwing.setSelected(DEFAULT_OPTIONAL_REDUCED_SWING);
         mIncludeUnspentPointsInTotal.setSelected(DEFAULT_TOTAL_POINTS_DISPLAY);
         mUseGurpsMetricRules.setSelected(DEFAULT_GURPS_METRIC_RULES);
@@ -649,6 +665,8 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
             Preferences.getInstance().setValue(MODULE, OPTIONAL_MODIFIER_RULES_KEY, mUseOptionalModifierRules.isSelected());
         } else if (source == mUseOptionalStrengthRules) {
             Preferences.getInstance().setValue(MODULE, OPTIONAL_STRENGTH_RULES_KEY, mUseOptionalStrengthRules.isSelected());
+        } else if (source == mUseOptionalThrustDamage) {
+            Preferences.getInstance().setValue(MODULE, OPTIONAL_THRUST_DAMAGE_KEY, mUseOptionalThrustDamage.isSelected());
         } else if (source == mUseOptionalReducedSwing) {
             Preferences.getInstance().setValue(MODULE, OPTIONAL_REDUCED_SWING_KEY, mUseOptionalReducedSwing.isSelected());
         } else if (source == mIncludeUnspentPointsInTotal) {

--- a/src/com/trollworks/gcs/preferences/SheetPreferences.java
+++ b/src/com/trollworks/gcs/preferences/SheetPreferences.java
@@ -241,7 +241,12 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     private static String WHERE_OBTAIN;
     @Localize("Unable to open {0}")
     private static String UNABLE_TO_OPEN_URL;
-    @Localize("Show User Description as a Tooltip")
+    @Localize("Show Advantage User Description as a Tooltip")
+    @Localize(locale = "de", value = "Vorteilsbenutzerbeschreibung als QuickInfo anzeigen")
+    @Localize(locale = "ru",
+              value = "Показать описание пользователя Advantage в виде всплывающей подсказки")
+    @Localize(locale = "es",
+              value = "Mostrar la descripción del usuario de Advantage como información sobre herramientas")
     private static String SHOW_USER_DESC_AS_TOOL_TIP;
 
     static {
@@ -289,6 +294,7 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     /** The GURPS Metric preference key. */
     public static final String       GURPS_METRIC_RULES_PREF_KEY        = Preferences.getModuleKey(MODULE, GURPS_METRIC_RULES_KEY);
 
+    public static final String       SHOW_USER_DESC_AS_TOOL_TIP_KEY     = "ShowUserDescAsToolTip";
     private static final boolean     DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP = true;
 
     private static final boolean     DEFAULT_GURPS_METRIC_RULES         = true;
@@ -398,7 +404,7 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     }
 
     public static boolean showUserDescAsTooltip() {
-        return Preferences.getInstance().getBooleanValue(MODULE, SHOW_USER_DESC_AS_TOOL_TIP, DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP);
+        return Preferences.getInstance().getBooleanValue(MODULE, SHOW_USER_DESC_AS_TOOL_TIP_KEY, DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP);
     }
 
     /**
@@ -649,6 +655,8 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
             Preferences.getInstance().setValue(MODULE, TOTAL_POINTS_DISPLAY_KEY, mIncludeUnspentPointsInTotal.isSelected());
         } else if (source == mUseGurpsMetricRules) {
             Preferences.getInstance().setValue(MODULE, GURPS_METRIC_RULES_KEY, mUseGurpsMetricRules.isSelected());
+        } else if (source == mShowUserDescAsToolTips) {
+            Preferences.getInstance().setValue(MODULE, SHOW_USER_DESC_AS_TOOL_TIP_KEY, mShowUserDescAsToolTips.isSelected());
         } else if (source == mAutoName) {
             Preferences.getInstance().setValue(MODULE, AUTO_NAME_KEY, mAutoName.isSelected());
         }

--- a/src/com/trollworks/gcs/preferences/SheetPreferences.java
+++ b/src/com/trollworks/gcs/preferences/SheetPreferences.java
@@ -241,56 +241,61 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     private static String WHERE_OBTAIN;
     @Localize("Unable to open {0}")
     private static String UNABLE_TO_OPEN_URL;
+    @Localize("Show User Description as a Tooltip")
+    private static String SHOW_USER_DESC_AS_TOOL_TIP;
 
     static {
         Localization.initialize();
     }
 
-    static final String              MODULE                           = "Sheet"; //$NON-NLS-1$
-    private static final String      OPTIONAL_DICE_RULES_KEY          = "UseOptionDiceRules"; //$NON-NLS-1$
+    static final String              MODULE                             = "Sheet"; //$NON-NLS-1$
+    private static final String      OPTIONAL_DICE_RULES_KEY            = "UseOptionDiceRules"; //$NON-NLS-1$
     /** The optional dice rules preference key. */
-    public static final String       OPTIONAL_DICE_RULES_PREF_KEY     = Preferences.getModuleKey(MODULE, OPTIONAL_DICE_RULES_KEY);
-    private static final boolean     DEFAULT_OPTIONAL_DICE_RULES      = false;
-    private static final String      OPTIONAL_IQ_RULES_KEY            = "UseOptionIQRules"; //$NON-NLS-1$
+    public static final String       OPTIONAL_DICE_RULES_PREF_KEY       = Preferences.getModuleKey(MODULE, OPTIONAL_DICE_RULES_KEY);
+    private static final boolean     DEFAULT_OPTIONAL_DICE_RULES        = false;
+    private static final String      OPTIONAL_IQ_RULES_KEY              = "UseOptionIQRules"; //$NON-NLS-1$
     /** The optional IQ rules preference key. */
-    public static final String       OPTIONAL_IQ_RULES_PREF_KEY       = Preferences.getModuleKey(MODULE, OPTIONAL_IQ_RULES_KEY);
-    private static final boolean     DEFAULT_OPTIONAL_IQ_RULES        = false;
-    private static final String      OPTIONAL_MODIFIER_RULES_KEY      = "UseOptionModifierRules"; //$NON-NLS-1$
+    public static final String       OPTIONAL_IQ_RULES_PREF_KEY         = Preferences.getModuleKey(MODULE, OPTIONAL_IQ_RULES_KEY);
+    private static final boolean     DEFAULT_OPTIONAL_IQ_RULES          = false;
+    private static final String      OPTIONAL_MODIFIER_RULES_KEY        = "UseOptionModifierRules"; //$NON-NLS-1$
     /** The optional modifier rules preference key. */
-    public static final String       OPTIONAL_MODIFIER_RULES_PREF_KEY = Preferences.getModuleKey(MODULE, OPTIONAL_MODIFIER_RULES_KEY);
-    private static final boolean     DEFAULT_OPTIONAL_MODIFIER_RULES  = false;
-    private static final String      OPTIONAL_STRENGTH_RULES_KEY      = "UseOptionalStrengthRules"; //$NON-NLS-1$
+    public static final String       OPTIONAL_MODIFIER_RULES_PREF_KEY   = Preferences.getModuleKey(MODULE, OPTIONAL_MODIFIER_RULES_KEY);
+    private static final boolean     DEFAULT_OPTIONAL_MODIFIER_RULES    = false;
+    private static final String      OPTIONAL_STRENGTH_RULES_KEY        = "UseOptionalStrengthRules"; //$NON-NLS-1$
     /** The optional Strength rules preference key. */
-    public static final String       OPTIONAL_STRENGTH_RULES_PREF_KEY = Preferences.getModuleKey(MODULE, OPTIONAL_STRENGTH_RULES_KEY);
-    private static final boolean     DEFAULT_OPTIONAL_STRENGTH_RULES  = false;
-    private static final String      OPTIONAL_REDUCED_SWING_KEY       = "UseOptionalReducedSwing"; //$NON-NLS-1$
+    public static final String       OPTIONAL_STRENGTH_RULES_PREF_KEY   = Preferences.getModuleKey(MODULE, OPTIONAL_STRENGTH_RULES_KEY);
+    private static final boolean     DEFAULT_OPTIONAL_STRENGTH_RULES    = false;
+    private static final String      OPTIONAL_REDUCED_SWING_KEY         = "UseOptionalReducedSwing"; //$NON-NLS-1$
     /** The optional Reduced Swing rules preference key. */
-    public static final String       OPTIONAL_REDUCED_SWING_PREF_KEY  = Preferences.getModuleKey(MODULE, OPTIONAL_REDUCED_SWING_KEY);
-    private static final boolean     DEFAULT_OPTIONAL_REDUCED_SWING   = false;
-    private static final String      AUTO_NAME_KEY                    = "AutoNameNewCharacters"; //$NON-NLS-1$
+    public static final String       OPTIONAL_REDUCED_SWING_PREF_KEY    = Preferences.getModuleKey(MODULE, OPTIONAL_REDUCED_SWING_KEY);
+    private static final boolean     DEFAULT_OPTIONAL_REDUCED_SWING     = false;
+    private static final String      AUTO_NAME_KEY                      = "AutoNameNewCharacters"; //$NON-NLS-1$
     /** The auto-naming preference key. */
-    public static final String       AUTO_NAME_PREF_KEY               = Preferences.getModuleKey(MODULE, AUTO_NAME_KEY);
-    private static final boolean     DEFAULT_AUTO_NAME                = true;
-    private static final String      LENGTH_UNITS_KEY                 = "LengthUnits"; //$NON-NLS-1$
+    public static final String       AUTO_NAME_PREF_KEY                 = Preferences.getModuleKey(MODULE, AUTO_NAME_KEY);
+    private static final boolean     DEFAULT_AUTO_NAME                  = true;
+    private static final String      LENGTH_UNITS_KEY                   = "LengthUnits"; //$NON-NLS-1$
     /** The default length units preference key. */
-    public static final String       LENGTH_UNITS_PREF_KEY            = Preferences.getModuleKey(MODULE, LENGTH_UNITS_KEY);
-    private static final LengthUnits DEFAULT_LENGTH_UNITS             = LengthUnits.FT_IN;
-    private static final String      WEIGHT_UNITS_KEY                 = "WeightUnits"; //$NON-NLS-1$
+    public static final String       LENGTH_UNITS_PREF_KEY              = Preferences.getModuleKey(MODULE, LENGTH_UNITS_KEY);
+    private static final LengthUnits DEFAULT_LENGTH_UNITS               = LengthUnits.FT_IN;
+    private static final String      WEIGHT_UNITS_KEY                   = "WeightUnits"; //$NON-NLS-1$
     /** The default weight units preference key. */
-    public static final String       WEIGHT_UNITS_PREF_KEY            = Preferences.getModuleKey(MODULE, WEIGHT_UNITS_KEY);
-    private static final WeightUnits DEFAULT_WEIGHT_UNITS             = WeightUnits.LB;
-    private static final String      TOTAL_POINTS_DISPLAY_KEY         = "TotalPointsIncludesUnspentPoints"; //$NON-NLS-1$
+    public static final String       WEIGHT_UNITS_PREF_KEY              = Preferences.getModuleKey(MODULE, WEIGHT_UNITS_KEY);
+    private static final WeightUnits DEFAULT_WEIGHT_UNITS               = WeightUnits.LB;
+    private static final String      TOTAL_POINTS_DISPLAY_KEY           = "TotalPointsIncludesUnspentPoints"; //$NON-NLS-1$
     /** The total points includes unspent points preference key. */
-    public static final String       TOTAL_POINTS_DISPLAY_PREF_KEY    = Preferences.getModuleKey(MODULE, TOTAL_POINTS_DISPLAY_KEY);
-    private static final boolean     DEFAULT_TOTAL_POINTS_DISPLAY     = true;
-    private static final String      GURPS_METRIC_RULES_KEY           = "UseGurpsMetricRules"; //$NON-NLS-1$
+    public static final String       TOTAL_POINTS_DISPLAY_PREF_KEY      = Preferences.getModuleKey(MODULE, TOTAL_POINTS_DISPLAY_KEY);
+    private static final boolean     DEFAULT_TOTAL_POINTS_DISPLAY       = true;
+    private static final String      GURPS_METRIC_RULES_KEY             = "UseGurpsMetricRules"; //$NON-NLS-1$
     /** The GURPS Metric preference key. */
-    public static final String       GURPS_METRIC_RULES_PREF_KEY      = Preferences.getModuleKey(MODULE, GURPS_METRIC_RULES_KEY);
-    private static final boolean     DEFAULT_GURPS_METRIC_RULES       = true;
-    private static final Scales      DEFAULT_SCALE                    = Scales.ACTUAL_SIZE;
-    private static final String      SCALE_KEY                        = "UIScale"; //$NON-NLS-1$
-    private static final String      INITIAL_POINTS_KEY               = "InitialPoints"; //$NON-NLS-1$
-    private static final int         DEFAULT_INITIAL_POINTS           = 100;
+    public static final String       GURPS_METRIC_RULES_PREF_KEY        = Preferences.getModuleKey(MODULE, GURPS_METRIC_RULES_KEY);
+
+    private static final boolean     DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP = true;
+
+    private static final boolean     DEFAULT_GURPS_METRIC_RULES         = true;
+    private static final Scales      DEFAULT_SCALE                      = Scales.ACTUAL_SIZE;
+    private static final String      SCALE_KEY                          = "UIScale"; //$NON-NLS-1$
+    private static final String      INITIAL_POINTS_KEY                 = "InitialPoints"; //$NON-NLS-1$
+    private static final int         DEFAULT_INITIAL_POINTS             = 100;
     private JTextField               mPlayerName;
     private JTextField               mCampaign;
     private JTextField               mTechLevel;
@@ -307,6 +312,7 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     private JCheckBox                mIncludeUnspentPointsInTotal;
     private JCheckBox                mUseGurpsMetricRules;
     private JCheckBox                mAutoName;
+    private JCheckBox                mShowUserDescAsToolTips;
 
     /** Initializes the services controlled by these preferences. */
     public static void initialize() {
@@ -391,6 +397,10 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
         return Preferences.getInstance().getIntValue(MODULE, INITIAL_POINTS_KEY, DEFAULT_INITIAL_POINTS);
     }
 
+    public static boolean showUserDescAsTooltip() {
+        return Preferences.getInstance().getBooleanValue(MODULE, SHOW_USER_DESC_AS_TOOL_TIP, DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP);
+    }
+
     /**
      * Creates a new {@link SheetPreferences}.
      *
@@ -462,6 +472,9 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
 
         mUseGurpsMetricRules = createCheckBox(USE_METRIC_RULES, null, areGurpsMetricRulesUsed());
         column.add(mUseGurpsMetricRules);
+
+        mShowUserDescAsToolTips = createCheckBox(SHOW_USER_DESC_AS_TOOL_TIP, SHOW_USER_DESC_AS_TOOL_TIP, showUserDescAsTooltip());
+        column.add(mShowUserDescAsToolTips);
 
         row = new FlexRow();
         row.add(createLabel(USE, null));

--- a/src/com/trollworks/gcs/preferences/SheetPreferences.java
+++ b/src/com/trollworks/gcs/preferences/SheetPreferences.java
@@ -280,11 +280,11 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     /** The auto-naming preference key. */
     public static final String       AUTO_NAME_PREF_KEY                 = Preferences.getModuleKey(MODULE, AUTO_NAME_KEY);
     private static final boolean     DEFAULT_AUTO_NAME                  = true;
-    private static final String      LENGTH_UNITS_KEY                   = "LengthUnits"; //$NON-NLS-1$
     /** The optional Thrust Damage rules preference key. */
     private static final String      OPTIONAL_THRUST_DAMAGE_KEY         = "UseOptionalThurstDamage"; //$NON-NLS-1$
     public static final String       OPTIONAL_THRUST_DAMAGE_PREF_KEY    = Preferences.getModuleKey(MODULE, OPTIONAL_THRUST_DAMAGE_KEY);
     private static final boolean     DEFAULT_OPTIONAL_THRUST_DAMAGE     = false;
+    private static final String      LENGTH_UNITS_KEY                   = "LengthUnits"; //$NON-NLS-1$
     /** The default length units preference key. */
     public static final String       LENGTH_UNITS_PREF_KEY              = Preferences.getModuleKey(MODULE, LENGTH_UNITS_KEY);
     private static final LengthUnits DEFAULT_LENGTH_UNITS               = LengthUnits.FT_IN;

--- a/src/com/trollworks/gcs/preferences/SystemPreferences.java
+++ b/src/com/trollworks/gcs/preferences/SystemPreferences.java
@@ -67,6 +67,8 @@ public class SystemPreferences extends PreferencePanel implements DocumentListen
         mToolTipTimeout = createTextField(TOOLTIP_TIMEOUT, Integer.toString(getToolTipTimeout()));
         row.add(mToolTipTimeout);
         column.add(row);
+
+        column.apply(this);
     }
 
     private JTextField createTextField(String tooltip, String value) {

--- a/src/com/trollworks/gcs/widgets/outline/RowEditor.java
+++ b/src/com/trollworks/gcs/widgets/outline/RowEditor.java
@@ -42,32 +42,32 @@ public abstract class RowEditor<T extends ListRow> extends ActionPanel {
     @Localize(locale = "de", value = "Bearbeite {0}")
     @Localize(locale = "ru", value = "Изменить {0}")
     @Localize(locale = "es", value = "Editar {0}")
-    private static String WINDOW_TITLE;
+    protected static String WINDOW_TITLE;
     @Localize("Cancel Remaining")
     @Localize(locale = "de", value = "Alles Abbrechen")
     @Localize(locale = "ru", value = "Пропустить остальные")
     @Localize(locale = "es", value = "Cancelar lo restante")
-    private static String CANCEL_REST;
+    private static String   CANCEL_REST;
     @Localize("Cancel")
     @Localize(locale = "de", value = "Abbrechen")
     @Localize(locale = "ru", value = "Отмена")
     @Localize(locale = "es", value = "Cancelar")
-    private static String CANCEL;
+    protected static String CANCEL;
     @Localize("Apply")
     @Localize(locale = "de", value = "Anwenden")
     @Localize(locale = "ru", value = "Применить")
     @Localize(locale = "es", value = "Aplicar")
-    private static String APPLY;
+    protected static String APPLY;
     @Localize("1 item remaining to be edited.")
     @Localize(locale = "de", value = "1 weiteres Element zu bearbeiten.")
     @Localize(locale = "ru", value = "осталось отредактировать 1 элемент.")
     @Localize(locale = "es", value = "Queda un elemento pendiente de editar")
-    private static String ONE_REMAINING;
+    private static String   ONE_REMAINING;
     @Localize("{0} items remaining to be edited.")
     @Localize(locale = "de", value = "{0} weitere Elemente zu bearbeiten.")
     @Localize(locale = "ru", value = "{0} элементов осталось отредактировать.")
     @Localize(locale = "es", value = "Quedan {0} elementos pendientes de editar")
-    private static String REMAINING;
+    private static String   REMAINING;
 
     static {
         Localization.initialize();


### PR DESCRIPTION
Ok, I really need your guidance on this one.   I added a "user description" to Advantage (as discussed in https://github.com/richardwilkes/gcs/issues/120).  

I wanted to use the Notes editor (and therefore a Note), but I wasn't too keen on adding a Note object to every Advantage.  And besides, Notes seem to need to be in an outline (collection) of Notes, so I was going to have to do some hacking to add a single Note.

However, to maintain the same "look", I wanted to reuse as much of the NoteEditor as I could.  Alas, I could not.   I made a temporary Note to try to fool the editor, but it is all closely tied to having a datafile and an owner (outline),   As some point (after faking out as much as I could), it just became too much, so I just copied the GUI code into the openUserDescDialog() method.

Yes, the OO programmer inside my head was screaming at me... but I just wanted to get it done.  It bothered me so much (as I was typing up this PR), that I refactored as much as I could into a static method.

I didn't create localized versions of the button label "User Desc.", since I wasn't certain how to handle the abbreviation.   Of course, the dialog title has been localized.

Where should I go from here?   This code works (now, after the second commit, I had to fix the "dirty" flag for the user description), and externally, looks good.

Once you are ok with this (however long that takes), I would like to add it to the tooltip code and add a property to turn it on/off, and add it to the text output code, so I can export this information to Fantasy Grounds.