### PR TITLE
Added Display Preferences for Advantage User Descriptions, Notes and …

### DIFF
--- a/src/com/trollworks/gcs/advantage/Advantage.java
+++ b/src/com/trollworks/gcs/advantage/Advantage.java
@@ -17,6 +17,7 @@ import com.trollworks.gcs.common.DataFile;
 import com.trollworks.gcs.common.HasSourceReference;
 import com.trollworks.gcs.common.LoadState;
 import com.trollworks.gcs.modifier.Modifier;
+import com.trollworks.gcs.preferences.DisplayPreferences;
 import com.trollworks.gcs.preferences.SheetPreferences;
 import com.trollworks.gcs.skill.SkillDefault;
 import com.trollworks.gcs.weapon.MeleeWeaponStats;
@@ -1100,6 +1101,24 @@ public class Advantage extends ListRow implements HasSourceReference, Switchable
     @Override
     protected String getCategoryID() {
         return ID_CATEGORY;
+    }
+
+    /** @return The "secondary" text, the text display below an Advantage. */
+    @Override
+    protected String getSecondaryText() {
+        StringBuilder builder = new StringBuilder();
+        if (DisplayPreferences.showUserDescInDisplay()) {
+            String desc = getUserDesc();
+            builder.append(desc);
+            if (desc.length() > 0) {
+                builder.append('\n');
+            }
+        }
+        builder.append(super.getSecondaryText());
+        if (builder.length() > 0) {
+            builder.setLength(builder.length() - 1);   // Remove the last '\n'
+        }
+        return builder.toString();
     }
 
     @Override

