### PR TITLE
Do not sort advantage and equipment modifiers.

### DIFF
--- a/com.trollworks.gcs/src/com/trollworks/gcs/modifier/AdvantageModifierEnabler.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/modifier/AdvantageModifierEnabler.java
@@ -132,7 +132,6 @@ public class AdvantageModifierEnabler extends JPanel {
         }
 
         mModifiers = mAdvantage.getModifiers().toArray(new AdvantageModifier[0]);
-        Arrays.sort(mModifiers);
 
         int length = mModifiers.length;
         mEnabled = new JCheckBox[length];

--- a/com.trollworks.gcs/src/com/trollworks/gcs/modifier/EquipmentModifierEnabler.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/modifier/EquipmentModifierEnabler.java
@@ -113,7 +113,6 @@ public class EquipmentModifierEnabler extends JPanel {
         JPanel wrapper = new JPanel(new ColumnLayout());
         wrapper.setBackground(Color.WHITE);
         mModifiers = mEquipment.getModifiers().toArray(new EquipmentModifier[0]);
-        Arrays.sort(mModifiers);
 
         int length = mModifiers.length;
         mEnabled = new JCheckBox[length];


### PR DESCRIPTION
There doesn't appear to be a need to do the sorting as the order is always preserved during saving/loading.
Related to #28