### PR TITLE
Ritual Magic Spell Object Ignores Difficulty Change-patch

### DIFF
--- a/com.trollworks.gcs/src/com/trollworks/gcs/spell/RitualMagicSpellEditor.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/spell/RitualMagicSpellEditor.java
@@ -171,6 +171,7 @@ public class RitualMagicSpellEditor extends BaseSpellEditor<RitualMagicSpell> {
         modified |= mRow.setCastingTime(mCastingTimeField.getText());
         modified |= mRow.setResist(mResistField.getText());
         modified |= mRow.setDuration(mDurationField.getText());
+        modified |= mRow.setDifficulty(getAttribute(), getDifficulty());
         modified |= mRow.setPrerequisiteSpellsCount(getPrerequisiteSpellsCount());
         if (mRow.getCharacter() != null || mRow.getTemplate() != null) {
             modified |= mRow.setRawPoints(getPoints());


### PR DESCRIPTION
This attempts to fix the Ritual Magic Spell objects ignoring changes to their difficulty inside the Ritual Magic Spell editor.