### PR TITLE
Mark Will in attribute listing with special value which will be replaced

### DIFF
--- a/com.trollworks.gcs/src/com/trollworks/gcs/character/AttributesPanel.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/character/AttributesPanel.java
@@ -38,7 +38,7 @@ public class AttributesPanel extends DropPanel {
         addLabelAndField(sheet, GURPSCharacter.ID_INTELLIGENCE, I18n.Text("Intelligence (IQ)"), true);
         addLabelAndField(sheet, GURPSCharacter.ID_HEALTH, I18n.Text("Health (HT)"), true);
         addDivider();
-        addLabelAndField(sheet, GURPSCharacter.ID_WILL, I18n.Text("Will"), true);
+        addLabelAndField(sheet, GURPSCharacter.ID_WILL, I18n.Text("Will (Will)").replace(" (Will)", ""), true);
         addLabelAndField(sheet, GURPSCharacter.ID_FRIGHT_CHECK, I18n.Text("Fright Check"), false);
         addDivider();
         addLabelAndField(sheet, GURPSCharacter.ID_BASIC_SPEED, I18n.Text("Basic Speed"), true);


### PR DESCRIPTION
I know this is rather "dirty"...

I am working on a German translation and "Will" translates to "Willenskraft". It is used in the attribute listing and for RSL. By marking one with another string I can have the long word in the attribute listing and e.g. WI in the relative skill level.

IMO, it would be best to mark calls to **I18n.Text("Will")** with some kind of (optional) context, e.g. **I18n.Text("Will", "attribute")**. This will require adjusting the Bundler. I could do that if you prefer it.