--- a/src/com/trollworks/gcs/advantage/AdvantageColumn.java
+++ b/src/com/trollworks/gcs/advantage/AdvantageColumn.java
@@ -51,7 +51,32 @@ public enum AdvantageColumn {
 
         @Override
         public String getToolTip(Advantage advantage) {
-            return getDataAsText(advantage);
+            StringBuilder builder = new StringBuilder();
+            if (DisplayPreferences.showUserDescAsTooltip()) {
+                String desc = advantage.getUserDesc();
+                builder.append(desc);
+                if (desc.length() > 0) {
+                    builder.append('\n');
+                }
+            }
+            if (DisplayPreferences.showModifiersAsTooltip()) {
+                String desc = advantage.getModifierNotes();
+                builder.append(desc);
+                if (desc.length() > 0) {
+                    builder.append('\n');
+                }
+            }
+            if (DisplayPreferences.showNotesAsTooltip()) {
+                String desc = advantage.getNotes();
+                builder.append(desc);
+                if (desc.length() > 0) {
+                    builder.append('\n');
+                }
+            }
+            if (builder.length() > 0) {
+                builder.setLength(builder.length() - 1);   // Remove the last '\n'
+            }
+            return builder.length() == 0 ? null : builder.toString();
         }
 
         @Override
@@ -72,31 +97,29 @@ public enum AdvantageColumn {
         @Override
         public String getDataAsText(Advantage advantage) {
             StringBuilder builder = new StringBuilder();
-            if (DisplayPreferences.showUserDescAsTooltip()) {
+            builder.append(advantage);
+            if (DisplayPreferences.showUserDescInDisplay()) {
                 String desc = advantage.getUserDesc();
-                builder.append(desc);
                 if (desc.length() > 0) {
-                    builder.append('\n');
+                    builder.append(" - ");
                 }
-            }
-            if (DisplayPreferences.showNotesAsTooltip()) {
-                String desc = advantage.getNotes();
                 builder.append(desc);
-                if (desc.length() > 0) {
-                    builder.append('\n');
-                }
             }
-            if (DisplayPreferences.showModifiersAsTooltip()) {
+            if (DisplayPreferences.showModifiersInDisplay()) {
                 String desc = advantage.getModifierNotes();
-                builder.append(desc);
                 if (desc.length() > 0) {
-                    builder.append('\n');
+                    builder.append(" - ");
                 }
+                builder.append(desc);
             }
-            if (builder.length() > 0) {
-                builder.setLength(builder.length() - 1);   // Remove the last '\n'
+            if (DisplayPreferences.showNotesInDisplay()) {
+                String desc = advantage.getNotes();
+                if (desc.length() > 0) {
+                    builder.append(" - ");
+                }
+                builder.append(desc);
             }
-            return builder.length() > 0 ? builder.toString() : null;
+            return builder.toString();
         }
     },
     /** The points spent in the advantage. */

--- a/src/com/trollworks/gcs/advantage/AdvantageColumn.java
+++ b/src/com/trollworks/gcs/advantage/AdvantageColumn.java
@@ -51,7 +51,7 @@ public enum AdvantageColumn {
 
         @Override
         public String getToolTip(Advantage advantage) {
-            return DisplayPreferences.showUserDescAsTooltip() ? advantage.getUserDesc() : null;
+            return getDataAsText(advantage);
         }
 
         @Override
@@ -72,19 +72,31 @@ public enum AdvantageColumn {
         @Override
         public String getDataAsText(Advantage advantage) {
             StringBuilder builder = new StringBuilder();
-            String        notes   = advantage.getModifierNotes();
-
-            builder.append(advantage.toString());
-            if (notes.length() > 0) {
-                builder.append(" - ");
-                builder.append(notes);
+            if (DisplayPreferences.showUserDescAsTooltip()) {
+                String desc = advantage.getUserDesc();
+                builder.append(desc);
+                if (desc.length() > 0) {
+                    builder.append('\n');
+                }
             }
-            notes = advantage.getNotes();
-            if (notes.length() > 0) {
-                builder.append(" - ");
-                builder.append(notes);
+            if (DisplayPreferences.showNotesAsTooltip()) {
+                String desc = advantage.getNotes();
+                builder.append(desc);
+                if (desc.length() > 0) {
+                    builder.append('\n');
+                }
             }
-            return builder.toString();
+            if (DisplayPreferences.showModifiersAsTooltip()) {
+                String desc = advantage.getModifierNotes();
+                builder.append(desc);
+                if (desc.length() > 0) {
+                    builder.append('\n');
+                }
+            }
+            if (builder.length() > 0) {
+                builder.setLength(builder.length() - 1);   // Remove the last '\n'
+            }
+            return builder.length() > 0 ? builder.toString() : null;
         }
     },
     /** The points spent in the advantage. */

--- a/src/com/trollworks/gcs/character/CharacterSheet.java
+++ b/src/com/trollworks/gcs/character/CharacterSheet.java
@@ -170,7 +170,7 @@ public class CharacterSheet extends JPanel implements ChangeListener, Scrollable
         if (!GraphicsUtilities.inHeadlessPrintMode()) {
             setDropTarget(new DropTarget(this, this));
         }
-        Preferences.getInstance().getNotifier().add(this, SheetPreferences.OPTIONAL_DICE_RULES_PREF_KEY, Fonts.FONT_NOTIFICATION_KEY, DisplayPreferences.WEIGHT_UNITS_PREF_KEY, SheetPreferences.GURPS_METRIC_RULES_PREF_KEY, SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY, SheetPreferences.OPTIONAL_REDUCED_SWING_PREF_KEY, DisplayPreferences.BLOCK_LAYOUT_PREF_KEY, SheetPreferences.OPTIONAL_THRUST_DAMAGE_PREF_KEY);
+        Preferences.getInstance().getNotifier().add(this, SheetPreferences.OPTIONAL_DICE_RULES_PREF_KEY, Fonts.FONT_NOTIFICATION_KEY, DisplayPreferences.WEIGHT_UNITS_PREF_KEY, SheetPreferences.GURPS_METRIC_RULES_PREF_KEY, SheetPreferences.OPTIONAL_STRENGTH_RULES_PREF_KEY, SheetPreferences.OPTIONAL_REDUCED_SWING_PREF_KEY, DisplayPreferences.BLOCK_LAYOUT_PREF_KEY, SheetPreferences.OPTIONAL_THRUST_DAMAGE_PREF_KEY, DisplayPreferences.SHOW_USER_DESC_IN_DISPLAY_PREF_KEY, DisplayPreferences.SHOW_MODIFIERS_IN_DISPLAY_PREF_KEY, DisplayPreferences.SHOW_NOTES_IN_DISPLAY_PREF_KEY);
     }
 
     /** Call when the sheet is no longer in use. */
@@ -787,6 +787,8 @@ public class CharacterSheet extends JPanel implements ChangeListener, Scrollable
             markForRebuild();
         } else {
             if (type.startsWith(Advantage.PREFIX)) {
+                OutlineSyncer.add(mAdvantageOutline);
+            } else if (DisplayPreferences.SHOW_USER_DESC_IN_DISPLAY_PREF_KEY.equals(type) || DisplayPreferences.SHOW_MODIFIERS_IN_DISPLAY_PREF_KEY.equals(type) || DisplayPreferences.SHOW_NOTES_IN_DISPLAY_PREF_KEY.equals(type)) {
                 OutlineSyncer.add(mAdvantageOutline);
             } else if (type.startsWith(Skill.PREFIX)) {
                 OutlineSyncer.add(mSkillOutline);

--- a/src/com/trollworks/gcs/preferences/DisplayPreferences.java
+++ b/src/com/trollworks/gcs/preferences/DisplayPreferences.java
@@ -365,6 +365,12 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         mWeightUnitsCombo.setSelectedIndex(DEFAULT_WEIGHT_UNITS.ordinal());
         mToolTipTimeout.setText(Integer.toString(DEFAULT_TOOLTIP_TIMEOUT));
         mBlockLayoutField.setText(DEFAULT_BLOCK_LAYOUT);
+        mShowUserDescAsToolTips.setSelected(DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP);
+        mShowUserDescInDisplay.setSelected(DEFAULT_SHOW_USER_DESC_IN_DISPLAY);
+        mShowModifiersAsToolTips.setSelected(DEFAULT_SHOW_MODIFIERS_AS_TOOL_TIP);
+        mShowModifiersInDisplay.setSelected(DEFAULT_SHOW_MODIFIERS_IN_DISPLAY);
+        mShowNotesAsToolTips.setSelected(DEFAULT_SHOW_NOTES_AS_TOOL_TIP);
+        mShowNotesInDisplay.setSelected(DEFAULT_SHOW_NOTES_IN_DISPLAY);
     }
 
     @Override

--- a/src/com/trollworks/gcs/preferences/DisplayPreferences.java
+++ b/src/com/trollworks/gcs/preferences/DisplayPreferences.java
@@ -76,14 +76,17 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
     public static final String       SHOW_USER_DESC_AS_TOOL_TIP_KEY     = "ShowUserDescAsToolTip";
     private static final boolean     DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP = true;
     public static final String       SHOW_USER_DESC_IN_DISPLAY_KEY      = "ShowUserDescInDisplay";
+    public static final String       SHOW_USER_DESC_IN_DISPLAY_PREF_KEY = Preferences.getModuleKey(MODULE, SHOW_USER_DESC_IN_DISPLAY_KEY);
     private static final boolean     DEFAULT_SHOW_USER_DESC_IN_DISPLAY  = false;
     public static final String       SHOW_MODIFIERS_AS_TOOL_TIP_KEY     = "ShowModifiersAsToolTip";
     private static final boolean     DEFAULT_SHOW_MODIFIERS_AS_TOOL_TIP = false;
     public static final String       SHOW_MODIFIERS_IN_DISPLAY_KEY      = "ShowModifiersInDisplay";
+    public static final String       SHOW_MODIFIERS_IN_DISPLAY_PREF_KEY = Preferences.getModuleKey(MODULE, SHOW_MODIFIERS_IN_DISPLAY_KEY);
     private static final boolean     DEFAULT_SHOW_MODIFIERS_IN_DISPLAY  = true;
     public static final String       SHOW_NOTES_AS_TOOL_TIP_KEY         = "ShowNotesAsToolTip";
     private static final boolean     DEFAULT_SHOW_NOTES_AS_TOOL_TIP     = false;
     public static final String       SHOW_NOTES_IN_DISPLAY_KEY          = "ShowNotesInDisplay";
+    public static final String       SHOW_NOTES_IN_DISPLAY_PREF_KEY     = Preferences.getModuleKey(MODULE, SHOW_NOTES_IN_DISPLAY_KEY);
     private static final boolean     DEFAULT_SHOW_NOTES_IN_DISPLAY      = true;
     private JCheckBox                mIncludeUnspentPointsInTotal;
     private JComboBox<Scales>        mUIScaleCombo;

--- a/src/com/trollworks/gcs/preferences/DisplayPreferences.java
+++ b/src/com/trollworks/gcs/preferences/DisplayPreferences.java
@@ -224,28 +224,6 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         mIncludeUnspentPointsInTotal = createCheckBox(I18n.Text("Character point total display includes unspent points"), null, shouldIncludeUnspentPointsInTotalPointDisplay());
         column.add(mIncludeUnspentPointsInTotal);
 
-        FlexGrid grid = new FlexGrid();
-        column.add(grid);
-        int i = 0;
-        mShowUserDescAsToolTips  = createCheckBox(I18n.Text("as a tooltip"), null, showUserDescAsTooltip());
-        mShowUserDescInDisplay   = createCheckBox(I18n.Text("in the main display"), null, showUserDescInDisplay());
-        mShowModifiersAsToolTips = createCheckBox(I18n.Text("as a tooltip"), null, showModifiersAsTooltip());
-        mShowModifiersInDisplay  = createCheckBox(I18n.Text("in the main display"), null, showModifiersInDisplay());
-        mShowNotesAsToolTips     = createCheckBox(I18n.Text("as a tooltip"), null, showNotesAsTooltip());
-        mShowNotesInDisplay      = createCheckBox(I18n.Text("in the main display"), null, showNotesInDisplay());
-        i++;
-        grid.add(new FlexComponent(createLabel(I18n.Text("Show Advantage User Descriptions:"), null), Alignment.RIGHT_BOTTOM, Alignment.CENTER), i, 1);
-        grid.add(mShowUserDescInDisplay, i, 2);
-        grid.add(mShowUserDescAsToolTips, i, 3);
-        i++;
-        grid.add(new FlexComponent(createLabel(I18n.Text("Notes:"), null), Alignment.RIGHT_BOTTOM, Alignment.CENTER), i, 1);
-        grid.add(mShowNotesInDisplay, i, 2);
-        grid.add(mShowNotesAsToolTips, i, 3);
-        i++;
-        grid.add(new FlexComponent(createLabel(I18n.Text("Modifiers:"), null), Alignment.RIGHT_BOTTOM, Alignment.CENTER), i, 1);
-        grid.add(mShowModifiersInDisplay, i, 2);
-        grid.add(mShowModifiersAsToolTips, i, 3);
-
         FlexRow row = new FlexRow();
         row.add(createLabel(I18n.Text("Use"), null));
         mUIScaleCombo = createUIScalePopup();
@@ -273,6 +251,28 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         row.add(mToolTipTimeout);
         row.add(createLabel(I18n.Text("seconds"), null));
         column.add(row);
+
+        FlexGrid grid = new FlexGrid();
+        column.add(grid);
+        int i = 0;
+        mShowUserDescAsToolTips  = createCheckBox(I18n.Text("as a tooltip"), null, showUserDescAsTooltip());
+        mShowUserDescInDisplay   = createCheckBox(I18n.Text("in the main display"), null, showUserDescInDisplay());
+        mShowModifiersAsToolTips = createCheckBox(I18n.Text("as a tooltip"), null, showModifiersAsTooltip());
+        mShowModifiersInDisplay  = createCheckBox(I18n.Text("in the main display"), null, showModifiersInDisplay());
+        mShowNotesAsToolTips     = createCheckBox(I18n.Text("as a tooltip"), null, showNotesAsTooltip());
+        mShowNotesInDisplay      = createCheckBox(I18n.Text("in the main display"), null, showNotesInDisplay());
+        i++;
+        grid.add(new FlexComponent(createLabel(I18n.Text("Show Advantage User Descriptions:"), null), Alignment.RIGHT_BOTTOM, Alignment.CENTER), i, 1);
+        grid.add(mShowUserDescInDisplay, i, 2);
+        grid.add(mShowUserDescAsToolTips, i, 3);
+        i++;
+        grid.add(new FlexComponent(createLabel(I18n.Text("Notes:"), null), Alignment.RIGHT_BOTTOM, Alignment.CENTER), i, 1);
+        grid.add(mShowNotesInDisplay, i, 2);
+        grid.add(mShowNotesAsToolTips, i, 3);
+        i++;
+        grid.add(new FlexComponent(createLabel(I18n.Text("Modifiers:"), null), Alignment.RIGHT_BOTTOM, Alignment.CENTER), i, 1);
+        grid.add(mShowModifiersInDisplay, i, 2);
+        grid.add(mShowModifiersAsToolTips, i, 3);
 
         row = new FlexRow();
         String blockLayoutTooltip = I18n.Text("Specifies the layout of the various blocks of data on the character sheet");

--- a/src/com/trollworks/gcs/preferences/DisplayPreferences.java
+++ b/src/com/trollworks/gcs/preferences/DisplayPreferences.java
@@ -14,7 +14,9 @@ package com.trollworks.gcs.preferences;
 import com.trollworks.toolkit.ui.TextDrawing;
 import com.trollworks.toolkit.ui.UIUtilities;
 import com.trollworks.toolkit.ui.border.LineBorder;
+import com.trollworks.toolkit.ui.layout.Alignment;
 import com.trollworks.toolkit.ui.layout.FlexColumn;
+import com.trollworks.toolkit.ui.layout.FlexComponent;
 import com.trollworks.toolkit.ui.layout.FlexGrid;
 import com.trollworks.toolkit.ui.layout.FlexRow;
 import com.trollworks.toolkit.ui.preferences.PreferencePanel;
@@ -73,6 +75,16 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
     private static final int         DEFAULT_TOOLTIP_TIMEOUT            = 60;
     public static final String       SHOW_USER_DESC_AS_TOOL_TIP_KEY     = "ShowUserDescAsToolTip";
     private static final boolean     DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP = true;
+    public static final String       SHOW_USER_DESC_IN_DISPLAY_KEY      = "ShowUserDescInDisplay";
+    private static final boolean     DEFAULT_SHOW_USER_DESC_IN_DISPLAY  = false;
+    public static final String       SHOW_MODIFIERS_AS_TOOL_TIP_KEY     = "ShowModifiersAsToolTip";
+    private static final boolean     DEFAULT_SHOW_MODIFIERS_AS_TOOL_TIP = false;
+    public static final String       SHOW_MODIFIERS_IN_DISPLAY_KEY      = "ShowModifiersInDisplay";
+    private static final boolean     DEFAULT_SHOW_MODIFIERS_IN_DISPLAY  = true;
+    public static final String       SHOW_NOTES_AS_TOOL_TIP_KEY         = "ShowNotesAsToolTip";
+    private static final boolean     DEFAULT_SHOW_NOTES_AS_TOOL_TIP     = false;
+    public static final String       SHOW_NOTES_IN_DISPLAY_KEY          = "ShowNotesInDisplay";
+    private static final boolean     DEFAULT_SHOW_NOTES_IN_DISPLAY      = true;
     private JCheckBox                mIncludeUnspentPointsInTotal;
     private JComboBox<Scales>        mUIScaleCombo;
     private JComboBox<String>        mLengthUnitsCombo;
@@ -80,6 +92,11 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
     private JTextField               mToolTipTimeout;
     private JTextArea                mBlockLayoutField;
     private JCheckBox                mShowUserDescAsToolTips;
+    private JCheckBox                mShowUserDescInDisplay;
+    private JCheckBox                mShowModifiersAsToolTips;
+    private JCheckBox                mShowModifiersInDisplay;
+    private JCheckBox                mShowNotesAsToolTips;
+    private JCheckBox                mShowNotesInDisplay;
 
     /** Initializes the services controlled by these preferences. */
     public static void initialize() {
@@ -136,6 +153,31 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         return Preferences.getInstance().getBooleanValue(MODULE, SHOW_USER_DESC_AS_TOOL_TIP_KEY, DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP);
     }
 
+    /** @return Whether to show the user description in the main display. */
+    public static boolean showUserDescInDisplay() {
+        return Preferences.getInstance().getBooleanValue(MODULE, SHOW_USER_DESC_IN_DISPLAY_KEY, DEFAULT_SHOW_USER_DESC_IN_DISPLAY);
+    }
+
+    /** @return Whether to show the modifiers list as a tooltip. */
+    public static boolean showModifiersAsTooltip() {
+        return Preferences.getInstance().getBooleanValue(MODULE, SHOW_MODIFIERS_AS_TOOL_TIP_KEY, DEFAULT_SHOW_MODIFIERS_AS_TOOL_TIP);
+    }
+
+    /** @return Whether to show the modifiers list in the main display. */
+    public static boolean showModifiersInDisplay() {
+        return Preferences.getInstance().getBooleanValue(MODULE, SHOW_MODIFIERS_IN_DISPLAY_KEY, DEFAULT_SHOW_MODIFIERS_IN_DISPLAY);
+    }
+
+    /** @return Whether to show the notes as a tooltip. */
+    public static boolean showNotesAsTooltip() {
+        return Preferences.getInstance().getBooleanValue(MODULE, SHOW_NOTES_AS_TOOL_TIP_KEY, DEFAULT_SHOW_NOTES_AS_TOOL_TIP);
+    }
+
+    /** @return Whether to show the notes in the main display. */
+    public static boolean showNotesInDisplay() {
+        return Preferences.getInstance().getBooleanValue(MODULE, SHOW_NOTES_IN_DISPLAY_KEY, DEFAULT_SHOW_NOTES_IN_DISPLAY);
+    }
+
     /**
      * @return Whether the character's total points are displayed with or without including earned
      *         (but unspent) points.
@@ -179,14 +221,30 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         super(I18n.Text("Display"), owner);
         FlexColumn column = new FlexColumn();
 
-        FlexGrid   grid   = new FlexGrid();
-        column.add(grid);
-
         mIncludeUnspentPointsInTotal = createCheckBox(I18n.Text("Character point total display includes unspent points"), null, shouldIncludeUnspentPointsInTotalPointDisplay());
         column.add(mIncludeUnspentPointsInTotal);
 
-        mShowUserDescAsToolTips = createCheckBox(I18n.Text("Show advantage user description as a tooltip"), null, showUserDescAsTooltip());
-        column.add(mShowUserDescAsToolTips);
+        FlexGrid grid = new FlexGrid();
+        column.add(grid);
+        int i = 0;
+        mShowUserDescAsToolTips  = createCheckBox(I18n.Text("as a tooltip"), null, showUserDescAsTooltip());
+        mShowUserDescInDisplay   = createCheckBox(I18n.Text("in the main display"), null, showUserDescInDisplay());
+        mShowModifiersAsToolTips = createCheckBox(I18n.Text("as a tooltip"), null, showModifiersAsTooltip());
+        mShowModifiersInDisplay  = createCheckBox(I18n.Text("in the main display"), null, showModifiersInDisplay());
+        mShowNotesAsToolTips     = createCheckBox(I18n.Text("as a tooltip"), null, showNotesAsTooltip());
+        mShowNotesInDisplay      = createCheckBox(I18n.Text("in the main display"), null, showNotesInDisplay());
+        i++;
+        grid.add(new FlexComponent(createLabel(I18n.Text("Show Advantage User Descriptions:"), null), Alignment.RIGHT_BOTTOM, Alignment.CENTER), i, 1);
+        grid.add(mShowUserDescInDisplay, i, 2);
+        grid.add(mShowUserDescAsToolTips, i, 3);
+        i++;
+        grid.add(new FlexComponent(createLabel(I18n.Text("Notes:"), null), Alignment.RIGHT_BOTTOM, Alignment.CENTER), i, 1);
+        grid.add(mShowNotesInDisplay, i, 2);
+        grid.add(mShowNotesAsToolTips, i, 3);
+        i++;
+        grid.add(new FlexComponent(createLabel(I18n.Text("Modifiers:"), null), Alignment.RIGHT_BOTTOM, Alignment.CENTER), i, 1);
+        grid.add(mShowModifiersInDisplay, i, 2);
+        grid.add(mShowModifiersAsToolTips, i, 3);
 
         FlexRow row = new FlexRow();
         row.add(createLabel(I18n.Text("Use"), null));
@@ -311,7 +369,7 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
 
     @Override
     public boolean isSetToDefaults() {
-        return shouldIncludeUnspentPointsInTotalPointDisplay() == DEFAULT_TOTAL_POINTS_DISPLAY && showUserDescAsTooltip() == DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP && getInitialUIScale() == DEFAULT_SCALE && mLengthUnitsCombo.getSelectedIndex() == DEFAULT_LENGTH_UNITS.ordinal() && mWeightUnitsCombo.getSelectedIndex() == DEFAULT_WEIGHT_UNITS.ordinal() && getToolTipTimeout() == DEFAULT_TOOLTIP_TIMEOUT && mBlockLayoutField.getText().equals(DEFAULT_BLOCK_LAYOUT);
+        return shouldIncludeUnspentPointsInTotalPointDisplay() == DEFAULT_TOTAL_POINTS_DISPLAY && showUserDescAsTooltip() == DEFAULT_SHOW_USER_DESC_AS_TOOL_TIP && getInitialUIScale() == DEFAULT_SCALE && mLengthUnitsCombo.getSelectedIndex() == DEFAULT_LENGTH_UNITS.ordinal() && mWeightUnitsCombo.getSelectedIndex() == DEFAULT_WEIGHT_UNITS.ordinal() && getToolTipTimeout() == DEFAULT_TOOLTIP_TIMEOUT && mBlockLayoutField.getText().equals(DEFAULT_BLOCK_LAYOUT) && showUserDescInDisplay() == DEFAULT_SHOW_USER_DESC_IN_DISPLAY && showModifiersAsTooltip() == DEFAULT_SHOW_MODIFIERS_AS_TOOL_TIP && showModifiersInDisplay() == DEFAULT_SHOW_MODIFIERS_IN_DISPLAY && showNotesAsTooltip() == DEFAULT_SHOW_NOTES_AS_TOOL_TIP && showNotesInDisplay() == DEFAULT_SHOW_NOTES_IN_DISPLAY;
     }
 
     @Override
@@ -344,6 +402,16 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
             Preferences.getInstance().setValue(MODULE, TOTAL_POINTS_DISPLAY_KEY, mIncludeUnspentPointsInTotal.isSelected());
         } else if (source == mShowUserDescAsToolTips) {
             Preferences.getInstance().setValue(MODULE, SHOW_USER_DESC_AS_TOOL_TIP_KEY, mShowUserDescAsToolTips.isSelected());
+        } else if (source == mShowUserDescInDisplay) {
+            Preferences.getInstance().setValue(MODULE, SHOW_USER_DESC_IN_DISPLAY_KEY, mShowUserDescInDisplay.isSelected());
+        } else if (source == mShowModifiersAsToolTips) {
+            Preferences.getInstance().setValue(MODULE, SHOW_MODIFIERS_AS_TOOL_TIP_KEY, mShowModifiersAsToolTips.isSelected());
+        } else if (source == mShowModifiersInDisplay) {
+            Preferences.getInstance().setValue(MODULE, SHOW_MODIFIERS_IN_DISPLAY_KEY, mShowModifiersInDisplay.isSelected());
+        } else if (source == mShowNotesAsToolTips) {
+            Preferences.getInstance().setValue(MODULE, SHOW_NOTES_AS_TOOL_TIP_KEY, mShowNotesAsToolTips.isSelected());
+        } else if (source == mShowNotesInDisplay) {
+            Preferences.getInstance().setValue(MODULE, SHOW_NOTES_IN_DISPLAY_KEY, mShowNotesInDisplay.isSelected());
         }
         adjustResetButton();
     }

--- a/src/com/trollworks/gcs/preferences/SheetPreferences.java
+++ b/src/com/trollworks/gcs/preferences/SheetPreferences.java
@@ -73,7 +73,7 @@ public class SheetPreferences extends PreferencePanel implements ActionListener,
     public static final String      AUTO_NAME_PREF_KEY               = Preferences.getModuleKey(MODULE, AUTO_NAME_KEY);
     private static final boolean    DEFAULT_AUTO_NAME                = true;
     /** The optional Thrust Damage rules preference key. */
-    private static final String     OPTIONAL_THRUST_DAMAGE_KEY       = "UseOptionalThurstDamage";
+    private static final String     OPTIONAL_THRUST_DAMAGE_KEY       = "UseOptionalThrustDamage";
     public static final String      OPTIONAL_THRUST_DAMAGE_PREF_KEY  = Preferences.getModuleKey(MODULE, OPTIONAL_THRUST_DAMAGE_KEY);
     private static final boolean    DEFAULT_OPTIONAL_THRUST_DAMAGE   = false;
     private static final String     GURPS_METRIC_RULES_KEY           = "UseGurpsMetricRules";

--- a/src/com/trollworks/gcs/widgets/outline/ListRow.java
+++ b/src/com/trollworks/gcs/widgets/outline/ListRow.java
@@ -22,6 +22,7 @@ import com.trollworks.gcs.feature.Feature;
 import com.trollworks.gcs.feature.SkillBonus;
 import com.trollworks.gcs.feature.SpellBonus;
 import com.trollworks.gcs.feature.WeaponBonus;
+import com.trollworks.gcs.preferences.DisplayPreferences;
 import com.trollworks.gcs.prereq.PrereqList;
 import com.trollworks.gcs.skill.SkillDefault;
 import com.trollworks.gcs.skill.Technique;
@@ -474,6 +475,29 @@ public abstract class ListRow extends Row {
     /** @return The owning template. */
     public Template getTemplate() {
         return mDataFile instanceof Template ? (Template) mDataFile : null;
+    }
+
+    /** @return The "secondary" text, the text display below an Advantage. */
+    protected String getSecondaryText() {
+        StringBuilder builder = new StringBuilder();
+        if (DisplayPreferences.showModifiersInDisplay()) {
+            String desc = getModifierNotes();
+            builder.append(desc);
+            if (desc.length() > 0) {
+                builder.append('\n');
+            }
+        }
+        if (DisplayPreferences.showNotesInDisplay()) {
+            String desc = getNotes();
+            builder.append(desc);
+            if (desc.length() > 0) {
+                builder.append('\n');
+            }
+        }
+        if (builder.length() > 0) {
+            builder.setLength(builder.length() - 1);   // Remove the last '\n'
+        }
+        return builder.toString();
     }
 
     /** @return The owning character. */

--- a/src/com/trollworks/gcs/widgets/outline/MultiCell.java
+++ b/src/com/trollworks/gcs/widgets/outline/MultiCell.java
@@ -11,9 +11,7 @@
 
 package com.trollworks.gcs.widgets.outline;
 
-import com.trollworks.gcs.advantage.Advantage;
 import com.trollworks.gcs.app.GCSFonts;
-import com.trollworks.gcs.preferences.DisplayPreferences;
 import com.trollworks.toolkit.ui.Colors;
 import com.trollworks.toolkit.ui.TextDrawing;
 import com.trollworks.toolkit.ui.scale.Scale;
@@ -111,35 +109,7 @@ public class MultiCell implements Cell {
      */
     @SuppressWarnings("static-method")
     protected String getSecondaryText(ListRow row) {
-        StringBuilder builder = new StringBuilder();
-        if (DisplayPreferences.showUserDescInDisplay()) {
-            if (row instanceof Advantage) {
-                Advantage ad   = (Advantage) row;
-                String    desc = ad.getUserDesc();
-                builder.append(desc);
-                if (desc.length() > 0) {
-                    builder.append('\n');
-                }
-            }
-        }
-        if (DisplayPreferences.showNotesInDisplay()) {
-            String desc = row.getNotes();
-            builder.append(desc);
-            if (desc.length() > 0) {
-                builder.append('\n');
-            }
-        }
-        if (DisplayPreferences.showModifiersInDisplay()) {
-            String desc = row.getModifierNotes();
-            builder.append(desc);
-            if (desc.length() > 0) {
-                builder.append('\n');
-            }
-        }
-        if (builder.length() > 0) {
-            builder.setLength(builder.length() - 1);   // Remove the last '\n'
-        }
-        return builder.toString();
+        return row.getSecondaryText();
     }
 
     @Override

--- a/src/com/trollworks/gcs/widgets/outline/MultiCell.java
+++ b/src/com/trollworks/gcs/widgets/outline/MultiCell.java
@@ -11,7 +11,9 @@
 
 package com.trollworks.gcs.widgets.outline;
 
+import com.trollworks.gcs.advantage.Advantage;
 import com.trollworks.gcs.app.GCSFonts;
+import com.trollworks.gcs.preferences.DisplayPreferences;
 import com.trollworks.toolkit.ui.Colors;
 import com.trollworks.toolkit.ui.TextDrawing;
 import com.trollworks.toolkit.ui.scale.Scale;
@@ -109,9 +111,35 @@ public class MultiCell implements Cell {
      */
     @SuppressWarnings("static-method")
     protected String getSecondaryText(ListRow row) {
-        String modifierNotes = row.getModifierNotes();
-        String notes         = row.getNotes();
-        return modifierNotes.length() == 0 ? notes : modifierNotes + '\n' + notes;
+        StringBuilder builder = new StringBuilder();
+        if (DisplayPreferences.showUserDescInDisplay()) {
+            if (row instanceof Advantage) {
+                Advantage ad   = (Advantage) row;
+                String    desc = ad.getUserDesc();
+                builder.append(desc);
+                if (desc.length() > 0) {
+                    builder.append('\n');
+                }
+            }
+        }
+        if (DisplayPreferences.showNotesInDisplay()) {
+            String desc = row.getNotes();
+            builder.append(desc);
+            if (desc.length() > 0) {
+                builder.append('\n');
+            }
+        }
+        if (DisplayPreferences.showModifiersInDisplay()) {
+            String desc = row.getModifierNotes();
+            builder.append(desc);
+            if (desc.length() > 0) {
+                builder.append('\n');
+            }
+        }
+        if (builder.length() > 0) {
+            builder.setLength(builder.length() - 1);   // Remove the last '\n'
+        }
+        return builder.toString();
     }
 
     @Override


### PR DESCRIPTION
Here is the integration of the Display options we talked about.      The user can select which items from the Advantage will show in the main display, and which will show as tool tips (User Description, Notes and Modifier notes).   I didn't make them radio buttons because, who knows, someone might actually want to have something show up twice.

This is what the Display Preferences looks like:
![image](https://user-images.githubusercontent.com/8931036/69926923-4d19da80-1484-11ea-9d57-55226ddd5ba2.png)