### PR TITLE
Added Thr=SW-2 damage option

### DIFF
--- a/src/com/trollworks/gcs/character/CharacterSheet.java
+++ b/src/com/trollworks/gcs/character/CharacterSheet.java
@@ -242,7 +242,7 @@ public class CharacterSheet extends JPanel implements ChangeListener, Scrollable
         if (!GraphicsUtilities.inHeadlessPrintMode()) {
             setDropTarget(new DropTarget(this, this));
         }
-        Preferences.getInstance().getNotifier().add(this, SheetPreferences.OPTIONAL_DICE_RULES_PREF_KEY, Fonts.FONT_NOTIFICATION_KEY, SheetPreferences.WEIGHT_UNITS_PREF_KEY, SheetPreferences.GURPS_METRIC_RULES_PREF_KEY, SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY, SheetPreferences.OPTIONAL_REDUCED_SWING_PREF_KEY, OutputPreferences.BLOCK_LAYOUT_PREF_KEY);
+        Preferences.getInstance().getNotifier().add(this, SheetPreferences.OPTIONAL_DICE_RULES_PREF_KEY, Fonts.FONT_NOTIFICATION_KEY, SheetPreferences.WEIGHT_UNITS_PREF_KEY, SheetPreferences.GURPS_METRIC_RULES_PREF_KEY, SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY, SheetPreferences.OPTIONAL_REDUCED_SWING_PREF_KEY, OutputPreferences.BLOCK_LAYOUT_PREF_KEY, SheetPreferences.OPTIONAL_THRUST_DAMAGE_PREF_KEY);
     }
 
     /** Call when the sheet is no longer in use. */
