### PR TITLE
Add ctrl+tab shortcut to switch current tab of DockContainer

### DIFF
--- a/com.trollworks.gcs/src/com/trollworks/gcs/ui/widget/dock/DockContainer.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/ui/widget/dock/DockContainer.java
@@ -14,6 +14,7 @@ package com.trollworks.gcs.ui.widget.dock;
 import com.trollworks.gcs.menu.file.CloseHandler;
 import com.trollworks.gcs.ui.UIUtilities;
 
+import java.awt.AWTKeyStroke;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
@@ -22,9 +23,19 @@ import java.awt.EventQueue;
 import java.awt.Insets;
 import java.awt.KeyboardFocusManager;
 import java.awt.LayoutManager;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import javax.swing.AbstractAction;
+import javax.swing.ActionMap;
+import javax.swing.InputMap;
 import javax.swing.JPanel;
+import javax.swing.KeyStroke;
 
 /**
  * All {@link Dockable}s are wrapped in a {@link DockContainer} when placed within a {@link Dock}.
@@ -53,6 +64,7 @@ public class DockContainer extends JPanel implements DockLayoutNode, LayoutManag
         mDockables.add(dockable);
         mHeader.addTab(dockable, 0);
         setMinimumSize(new Dimension(0, 0));
+        setupDockablesSwitchKeys();
     }
 
     /** @return The {@link Dock} this {@link DockContainer} resides in. */
@@ -330,6 +342,74 @@ public class DockContainer extends JPanel implements DockLayoutNode, LayoutManag
                 remaining = 0;
             }
             current.setBounds(insets.left, insets.top + height, width, remaining);
+        }
+    }
+
+    private void setupDockablesSwitchKeys() {
+        // Standard modifier for shortcuts _should_ be CTRL on win and linux and CMD on mac
+        int       standardModifier = Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
+        KeyStroke keyStrokeNext    = KeyStroke.getKeyStroke(KeyEvent.VK_TAB, standardModifier);
+        KeyStroke keyStrokePrev    = KeyStroke.getKeyStroke(KeyEvent.VK_TAB, standardModifier | InputEvent.SHIFT_DOWN_MASK);
+
+        // http://www.davidc.net/programming/java/how-make-ctrl-tab-switch-tabs-jtabbedpane
+        Set<AWTKeyStroke> forwardKeys = new HashSet<>(getFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS));
+        forwardKeys.remove(keyStrokeNext);
+        setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, forwardKeys);
+
+        Set<AWTKeyStroke> backwardKeys = new HashSet<>(getFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS));
+        backwardKeys.remove(keyStrokePrev);
+        setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, backwardKeys);
+
+        // Map keystrokes to action names
+        InputMap inputMap = getInputMap(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+        inputMap.put(keyStrokeNext, "ShowNextDockable");
+        inputMap.put(keyStrokePrev, "ShowPrevDockable");
+
+        // Map action names to actions
+        ActionMap actionMap = getActionMap();
+        actionMap.put("ShowNextDockable", new ShowNextDockableAction());
+        actionMap.put("ShowPrevDockable", new ShowPrevDockableAction());
+    }
+
+
+    static class ShowNextDockableAction extends AbstractAction {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void actionPerformed(ActionEvent event) {
+            DockContainer  container = (DockContainer) event.getSource();
+            List<Dockable> dockables = container.getDockables();
+
+            if (dockables.size() < 2) {
+                return;
+            }
+            int next = container.getCurrentTabIndex() + 1;
+            if (next >= dockables.size()) {
+                next = 0;
+            }
+            Dockable dockable = dockables.get(next);
+            container.setCurrentDockable(dockable);
+        }
+    }
+
+
+    static class ShowPrevDockableAction extends AbstractAction {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void actionPerformed(ActionEvent event) {
+            DockContainer  container = (DockContainer) event.getSource();
+            List<Dockable> dockables = container.getDockables();
+
+            if (dockables.size() < 2) {
+                return;
+            }
+            int prev = container.getCurrentTabIndex() - 1;
+            if (prev < 0) {
+                prev = dockables.size() - 1;
+            }
+            Dockable dockable = dockables.get(prev);
+            container.setCurrentDockable(dockable);
         }
     }
 }

--- a/com.trollworks.gcs/src/com/trollworks/gcs/ui/widget/dock/DockContainer.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/ui/widget/dock/DockContainer.java
@@ -373,8 +373,6 @@ public class DockContainer extends JPanel implements DockLayoutNode, LayoutManag
 
 
     static class ShowNextDockableAction extends AbstractAction {
-        private static final long serialVersionUID = 1L;
-
         @Override
         public void actionPerformed(ActionEvent event) {
             DockContainer  container = (DockContainer) event.getSource();
@@ -394,8 +392,6 @@ public class DockContainer extends JPanel implements DockLayoutNode, LayoutManag
 
 
     static class ShowPrevDockableAction extends AbstractAction {
-        private static final long serialVersionUID = 1L;
-
         @Override
         public void actionPerformed(ActionEvent event) {
             DockContainer  container = (DockContainer) event.getSource();

--- a/com.trollworks.gcs/src/com/trollworks/gcs/ui/widget/dock/DockContainer.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/ui/widget/dock/DockContainer.java
@@ -346,10 +346,8 @@ public class DockContainer extends JPanel implements DockLayoutNode, LayoutManag
     }
 
     private void setupDockablesSwitchKeys() {
-        // Standard modifier for shortcuts _should_ be CTRL on win and linux and CMD on mac
-        int       standardModifier = Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
-        KeyStroke keyStrokeNext    = KeyStroke.getKeyStroke(KeyEvent.VK_TAB, standardModifier);
-        KeyStroke keyStrokePrev    = KeyStroke.getKeyStroke(KeyEvent.VK_TAB, standardModifier | InputEvent.SHIFT_DOWN_MASK);
+        KeyStroke keyStrokeNext = KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK);
+        KeyStroke keyStrokePrev = KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK);
 
         // http://www.davidc.net/programming/java/how-make-ctrl-tab-switch-tabs-jtabbedpane
         Set<AWTKeyStroke> forwardKeys = new HashSet<>(getFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS));


### PR DESCRIPTION
Adds `ctrl+tab` and `ctrl+shift+tab` as shortcuts to cycle through the tabs of `DockContainer` when it, or any descendent, has focus.

The change motivated by the fact that a lot* of software uses those shortcuts to switch tabs. Among those I have open at the moment, my file explorer, firefox, vscode and intellij have this behavior.

The ctrl modifier is actually chosen using the same code used by menu commands. I hope this makes it cross-platform (i.e. uses ctrl on win and linux, cmd on Mac) but I cannot test it.

As far as I could tell the shortcuts do not interfere with normal focus traversal, except for the loss of ability to change focus even with ctrl held down (but who does that anyway?).

\*A subjective lot