@@ -844,7 +844,7 @@ public class CharacterSheet extends JPanel implements ChangeListener, Scrollable
 
     @Override
     public void handleNotification(Object producer, String type, Object data) {
-        if (SheetPreferences.OPTIONAL_DICE_RULES_PREF_KEY.equals(type) || Fonts.FONT_NOTIFICATION_KEY.equals(type) || SheetPreferences.WEIGHT_UNITS_PREF_KEY.equals(type) || SheetPreferences.GURPS_METRIC_RULES_PREF_KEY.equals(type) || Profile.ID_BODY_TYPE.equals(type) || SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY.equals(type) || SheetPreferences.OPTIONAL_REDUCED_SWING_PREF_KEY.equals(type) || OutputPreferences.BLOCK_LAYOUT_PREF_KEY.equals(type)) {
+        if (SheetPreferences.OPTIONAL_DICE_RULES_PREF_KEY.equals(type) || Fonts.FONT_NOTIFICATION_KEY.equals(type) || SheetPreferences.WEIGHT_UNITS_PREF_KEY.equals(type) || SheetPreferences.GURPS_METRIC_RULES_PREF_KEY.equals(type) || Profile.ID_BODY_TYPE.equals(type) || SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY.equals(type) || SheetPreferences.OPTIONAL_REDUCED_SWING_PREF_KEY.equals(type) || OutputPreferences.BLOCK_LAYOUT_PREF_KEY.equals(type) || SheetPreferences.OPTIONAL_THRUST_DAMAGE_PREF_KEY.equals(type)) {
             markForRebuild();
         } else {
             if (type.startsWith(Advantage.PREFIX)) {

--- a/src/com/trollworks/gcs/character/GURPSCharacter.java
+++ b/src/com/trollworks/gcs/character/GURPSCharacter.java
@@ -1132,6 +1132,11 @@ public class GURPSCharacter extends DataFile {
      * @return The basic thrusting damage.
      */
     public static Dice getThrust(int strength) {
+        if (SheetPreferences.areOptionalThrustDamageUsed()) {
+            Dice dice = getSwing(strength);
+            dice.add(-2);
+            return dice;
+        }
         if (SheetPreferences.areOptionalReducedSwingUsed()) {
             if (strength < 19) {
                 return new Dice(1, -(6 - (strength - 1) / 2));

--- a/src/com/trollworks/gcs/character/PrerequisitesThread.java
+++ b/src/com/trollworks/gcs/character/PrerequisitesThread.java
@@ -96,7 +96,7 @@ public class PrerequisitesThread extends Thread implements NotifierTarget {
         mCharacter  = sheet.getCharacter();
         mNeedUpdate = true;
         mCharacter.addTarget(this, Profile.ID_TECH_LEVEL, GURPSCharacter.ID_STRENGTH, GURPSCharacter.ID_DEXTERITY, GURPSCharacter.ID_INTELLIGENCE, GURPSCharacter.ID_HEALTH, GURPSCharacter.ID_WILL, GURPSCharacter.ID_PERCEPTION, Spell.ID_NAME, Spell.ID_COLLEGE, Spell.ID_POINTS, Spell.ID_LIST_CHANGED, Skill.ID_NAME, Skill.ID_SPECIALIZATION, Skill.ID_LEVEL, Skill.ID_RELATIVE_LEVEL, Skill.ID_ENCUMBRANCE_PENALTY, Skill.ID_POINTS, Skill.ID_TECH_LEVEL, Skill.ID_LIST_CHANGED, Advantage.ID_NAME, Advantage.ID_LEVELS, Advantage.ID_LIST_CHANGED, Equipment.ID_EXTENDED_WEIGHT, Equipment.ID_STATE, Equipment.ID_QUANTITY, Equipment.ID_LIST_CHANGED);
-        Preferences.getInstance().getNotifier().add(this, SheetPreferences.OPTIONAL_IQ_RULES_PREF_KEY, SheetPreferences.OPTIONAL_MODIFIER_RULES_PREF_KEY, SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY);
+        Preferences.getInstance().getNotifier().add(this, SheetPreferences.OPTIONAL_IQ_RULES_PREF_KEY, SheetPreferences.OPTIONAL_MODIFIER_RULES_PREF_KEY, SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY, SheetPreferences.OPTIONAL_THRUST_DAMAGE_PREF_KEY);
         synchronized (MAP) {
             MAP.put(mCharacter, this);
         }
@@ -258,6 +258,8 @@ public class PrerequisitesThread extends Thread implements NotifierTarget {
         } else if (SheetPreferences.OPTIONAL_MODIFIER_RULES_PREF_KEY.equals(type)) {
             mCharacter.notifySingle(Advantage.ID_LIST_CHANGED, null);
         } else if (SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY.equals(type)) {
+            mCharacter.notifySingle(type, data);
+        } else if (SheetPreferences.OPTIONAL_THRUST_DAMAGE_PREF_KEY.equals(type)) {
             mCharacter.notifySingle(type, data);
         }
         markForUpdate();

--- a/src/com/trollworks/gcs/preferences/SheetPreferences.java
+++ b/src/com/trollworks/gcs/preferences/SheetPreferences.java
@@ -140,6 +140,8 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     private static String OPTIONAL_DICE_RULES;
     @Localize("Use optional strength rules from the \"Knowing Your Own Strength\" Pyramid article")
     private static String OPTIONAL_STRENGTH_RULES;
+    @Localize("Use optional Thrust damage (Thrust = Swing -2)")
+    private static String OPTIONAL_THRUST_DAMAGE;
     @Localize("Use optional Reduced Swing rules from the  \"Adjusting Swing Damage in Dungeon Fantasy\" No School Grognard article")
     private static String OPTIONAL_REDUCED_SWING;
     @Localize("for the initial scale when opening character sheets, templates and lists")
@@ -271,6 +273,10 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     /** The auto-naming preference key. */
     public static final String       AUTO_NAME_PREF_KEY               = Preferences.getModuleKey(MODULE, AUTO_NAME_KEY);
     private static final boolean     DEFAULT_AUTO_NAME                = true;
+    /** The optional Thrust Damage rules preference key. */
+    private static final String      OPTIONAL_THRUST_DAMAGE_KEY       = "UseOptionalThurstDamage"; //$NON-NLS-1$
+    public static final String       OPTIONAL_THRUST_DAMAGE_PREF_KEY  = Preferences.getModuleKey(MODULE, OPTIONAL_THRUST_DAMAGE_KEY);
+    private static final boolean     DEFAULT_OPTIONAL_THRUST_DAMAGE   = false;
     private static final String      LENGTH_UNITS_KEY                 = "LengthUnits"; //$NON-NLS-1$
     /** The default length units preference key. */
     public static final String       LENGTH_UNITS_PREF_KEY            = Preferences.getModuleKey(MODULE, LENGTH_UNITS_KEY);
@@ -307,6 +313,7 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     private JCheckBox                mIncludeUnspentPointsInTotal;
     private JCheckBox                mUseGurpsMetricRules;
     private JCheckBox                mAutoName;
+    private JCheckBox                mUseOptionalThrustDamage;
 
     /** Initializes the services controlled by these preferences. */
     public static void initialize() {
@@ -347,6 +354,11 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     /** @return Whether the optional strength rules (KYOS) are in use. */
     public static boolean areOptionalStrengthRulesUsed() {
         return Preferences.getInstance().getBooleanValue(MODULE, OPTIONAL_STRENGTH_RULES_KEY, DEFAULT_OPTIONAL_STRENGTH_RULES);
+    }
+
+    /** @return Whether the optional thrust damage (sw-2) rules are in use. */
+    public static boolean areOptionalThrustDamageUsed() {
+        return Preferences.getInstance().getBooleanValue(MODULE, OPTIONAL_THRUST_DAMAGE_KEY, DEFAULT_OPTIONAL_THRUST_DAMAGE);
     }
 
     /**
@@ -456,6 +468,9 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
 
         mUseOptionalReducedSwing = createCheckBox(OPTIONAL_REDUCED_SWING, null, areOptionalReducedSwingUsed());
         column.add(mUseOptionalReducedSwing);
+
+        mUseOptionalThrustDamage = createCheckBox(OPTIONAL_THRUST_DAMAGE, null, areOptionalThrustDamageUsed());
+        column.add(mUseOptionalThrustDamage);
 
         mIncludeUnspentPointsInTotal = createCheckBox(TOTAL_POINTS_INCLUDES_UNSPENT_POINTS, null, shouldIncludeUnspentPointsInTotalPointDisplay());
         column.add(mIncludeUnspentPointsInTotal);
@@ -576,6 +591,7 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
         mUseOptionalIQRules.setSelected(DEFAULT_OPTIONAL_IQ_RULES);
         mUseOptionalModifierRules.setSelected(DEFAULT_OPTIONAL_MODIFIER_RULES);
         mUseOptionalStrengthRules.setSelected(DEFAULT_OPTIONAL_STRENGTH_RULES);
+        mUseOptionalThrustDamage.setSelected(DEFAULT_OPTIONAL_THRUST_DAMAGE);
         mUseOptionalReducedSwing.setSelected(DEFAULT_OPTIONAL_REDUCED_SWING);
         mIncludeUnspentPointsInTotal.setSelected(DEFAULT_TOTAL_POINTS_DISPLAY);
         mUseGurpsMetricRules.setSelected(DEFAULT_GURPS_METRIC_RULES);
@@ -630,6 +646,8 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
             Preferences.getInstance().setValue(MODULE, OPTIONAL_MODIFIER_RULES_KEY, mUseOptionalModifierRules.isSelected());
         } else if (source == mUseOptionalStrengthRules) {
             Preferences.getInstance().setValue(MODULE, OPTIONAL_STRENGTH_RULES_KEY, mUseOptionalStrengthRules.isSelected());
+        } else if (source == mUseOptionalThrustDamage) {
+            Preferences.getInstance().setValue(MODULE, OPTIONAL_THRUST_DAMAGE_KEY, mUseOptionalThrustDamage.isSelected());
         } else if (source == mUseOptionalReducedSwing) {
             Preferences.getInstance().setValue(MODULE, OPTIONAL_REDUCED_SWING_KEY, mUseOptionalReducedSwing.isSelected());
         } else if (source == mIncludeUnspentPointsInTotal) {


### PR DESCRIPTION
I believe this solves https://github.com/richardwilkes/gcs/issues/97.  Since they were requesting "no modification to Basic Lifting and trait costs", it seemed simple enough.

It adds a preference option "Use optional Thrust damage (Thrust = Swing - 2)", and then just redirects the getThrust() method to the getSwing() method, minus 2.

I tested the notifications (although, I must admit, I was blindly copying code), but it seems to work correctly.   If you change the option, you will see the Thr damage change, and you will see all of the weapon damages change (based on thrust).