### PR TITLE
Stretch encumbrance/lift panel instead of FP/HP panel.

### DIFF
--- a/com.trollworks.gcs/src/com/trollworks/gcs/character/CharacterSheet.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/character/CharacterSheet.java
@@ -218,17 +218,19 @@ public class CharacterSheet extends CollectedOutlines implements ChangeListener,
         wrapper.add(new DescriptionPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setHorizontalSpan(2));
         pageAssembler.addToContent(wrapper, null, null);
 
+        boolean extraSpaceAroundFP = mCharacter.getSettings().extraSpaceAroundFP();
+
         wrapper = new Wrapper(new PrecisionLayout().setColumns(4).setMargins(0).setSpacing(GAP, GAP).setFillAlignment());
         wrapper.add(new AttributesPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment());
         Wrapper wrapper2 = new Wrapper(new PrecisionLayout().setMargins(0).setSpacing(GAP, GAP).setFillAlignment());
-        wrapper2.add(new FatiguePointsPanel(this), new PrecisionLayoutData().setFillAlignment());
-        wrapper2.add(new HitPointsPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment());
-        wrapper.add(wrapper2, new PrecisionLayoutData().setFillAlignment());
+        wrapper2.add(new FatiguePointsPanel(this), new PrecisionLayoutData().setFillAlignment().setGrabHorizontalSpace(extraSpaceAroundFP));
+        wrapper2.add(new HitPointsPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(extraSpaceAroundFP));
+        wrapper.add(wrapper2, new PrecisionLayoutData().setGrabSpace(extraSpaceAroundFP).setFillAlignment());
         wrapper.add(new HitLocationPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment());
         wrapper2 = new Wrapper(new PrecisionLayout().setMargins(0).setSpacing(GAP, GAP).setFillAlignment());
-        wrapper2.add(new EncumbrancePanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(true));
-        wrapper2.add(new LiftPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(true));
-        wrapper.add(wrapper2, new PrecisionLayoutData().setGrabSpace(true).setFillAlignment());
+        wrapper2.add(new EncumbrancePanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(!extraSpaceAroundFP));
+        wrapper2.add(new LiftPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(!extraSpaceAroundFP));
+        wrapper.add(wrapper2, new PrecisionLayoutData().setGrabSpace(!extraSpaceAroundFP).setFillAlignment());
         pageAssembler.addToContent(wrapper, null, null);
 
         // Add the various outline blocks, based on the layout preference.
@@ -707,6 +709,7 @@ public class CharacterSheet extends CollectedOutlines implements ChangeListener,
         MARK_FOR_REBUILD_NOTIFICATIONS.add(Settings.ID_USE_THRUST_EQUALS_SWING_MINUS_2);
         MARK_FOR_REBUILD_NOTIFICATIONS.add(Settings.ID_SHOW_COLLEGE_IN_SPELLS);
         MARK_FOR_REBUILD_NOTIFICATIONS.add(Settings.ID_SHOW_DIFFICULTY);
+        MARK_FOR_REBUILD_NOTIFICATIONS.add(Settings.ID_EXTRA_SPACE_AROUND_FP);
 
         MARK_FOR_WEAPON_REBUILD_NOTIFICATIONS.add(Advantage.ID_DISABLED);
         MARK_FOR_WEAPON_REBUILD_NOTIFICATIONS.add(Advantage.ID_WEAPON_STATUS_CHANGED);

--- a/com.trollworks.gcs/src/com/trollworks/gcs/character/CharacterSheet.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/character/CharacterSheet.java
@@ -221,14 +221,14 @@ public class CharacterSheet extends CollectedOutlines implements ChangeListener,
         wrapper = new Wrapper(new PrecisionLayout().setColumns(4).setMargins(0).setSpacing(GAP, GAP).setFillAlignment());
         wrapper.add(new AttributesPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment());
         Wrapper wrapper2 = new Wrapper(new PrecisionLayout().setMargins(0).setSpacing(GAP, GAP).setFillAlignment());
-        wrapper2.add(new FatiguePointsPanel(this), new PrecisionLayoutData().setFillAlignment().setGrabHorizontalSpace(true));
-        wrapper2.add(new HitPointsPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(true));
-        wrapper.add(wrapper2, new PrecisionLayoutData().setGrabSpace(true).setFillAlignment());
+        wrapper2.add(new FatiguePointsPanel(this), new PrecisionLayoutData().setFillAlignment());
+        wrapper2.add(new HitPointsPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment());
+        wrapper.add(wrapper2, new PrecisionLayoutData().setFillAlignment());
         wrapper.add(new HitLocationPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment());
         wrapper2 = new Wrapper(new PrecisionLayout().setMargins(0).setSpacing(GAP, GAP).setFillAlignment());
-        wrapper2.add(new EncumbrancePanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment());
-        wrapper2.add(new LiftPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment());
-        wrapper.add(wrapper2, new PrecisionLayoutData().setFillAlignment());
+        wrapper2.add(new EncumbrancePanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(true));
+        wrapper2.add(new LiftPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(true));
+        wrapper.add(wrapper2, new PrecisionLayoutData().setGrabSpace(true).setFillAlignment());
         pageAssembler.addToContent(wrapper, null, null);
 
         // Add the various outline blocks, based on the layout preference.

--- a/com.trollworks.gcs/src/com/trollworks/gcs/character/CharacterSheet.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/character/CharacterSheet.java
@@ -218,19 +218,19 @@ public class CharacterSheet extends CollectedOutlines implements ChangeListener,
         wrapper.add(new DescriptionPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setHorizontalSpan(2));
         pageAssembler.addToContent(wrapper, null, null);
 
-        boolean extraSpaceAroundFP = mCharacter.getSettings().extraSpaceAroundFP();
+        boolean extraSpaceAroundEncumbrance = mCharacter.getSettings().extraSpaceAroundEncumbrance();
 
         wrapper = new Wrapper(new PrecisionLayout().setColumns(4).setMargins(0).setSpacing(GAP, GAP).setFillAlignment());
         wrapper.add(new AttributesPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment());
         Wrapper wrapper2 = new Wrapper(new PrecisionLayout().setMargins(0).setSpacing(GAP, GAP).setFillAlignment());
-        wrapper2.add(new FatiguePointsPanel(this), new PrecisionLayoutData().setFillAlignment().setGrabHorizontalSpace(extraSpaceAroundFP));
-        wrapper2.add(new HitPointsPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(extraSpaceAroundFP));
-        wrapper.add(wrapper2, new PrecisionLayoutData().setGrabSpace(extraSpaceAroundFP).setFillAlignment());
+        wrapper2.add(new FatiguePointsPanel(this), new PrecisionLayoutData().setFillAlignment().setGrabHorizontalSpace(!extraSpaceAroundEncumbrance));
+        wrapper2.add(new HitPointsPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(!extraSpaceAroundEncumbrance));
+        wrapper.add(wrapper2, new PrecisionLayoutData().setGrabSpace(!extraSpaceAroundEncumbrance).setFillAlignment());
         wrapper.add(new HitLocationPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment());
         wrapper2 = new Wrapper(new PrecisionLayout().setMargins(0).setSpacing(GAP, GAP).setFillAlignment());
-        wrapper2.add(new EncumbrancePanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(!extraSpaceAroundFP));
-        wrapper2.add(new LiftPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(!extraSpaceAroundFP));
-        wrapper.add(wrapper2, new PrecisionLayoutData().setGrabSpace(!extraSpaceAroundFP).setFillAlignment());
+        wrapper2.add(new EncumbrancePanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(extraSpaceAroundEncumbrance));
+        wrapper2.add(new LiftPanel(this), new PrecisionLayoutData().setGrabVerticalSpace(true).setFillAlignment().setGrabHorizontalSpace(extraSpaceAroundEncumbrance));
+        wrapper.add(wrapper2, new PrecisionLayoutData().setGrabSpace(extraSpaceAroundEncumbrance).setFillAlignment());
         pageAssembler.addToContent(wrapper, null, null);
 
         // Add the various outline blocks, based on the layout preference.
@@ -709,7 +709,7 @@ public class CharacterSheet extends CollectedOutlines implements ChangeListener,
         MARK_FOR_REBUILD_NOTIFICATIONS.add(Settings.ID_USE_THRUST_EQUALS_SWING_MINUS_2);
         MARK_FOR_REBUILD_NOTIFICATIONS.add(Settings.ID_SHOW_COLLEGE_IN_SPELLS);
         MARK_FOR_REBUILD_NOTIFICATIONS.add(Settings.ID_SHOW_DIFFICULTY);
-        MARK_FOR_REBUILD_NOTIFICATIONS.add(Settings.ID_EXTRA_SPACE_AROUND_FP);
+        MARK_FOR_REBUILD_NOTIFICATIONS.add(Settings.ID_EXTRA_SPACE_AROUND_ENCUMBRANCE);
 
         MARK_FOR_WEAPON_REBUILD_NOTIFICATIONS.add(Advantage.ID_DISABLED);
         MARK_FOR_WEAPON_REBUILD_NOTIFICATIONS.add(Advantage.ID_WEAPON_STATUS_CHANGED);

--- a/com.trollworks.gcs/src/com/trollworks/gcs/character/Settings.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/character/Settings.java
@@ -48,7 +48,7 @@ public class Settings {
     public static final  String         TAG_SHOW_COLLEGE_IN_SPELLS             = "show_college_in_sheet_spells";
     public static final  String         TAG_SHOW_DIFFICULTY                    = "show_difficulty";
     public static final  String         TAG_USE_TITLE_IN_FOOTER                = "use_title_in_footer";
-    private static final String         TAG_EXTRA_SPACE_AROUND_FP              = "extra_space_around_fp";
+    private static final String         TAG_EXTRA_SPACE_AROUND_ENCUMBRANCE     = "extra_space_around_encumbrance";
     public static final  String         PREFIX                                 = GURPSCharacter.CHARACTER_PREFIX + "settings.";
     public static final  String         ID_DEFAULT_LENGTH_UNITS                = PREFIX + TAG_DEFAULT_LENGTH_UNITS;
     public static final  String         ID_DEFAULT_WEIGHT_UNITS                = PREFIX + TAG_DEFAULT_WEIGHT_UNITS;
@@ -67,7 +67,7 @@ public class Settings {
     public static final  String         ID_SHOW_COLLEGE_IN_SPELLS              = PREFIX + TAG_SHOW_COLLEGE_IN_SPELLS;
     public static final  String         ID_SHOW_DIFFICULTY                     = PREFIX + TAG_SHOW_DIFFICULTY;
     public static final  String         ID_USE_TITLE_IN_FOOTER                 = PREFIX + TAG_USE_TITLE_IN_FOOTER;
-    public static final  String         ID_EXTRA_SPACE_AROUND_FP               = PREFIX + TAG_EXTRA_SPACE_AROUND_FP;
+    public static final  String         ID_EXTRA_SPACE_AROUND_ENCUMBRANCE      = PREFIX + TAG_EXTRA_SPACE_AROUND_ENCUMBRANCE;
     private              GURPSCharacter mCharacter;
     private              LengthUnits    mDefaultLengthUnits;
     private              WeightUnits    mDefaultWeightUnits;
@@ -86,7 +86,7 @@ public class Settings {
     private              boolean        mShowCollegeInSpells;
     private              boolean        mShowDifficulty;
     private              boolean        mUseTitleInFooter;
-    private              boolean        mExtraSpaceAroundFP;
+    private              boolean        mExtraSpaceAroundEncumbrance;
 
     public Settings(GURPSCharacter character) {
         Preferences prefs = Preferences.getInstance();
@@ -108,7 +108,7 @@ public class Settings {
         mShowCollegeInSpells = prefs.showCollegeInSheetSpells();
         mShowDifficulty = prefs.showDifficulty();
         mUseTitleInFooter = prefs.useTitleInFooter();
-        mExtraSpaceAroundFP = prefs.extraSpaceAroundFP();
+        mExtraSpaceAroundEncumbrance = prefs.extraSpaceAroundEncumbrance();
     }
 
     void load(JsonMap m) throws IOException {
@@ -140,7 +140,7 @@ public class Settings {
         mShowCollegeInSpells = m.getBoolean(TAG_SHOW_COLLEGE_IN_SPELLS);
         mShowDifficulty = m.getBoolean(TAG_SHOW_DIFFICULTY);
         mUseTitleInFooter = m.getBoolean(TAG_USE_TITLE_IN_FOOTER);
-        mExtraSpaceAroundFP = m.getBoolean(TAG_EXTRA_SPACE_AROUND_FP);
+        mExtraSpaceAroundEncumbrance = m.getBoolean(TAG_EXTRA_SPACE_AROUND_ENCUMBRANCE);
         mBlockLayout = new ArrayList<>();
         JsonArray a     = m.getArray(TAG_BLOCK_LAYOUT);
         int       count = a.size();
@@ -168,7 +168,7 @@ public class Settings {
         w.keyValue(TAG_SHOW_COLLEGE_IN_SPELLS, mShowCollegeInSpells);
         w.keyValue(TAG_SHOW_DIFFICULTY, mShowDifficulty);
         w.keyValue(TAG_USE_TITLE_IN_FOOTER, mUseTitleInFooter);
-        w.keyValue(TAG_EXTRA_SPACE_AROUND_FP, mExtraSpaceAroundFP);
+        w.keyValue(TAG_EXTRA_SPACE_AROUND_ENCUMBRANCE, mExtraSpaceAroundEncumbrance);
         w.key(TAG_BLOCK_LAYOUT);
         w.startArray();
         for (String one : mBlockLayout) {
@@ -379,14 +379,14 @@ public class Settings {
         }
     }
 
-    public boolean extraSpaceAroundFP() {
-        return mExtraSpaceAroundFP;
+    public boolean extraSpaceAroundEncumbrance() {
+        return mExtraSpaceAroundEncumbrance;
     }
 
-    public void setExtraSpaceAroundFP(boolean extraSpaceAroundFP) {
-        if (mExtraSpaceAroundFP != extraSpaceAroundFP) {
-            mExtraSpaceAroundFP = extraSpaceAroundFP;
-            mCharacter.notifySingle(ID_EXTRA_SPACE_AROUND_FP, Boolean.valueOf(mExtraSpaceAroundFP));
+    public void setExtraSpaceAroundEncumbrance(boolean extraSpaceAroundEncumbrance) {
+        if (mExtraSpaceAroundEncumbrance != extraSpaceAroundEncumbrance) {
+            mExtraSpaceAroundEncumbrance = extraSpaceAroundEncumbrance;
+            mCharacter.notifySingle(ID_EXTRA_SPACE_AROUND_ENCUMBRANCE, Boolean.valueOf(mExtraSpaceAroundEncumbrance));
         }
     }
 }

--- a/com.trollworks.gcs/src/com/trollworks/gcs/character/Settings.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/character/Settings.java
@@ -48,6 +48,7 @@ public class Settings {
     public static final  String         TAG_SHOW_COLLEGE_IN_SPELLS             = "show_college_in_sheet_spells";
     public static final  String         TAG_SHOW_DIFFICULTY                    = "show_difficulty";
     public static final  String         TAG_USE_TITLE_IN_FOOTER                = "use_title_in_footer";
+    private static final String         TAG_EXTRA_SPACE_AROUND_FP              = "extra_space_around_fp";
     public static final  String         PREFIX                                 = GURPSCharacter.CHARACTER_PREFIX + "settings.";
     public static final  String         ID_DEFAULT_LENGTH_UNITS                = PREFIX + TAG_DEFAULT_LENGTH_UNITS;
     public static final  String         ID_DEFAULT_WEIGHT_UNITS                = PREFIX + TAG_DEFAULT_WEIGHT_UNITS;
@@ -66,6 +67,7 @@ public class Settings {
     public static final  String         ID_SHOW_COLLEGE_IN_SPELLS              = PREFIX + TAG_SHOW_COLLEGE_IN_SPELLS;
     public static final  String         ID_SHOW_DIFFICULTY                     = PREFIX + TAG_SHOW_DIFFICULTY;
     public static final  String         ID_USE_TITLE_IN_FOOTER                 = PREFIX + TAG_USE_TITLE_IN_FOOTER;
+    public static final  String         ID_EXTRA_SPACE_AROUND_FP               = PREFIX + TAG_EXTRA_SPACE_AROUND_FP;
     private              GURPSCharacter mCharacter;
     private              LengthUnits    mDefaultLengthUnits;
     private              WeightUnits    mDefaultWeightUnits;
@@ -84,6 +86,7 @@ public class Settings {
     private              boolean        mShowCollegeInSpells;
     private              boolean        mShowDifficulty;
     private              boolean        mUseTitleInFooter;
+    private              boolean        mExtraSpaceAroundFP;
 
     public Settings(GURPSCharacter character) {
         Preferences prefs = Preferences.getInstance();
@@ -105,6 +108,7 @@ public class Settings {
         mShowCollegeInSpells = prefs.showCollegeInSheetSpells();
         mShowDifficulty = prefs.showDifficulty();
         mUseTitleInFooter = prefs.useTitleInFooter();
+        mExtraSpaceAroundFP = prefs.extraSpaceAroundFP();
     }
 
     void load(JsonMap m) throws IOException {
@@ -136,6 +140,7 @@ public class Settings {
         mShowCollegeInSpells = m.getBoolean(TAG_SHOW_COLLEGE_IN_SPELLS);
         mShowDifficulty = m.getBoolean(TAG_SHOW_DIFFICULTY);
         mUseTitleInFooter = m.getBoolean(TAG_USE_TITLE_IN_FOOTER);
+        mExtraSpaceAroundFP = m.getBoolean(TAG_EXTRA_SPACE_AROUND_FP);
         mBlockLayout = new ArrayList<>();
         JsonArray a     = m.getArray(TAG_BLOCK_LAYOUT);
         int       count = a.size();
@@ -163,6 +168,7 @@ public class Settings {
         w.keyValue(TAG_SHOW_COLLEGE_IN_SPELLS, mShowCollegeInSpells);
         w.keyValue(TAG_SHOW_DIFFICULTY, mShowDifficulty);
         w.keyValue(TAG_USE_TITLE_IN_FOOTER, mUseTitleInFooter);
+        w.keyValue(TAG_EXTRA_SPACE_AROUND_FP, mExtraSpaceAroundFP);
         w.key(TAG_BLOCK_LAYOUT);
         w.startArray();
         for (String one : mBlockLayout) {
@@ -370,6 +376,17 @@ public class Settings {
         if (mUseTitleInFooter != show) {
             mUseTitleInFooter = show;
             mCharacter.notifySingle(ID_USE_TITLE_IN_FOOTER, Boolean.valueOf(mUseTitleInFooter));
+        }
+    }
+
+    public boolean extraSpaceAroundFP() {
+        return mExtraSpaceAroundFP;
+    }
+
+    public void setExtraSpaceAroundFP(boolean extraSpaceAroundFP) {
+        if (mExtraSpaceAroundFP != extraSpaceAroundFP) {
+            mExtraSpaceAroundFP = extraSpaceAroundFP;
+            mCharacter.notifySingle(ID_EXTRA_SPACE_AROUND_FP, Boolean.valueOf(mExtraSpaceAroundFP));
         }
     }
 }

--- a/com.trollworks.gcs/src/com/trollworks/gcs/character/SettingsEditor.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/character/SettingsEditor.java
@@ -59,7 +59,7 @@ public class SettingsEditor extends BaseWindow implements ActionListener, Docume
     private JCheckBox                mShowCollegeInSpells;
     private JCheckBox                mShowDifficulty;
     private JCheckBox                mShowTitleInsteadOfNameInPageFooter;
-    private JCheckBox                mExtraSpaceAroundFP;
+    private JCheckBox                mExtraSpaceAroundEncumbrance;
     private JComboBox<LengthUnits>   mLengthUnitsCombo;
     private JComboBox<WeightUnits>   mWeightUnitsCombo;
     private JComboBox<DisplayOption> mUserDescriptionDisplayCombo;
@@ -111,7 +111,7 @@ public class SettingsEditor extends BaseWindow implements ActionListener, Docume
         mShowCollegeInSpells = addCheckBox(panel, I18n.Text("Show the College column in the spells list"), null, mSettings.showCollegeInSpells());
         mShowDifficulty = addCheckBox(panel, I18n.Text("Show the Difficulty column in the skills and spells lists"), null, mSettings.showDifficulty());
         mShowTitleInsteadOfNameInPageFooter = addCheckBox(panel, I18n.Text("Show the title rather than the name in the page footer"), null, mSettings.useTitleInFooter());
-        mExtraSpaceAroundFP = addCheckBox(panel, I18n.Text("Add extra space around FP/HP table rather than around Encumbrance table"), null, mSettings.extraSpaceAroundFP());
+        mExtraSpaceAroundEncumbrance = addCheckBox(panel, I18n.Text("Add extra space around Encumbrance table rather than around FP/HP table"), null, mSettings.extraSpaceAroundEncumbrance());
         mBaseWillOn10 = addCheckBox(panel, I18n.Text("Base Will on 10 and not IQ"), null, mSettings.baseWillOn10());
         mBasePerOn10 = addCheckBox(panel, I18n.Text("Base Perception on 10 and not IQ"), null, mSettings.basePerOn10());
         mUseMultiplicativeModifiers = addCheckBox(panel, I18n.Text("Use Multiplicative Modifiers from PW102 (note: changes point value)"), null, mSettings.useMultiplicativeModifiers());
@@ -194,8 +194,8 @@ public class SettingsEditor extends BaseWindow implements ActionListener, Docume
             mSettings.setShowDifficulty(mShowDifficulty.isSelected());
         } else if (source == mShowTitleInsteadOfNameInPageFooter) {
             mSettings.setUseTitleInFooter(mShowTitleInsteadOfNameInPageFooter.isSelected());
-        } else if (source == mExtraSpaceAroundFP) {
-            mSettings.setExtraSpaceAroundFP(mExtraSpaceAroundFP.isSelected());
+        } else if (source == mExtraSpaceAroundEncumbrance) {
+            mSettings.setExtraSpaceAroundEncumbrance(mExtraSpaceAroundEncumbrance.isSelected());
         } else if (source == mBaseWillOn10) {
             mSettings.setBaseWillOn10(mBaseWillOn10.isSelected());
         } else if (source == mBasePerOn10) {
@@ -226,7 +226,7 @@ public class SettingsEditor extends BaseWindow implements ActionListener, Docume
         atDefaults = atDefaults && mShowCollegeInSpells.isSelected() == prefs.showCollegeInSheetSpells();
         atDefaults = atDefaults && mShowDifficulty.isSelected() == prefs.showDifficulty();
         atDefaults = atDefaults && mShowTitleInsteadOfNameInPageFooter.isSelected() == prefs.useTitleInFooter();
-        atDefaults = atDefaults && mExtraSpaceAroundFP.isSelected() == prefs.extraSpaceAroundFP();
+        atDefaults = atDefaults && mExtraSpaceAroundEncumbrance.isSelected() == prefs.extraSpaceAroundEncumbrance();
         atDefaults = atDefaults && mBaseWillOn10.isSelected() == prefs.baseWillOn10();
         atDefaults = atDefaults && mBasePerOn10.isSelected() == prefs.basePerOn10();
         atDefaults = atDefaults && mUseMultiplicativeModifiers.isSelected() == prefs.useMultiplicativeModifiers();
@@ -262,7 +262,7 @@ public class SettingsEditor extends BaseWindow implements ActionListener, Docume
             mShowCollegeInSpells.setSelected(prefs.showCollegeInSheetSpells());
             mShowDifficulty.setSelected(prefs.showDifficulty());
             mShowTitleInsteadOfNameInPageFooter.setSelected(prefs.useTitleInFooter());
-            mExtraSpaceAroundFP.setSelected(prefs.extraSpaceAroundFP());
+            mExtraSpaceAroundEncumbrance.setSelected(prefs.extraSpaceAroundEncumbrance());
             mBaseWillOn10.setSelected(prefs.baseWillOn10());
             mBasePerOn10.setSelected(prefs.basePerOn10());
             mUseMultiplicativeModifiers.setSelected(prefs.useMultiplicativeModifiers());

--- a/com.trollworks.gcs/src/com/trollworks/gcs/character/SettingsEditor.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/character/SettingsEditor.java
@@ -59,6 +59,7 @@ public class SettingsEditor extends BaseWindow implements ActionListener, Docume
     private JCheckBox                mShowCollegeInSpells;
     private JCheckBox                mShowDifficulty;
     private JCheckBox                mShowTitleInsteadOfNameInPageFooter;
+    private JCheckBox                mExtraSpaceAroundFP;
     private JComboBox<LengthUnits>   mLengthUnitsCombo;
     private JComboBox<WeightUnits>   mWeightUnitsCombo;
     private JComboBox<DisplayOption> mUserDescriptionDisplayCombo;
@@ -110,6 +111,7 @@ public class SettingsEditor extends BaseWindow implements ActionListener, Docume
         mShowCollegeInSpells = addCheckBox(panel, I18n.Text("Show the College column in the spells list"), null, mSettings.showCollegeInSpells());
         mShowDifficulty = addCheckBox(panel, I18n.Text("Show the Difficulty column in the skills and spells lists"), null, mSettings.showDifficulty());
         mShowTitleInsteadOfNameInPageFooter = addCheckBox(panel, I18n.Text("Show the title rather than the name in the page footer"), null, mSettings.useTitleInFooter());
+        mExtraSpaceAroundFP = addCheckBox(panel, I18n.Text("Add extra space around FP/HP table rather than around Encumbrance table"), null, mSettings.extraSpaceAroundFP());
         mBaseWillOn10 = addCheckBox(panel, I18n.Text("Base Will on 10 and not IQ"), null, mSettings.baseWillOn10());
         mBasePerOn10 = addCheckBox(panel, I18n.Text("Base Perception on 10 and not IQ"), null, mSettings.basePerOn10());
         mUseMultiplicativeModifiers = addCheckBox(panel, I18n.Text("Use Multiplicative Modifiers from PW102 (note: changes point value)"), null, mSettings.useMultiplicativeModifiers());
@@ -192,6 +194,8 @@ public class SettingsEditor extends BaseWindow implements ActionListener, Docume
             mSettings.setShowDifficulty(mShowDifficulty.isSelected());
         } else if (source == mShowTitleInsteadOfNameInPageFooter) {
             mSettings.setUseTitleInFooter(mShowTitleInsteadOfNameInPageFooter.isSelected());
+        } else if (source == mExtraSpaceAroundFP) {
+            mSettings.setExtraSpaceAroundFP(mExtraSpaceAroundFP.isSelected());
         } else if (source == mBaseWillOn10) {
             mSettings.setBaseWillOn10(mBaseWillOn10.isSelected());
         } else if (source == mBasePerOn10) {
@@ -222,6 +226,7 @@ public class SettingsEditor extends BaseWindow implements ActionListener, Docume
         atDefaults = atDefaults && mShowCollegeInSpells.isSelected() == prefs.showCollegeInSheetSpells();
         atDefaults = atDefaults && mShowDifficulty.isSelected() == prefs.showDifficulty();
         atDefaults = atDefaults && mShowTitleInsteadOfNameInPageFooter.isSelected() == prefs.useTitleInFooter();
+        atDefaults = atDefaults && mExtraSpaceAroundFP.isSelected() == prefs.extraSpaceAroundFP();
         atDefaults = atDefaults && mBaseWillOn10.isSelected() == prefs.baseWillOn10();
         atDefaults = atDefaults && mBasePerOn10.isSelected() == prefs.basePerOn10();
         atDefaults = atDefaults && mUseMultiplicativeModifiers.isSelected() == prefs.useMultiplicativeModifiers();
@@ -257,6 +262,7 @@ public class SettingsEditor extends BaseWindow implements ActionListener, Docume
             mShowCollegeInSpells.setSelected(prefs.showCollegeInSheetSpells());
             mShowDifficulty.setSelected(prefs.showDifficulty());
             mShowTitleInsteadOfNameInPageFooter.setSelected(prefs.useTitleInFooter());
+            mExtraSpaceAroundFP.setSelected(prefs.extraSpaceAroundFP());
             mBaseWillOn10.setSelected(prefs.baseWillOn10());
             mBasePerOn10.setSelected(prefs.basePerOn10());
             mUseMultiplicativeModifiers.setSelected(prefs.useMultiplicativeModifiers());

--- a/com.trollworks.gcs/src/com/trollworks/gcs/preferences/DisplayPreferences.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/preferences/DisplayPreferences.java
@@ -71,7 +71,7 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         mShowCollegeInSheetSpells = addCheckBox(I18n.Text("Show the College column in character sheet spells list *"), prefs.showCollegeInSheetSpells());
         mShowDifficulty = addCheckBox(I18n.Text("Show the Difficulty column in character sheet skills and spells lists *"), prefs.showDifficulty());
         mShowTitleInsteadOfNameInPageFooter = addCheckBox(I18n.Text("Show the title rather than the name in the page footer on character sheets *"), prefs.useTitleInFooter());
-        mExtraSpaceAroundEncumbrance = addCheckBox(I18n.Text("Add extra space around Encumrance table rather than around FP/HP table *"), prefs.extraSpaceAroundEncumbrance());
+        mExtraSpaceAroundEncumbrance = addCheckBox(I18n.Text("Add extra space around Encumbrance table rather than around FP/HP table *"), prefs.extraSpaceAroundEncumbrance());
 
         addLabel(I18n.Text("Initial Scale"));
         mUIScaleCombo = addCombo(Scales.values(), prefs.getInitialUIScale(), null);

--- a/com.trollworks.gcs/src/com/trollworks/gcs/preferences/DisplayPreferences.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/preferences/DisplayPreferences.java
@@ -47,7 +47,7 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
     private JCheckBox                mShowCollegeInSheetSpells;
     private JCheckBox                mShowDifficulty;
     private JCheckBox                mShowTitleInsteadOfNameInPageFooter;
-    private JCheckBox                mExtraSpaceAroundFP;
+    private JCheckBox                mExtraSpaceAroundEncumbrance;
     private JComboBox<Scales>        mUIScaleCombo;
     private JComboBox<LengthUnits>   mLengthUnitsCombo;
     private JComboBox<WeightUnits>   mWeightUnitsCombo;
@@ -71,7 +71,7 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         mShowCollegeInSheetSpells = addCheckBox(I18n.Text("Show the College column in character sheet spells list *"), prefs.showCollegeInSheetSpells());
         mShowDifficulty = addCheckBox(I18n.Text("Show the Difficulty column in character sheet skills and spells lists *"), prefs.showDifficulty());
         mShowTitleInsteadOfNameInPageFooter = addCheckBox(I18n.Text("Show the title rather than the name in the page footer on character sheets *"), prefs.useTitleInFooter());
-        mExtraSpaceAroundFP = addCheckBox(I18n.Text("Add extra space around FP/HP table rather than around Encumbrance table *"), prefs.extraSpaceAroundFP());
+        mExtraSpaceAroundEncumbrance = addCheckBox(I18n.Text("Add extra space around Encumrance table rather than around FP/HP table *"), prefs.extraSpaceAroundEncumbrance());
 
         addLabel(I18n.Text("Initial Scale"));
         mUIScaleCombo = addCombo(Scales.values(), prefs.getInitialUIScale(), null);
@@ -201,8 +201,8 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
             Preferences.getInstance().setShowDifficulty(mShowDifficulty.isSelected());
         } else if (source == mShowTitleInsteadOfNameInPageFooter) {
             Preferences.getInstance().setUseTitleInFooter(mShowTitleInsteadOfNameInPageFooter.isSelected());
-        } else if (source == mExtraSpaceAroundFP) {
-            Preferences.getInstance().setExtraSpaceAroundFp(mExtraSpaceAroundFP.isSelected());
+        } else if (source == mExtraSpaceAroundEncumbrance) {
+            Preferences.getInstance().setExtraSpaceAroundEncumbrance(mExtraSpaceAroundEncumbrance.isSelected());
         }
         adjustResetButton();
     }
@@ -213,7 +213,7 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         mShowCollegeInSheetSpells.setSelected(Preferences.DEFAULT_SHOW_COLLEGE_IN_SHEET_SPELLS);
         mShowDifficulty.setSelected(Preferences.DEFAULT_SHOW_DIFFICULTY);
         mShowTitleInsteadOfNameInPageFooter.setSelected(Preferences.DEFAULT_USE_TITLE_IN_FOOTER);
-        mExtraSpaceAroundFP.setSelected(Preferences.DEFAULT_EXTRA_SPACE_AROUND_FP);
+        mExtraSpaceAroundEncumbrance.setSelected(Preferences.DEFAULT_EXTRA_SPACE_AROUND_ENCUMBRANCE);
         mUIScaleCombo.setSelectedItem(Preferences.DEFAULT_INITIAL_UI_SCALE);
         mLengthUnitsCombo.setSelectedItem(Preferences.DEFAULT_DEFAULT_LENGTH_UNITS);
         mWeightUnitsCombo.setSelectedItem(Preferences.DEFAULT_DEFAULT_WEIGHT_UNITS);
@@ -230,7 +230,7 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         boolean     atDefault = prefs.includeUnspentPointsInTotal() == Preferences.DEFAULT_INCLUDE_UNSPENT_POINTS_IN_TOTAL;
         atDefault = atDefault && prefs.showCollegeInSheetSpells() == Preferences.DEFAULT_SHOW_COLLEGE_IN_SHEET_SPELLS;
         atDefault = atDefault && prefs.showDifficulty() == Preferences.DEFAULT_SHOW_DIFFICULTY;
-        atDefault = atDefault && prefs.extraSpaceAroundFP() == Preferences.DEFAULT_EXTRA_SPACE_AROUND_FP;
+        atDefault = atDefault && prefs.extraSpaceAroundEncumbrance() == Preferences.DEFAULT_EXTRA_SPACE_AROUND_ENCUMBRANCE;
         atDefault = atDefault && prefs.getInitialUIScale() == Preferences.DEFAULT_INITIAL_UI_SCALE;
         atDefault = atDefault && prefs.getDefaultLengthUnits() == Preferences.DEFAULT_DEFAULT_LENGTH_UNITS;
         atDefault = atDefault && prefs.getDefaultWeightUnits() == Preferences.DEFAULT_DEFAULT_WEIGHT_UNITS;

--- a/com.trollworks.gcs/src/com/trollworks/gcs/preferences/DisplayPreferences.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/preferences/DisplayPreferences.java
@@ -47,6 +47,7 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
     private JCheckBox                mShowCollegeInSheetSpells;
     private JCheckBox                mShowDifficulty;
     private JCheckBox                mShowTitleInsteadOfNameInPageFooter;
+    private JCheckBox                mExtraSpaceAroundFP;
     private JComboBox<Scales>        mUIScaleCombo;
     private JComboBox<LengthUnits>   mLengthUnitsCombo;
     private JComboBox<WeightUnits>   mWeightUnitsCombo;
@@ -70,6 +71,7 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         mShowCollegeInSheetSpells = addCheckBox(I18n.Text("Show the College column in character sheet spells list *"), prefs.showCollegeInSheetSpells());
         mShowDifficulty = addCheckBox(I18n.Text("Show the Difficulty column in character sheet skills and spells lists *"), prefs.showDifficulty());
         mShowTitleInsteadOfNameInPageFooter = addCheckBox(I18n.Text("Show the title rather than the name in the page footer on character sheets *"), prefs.useTitleInFooter());
+        mExtraSpaceAroundFP = addCheckBox(I18n.Text("Add extra space around FP/HP table rather than around Encumbrance table *"), prefs.extraSpaceAroundFP());
 
         addLabel(I18n.Text("Initial Scale"));
         mUIScaleCombo = addCombo(Scales.values(), prefs.getInitialUIScale(), null);
@@ -199,6 +201,8 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
             Preferences.getInstance().setShowDifficulty(mShowDifficulty.isSelected());
         } else if (source == mShowTitleInsteadOfNameInPageFooter) {
             Preferences.getInstance().setUseTitleInFooter(mShowTitleInsteadOfNameInPageFooter.isSelected());
+        } else if (source == mExtraSpaceAroundFP) {
+            Preferences.getInstance().setExtraSpaceAroundFp(mExtraSpaceAroundFP.isSelected());
         }
         adjustResetButton();
     }
@@ -209,6 +213,7 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         mShowCollegeInSheetSpells.setSelected(Preferences.DEFAULT_SHOW_COLLEGE_IN_SHEET_SPELLS);
         mShowDifficulty.setSelected(Preferences.DEFAULT_SHOW_DIFFICULTY);
         mShowTitleInsteadOfNameInPageFooter.setSelected(Preferences.DEFAULT_USE_TITLE_IN_FOOTER);
+        mExtraSpaceAroundFP.setSelected(Preferences.DEFAULT_EXTRA_SPACE_AROUND_FP);
         mUIScaleCombo.setSelectedItem(Preferences.DEFAULT_INITIAL_UI_SCALE);
         mLengthUnitsCombo.setSelectedItem(Preferences.DEFAULT_DEFAULT_LENGTH_UNITS);
         mWeightUnitsCombo.setSelectedItem(Preferences.DEFAULT_DEFAULT_WEIGHT_UNITS);
@@ -225,6 +230,7 @@ public class DisplayPreferences extends PreferencePanel implements ActionListene
         boolean     atDefault = prefs.includeUnspentPointsInTotal() == Preferences.DEFAULT_INCLUDE_UNSPENT_POINTS_IN_TOTAL;
         atDefault = atDefault && prefs.showCollegeInSheetSpells() == Preferences.DEFAULT_SHOW_COLLEGE_IN_SHEET_SPELLS;
         atDefault = atDefault && prefs.showDifficulty() == Preferences.DEFAULT_SHOW_DIFFICULTY;
+        atDefault = atDefault && prefs.extraSpaceAroundFP() == Preferences.DEFAULT_EXTRA_SPACE_AROUND_FP;
         atDefault = atDefault && prefs.getInitialUIScale() == Preferences.DEFAULT_INITIAL_UI_SCALE;
         atDefault = atDefault && prefs.getDefaultLengthUnits() == Preferences.DEFAULT_DEFAULT_LENGTH_UNITS;
         atDefault = atDefault && prefs.getDefaultWeightUnits() == Preferences.DEFAULT_DEFAULT_WEIGHT_UNITS;

--- a/com.trollworks.gcs/src/com/trollworks/gcs/preferences/Preferences.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/preferences/Preferences.java
@@ -92,6 +92,7 @@ public class Preferences {
     private static final String SHOW_COLLEGE_IN_SHEET_SPELLS       = "show_college_in_sheet_spells";
     private static final String SHOW_DIFFICULTY                    = "show_difficulty";
     private static final String USE_TITLE_IN_FOOTER                = "use_title_in_footer";
+    private static final String EXTRA_SPACE_AROUND_FP              = "extra_space_around_fp";
     private static final String THEME                              = "theme";
     private static final String TOOLTIP_TIMEOUT                    = "tooltip_timeout";
     private static final String USE_KNOW_YOUR_OWN_STRENGTH         = "use_know_your_own_strength";
@@ -119,6 +120,7 @@ public class Preferences {
     public static final String KEY_SHOW_COLLEGE_IN_SHEET_SPELLS    = KEY_PER_SHEET_PREFIX + SHOW_COLLEGE_IN_SHEET_SPELLS;
     public static final String KEY_SHOW_DIFFICULTY                 = KEY_PER_SHEET_PREFIX + SHOW_DIFFICULTY;
     public static final String KEY_USE_TITLE_IN_FOOTER             = KEY_PER_SHEET_PREFIX + USE_TITLE_IN_FOOTER;
+    public static final String KEY_EXTRA_SPACE_AROUND_FP           = KEY_PER_SHEET_PREFIX + EXTRA_SPACE_AROUND_FP;
     public static final String KEY_USE_KNOW_YOUR_OWN_STRENGTH      = KEY_PER_SHEET_PREFIX + USE_KNOW_YOUR_OWN_STRENGTH;
     public static final String KEY_USE_MODIFYING_DICE_PLUS_ADDS    = KEY_PER_SHEET_PREFIX + USE_MODIFYING_DICE_PLUS_ADDS;
     public static final String KEY_USE_MULTIPLICATIVE_MODIFIERS    = KEY_PER_SHEET_PREFIX + USE_MULTIPLICATIVE_MODIFIERS;
@@ -136,6 +138,7 @@ public class Preferences {
     public static final boolean       DEFAULT_SHOW_COLLEGE_IN_SHEET_SPELLS      = false;
     public static final boolean       DEFAULT_SHOW_DIFFICULTY                   = false;
     public static final boolean       DEFAULT_USE_TITLE_IN_FOOTER               = false;
+    public static final boolean       DEFAULT_EXTRA_SPACE_AROUND_FP             = true;
     public static final boolean       DEFAULT_USE_KNOW_YOUR_OWN_STRENGTH        = false;
     public static final boolean       DEFAULT_USE_MODIFYING_DICE_PLUS_ADDS      = false;
     public static final boolean       DEFAULT_USE_MULTIPLICATIVE_MODIFIERS      = false;
@@ -202,6 +205,7 @@ public class Preferences {
     private        boolean                          mShowCollegeInSheetSpells;
     private        boolean                          mShowDifficulty;
     private        boolean                          mUseTitleInFooter;
+    private        boolean                          mExtraSpaceAroundFP;
 
     public static synchronized Preferences getInstance() {
         if (INSTANCE == null) {
@@ -270,6 +274,7 @@ public class Preferences {
         mShowCollegeInSheetSpells = DEFAULT_SHOW_COLLEGE_IN_SHEET_SPELLS;
         mShowDifficulty = DEFAULT_SHOW_DIFFICULTY;
         mUseTitleInFooter = DEFAULT_USE_TITLE_IN_FOOTER;
+        mExtraSpaceAroundFP = DEFAULT_EXTRA_SPACE_AROUND_FP;
         Path path = getPreferencesPath();
         if (Files.isReadable(path) && Files.isRegularFile(path)) {
             try (BufferedReader in = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
@@ -375,6 +380,7 @@ public class Preferences {
                         mShowCollegeInSheetSpells = m.getBooleanWithDefault(SHOW_COLLEGE_IN_SHEET_SPELLS, mShowCollegeInSheetSpells);
                         mShowDifficulty = m.getBooleanWithDefault(SHOW_DIFFICULTY, mShowDifficulty);
                         mUseTitleInFooter = m.getBooleanWithDefault(USE_TITLE_IN_FOOTER, mUseTitleInFooter);
+                        mExtraSpaceAroundFP = m.getBooleanWithDefault(EXTRA_SPACE_AROUND_FP, mExtraSpaceAroundFP);
                         if (m.has(THEME)) {
                             Theme.set(new Theme(m.getMap(THEME)));
                         }
@@ -526,6 +532,7 @@ public class Preferences {
                     w.keyValue(SHOW_COLLEGE_IN_SHEET_SPELLS, mShowCollegeInSheetSpells);
                     w.keyValue(SHOW_DIFFICULTY, mShowDifficulty);
                     w.keyValue(USE_TITLE_IN_FOOTER, mUseTitleInFooter);
+                    w.keyValue(EXTRA_SPACE_AROUND_FP, mExtraSpaceAroundFP);
                     w.keyValue(AUTO_NAME_NEW_CHARACTERS, mAutoNameNewCharacters);
                     w.key(THEME);
                     Theme.current().save(w);
@@ -909,6 +916,18 @@ public class Preferences {
         if (mUseTitleInFooter != show) {
             mUseTitleInFooter = show;
             mNotifier.notify(this, KEY_USE_TITLE_IN_FOOTER);
+        }
+    }
+
+    /** @return Whether or not to add extra space around FP/HP table. */
+    public boolean extraSpaceAroundFP() {
+        return mExtraSpaceAroundFP;
+    }
+
+    public void setExtraSpaceAroundFp(boolean extraSpaceAroundFP) {
+        if (mExtraSpaceAroundFP != extraSpaceAroundFP) {
+            mExtraSpaceAroundFP = extraSpaceAroundFP;
+            mNotifier.notify(this, KEY_EXTRA_SPACE_AROUND_FP);
         }
     }
 

--- a/com.trollworks.gcs/src/com/trollworks/gcs/preferences/Preferences.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/preferences/Preferences.java
@@ -92,7 +92,7 @@ public class Preferences {
     private static final String SHOW_COLLEGE_IN_SHEET_SPELLS       = "show_college_in_sheet_spells";
     private static final String SHOW_DIFFICULTY                    = "show_difficulty";
     private static final String USE_TITLE_IN_FOOTER                = "use_title_in_footer";
-    private static final String EXTRA_SPACE_AROUND_FP              = "extra_space_around_fp";
+    private static final String EXTRA_SPACE_AROUND_ENCUMBRANCE     = "extra_space_around_fp";
     private static final String THEME                              = "theme";
     private static final String TOOLTIP_TIMEOUT                    = "tooltip_timeout";
     private static final String USE_KNOW_YOUR_OWN_STRENGTH         = "use_know_your_own_strength";
@@ -120,7 +120,7 @@ public class Preferences {
     public static final String KEY_SHOW_COLLEGE_IN_SHEET_SPELLS    = KEY_PER_SHEET_PREFIX + SHOW_COLLEGE_IN_SHEET_SPELLS;
     public static final String KEY_SHOW_DIFFICULTY                 = KEY_PER_SHEET_PREFIX + SHOW_DIFFICULTY;
     public static final String KEY_USE_TITLE_IN_FOOTER             = KEY_PER_SHEET_PREFIX + USE_TITLE_IN_FOOTER;
-    public static final String KEY_EXTRA_SPACE_AROUND_FP           = KEY_PER_SHEET_PREFIX + EXTRA_SPACE_AROUND_FP;
+    public static final String KEY_EXTRA_SPACE_AROUND_ENCUMBRANCE  = KEY_PER_SHEET_PREFIX + EXTRA_SPACE_AROUND_ENCUMBRANCE;
     public static final String KEY_USE_KNOW_YOUR_OWN_STRENGTH      = KEY_PER_SHEET_PREFIX + USE_KNOW_YOUR_OWN_STRENGTH;
     public static final String KEY_USE_MODIFYING_DICE_PLUS_ADDS    = KEY_PER_SHEET_PREFIX + USE_MODIFYING_DICE_PLUS_ADDS;
     public static final String KEY_USE_MULTIPLICATIVE_MODIFIERS    = KEY_PER_SHEET_PREFIX + USE_MULTIPLICATIVE_MODIFIERS;
@@ -138,7 +138,7 @@ public class Preferences {
     public static final boolean       DEFAULT_SHOW_COLLEGE_IN_SHEET_SPELLS      = false;
     public static final boolean       DEFAULT_SHOW_DIFFICULTY                   = false;
     public static final boolean       DEFAULT_USE_TITLE_IN_FOOTER               = false;
-    public static final boolean       DEFAULT_EXTRA_SPACE_AROUND_FP             = true;
+    public static final boolean       DEFAULT_EXTRA_SPACE_AROUND_ENCUMBRANCE    = false;
     public static final boolean       DEFAULT_USE_KNOW_YOUR_OWN_STRENGTH        = false;
     public static final boolean       DEFAULT_USE_MODIFYING_DICE_PLUS_ADDS      = false;
     public static final boolean       DEFAULT_USE_MULTIPLICATIVE_MODIFIERS      = false;
@@ -205,7 +205,7 @@ public class Preferences {
     private        boolean                          mShowCollegeInSheetSpells;
     private        boolean                          mShowDifficulty;
     private        boolean                          mUseTitleInFooter;
-    private        boolean                          mExtraSpaceAroundFP;
+    private        boolean                          mExtraSpaceAroundEncumbrance;
 
     public static synchronized Preferences getInstance() {
         if (INSTANCE == null) {
@@ -274,7 +274,7 @@ public class Preferences {
         mShowCollegeInSheetSpells = DEFAULT_SHOW_COLLEGE_IN_SHEET_SPELLS;
         mShowDifficulty = DEFAULT_SHOW_DIFFICULTY;
         mUseTitleInFooter = DEFAULT_USE_TITLE_IN_FOOTER;
-        mExtraSpaceAroundFP = DEFAULT_EXTRA_SPACE_AROUND_FP;
+        mExtraSpaceAroundEncumbrance = DEFAULT_EXTRA_SPACE_AROUND_ENCUMBRANCE;
         Path path = getPreferencesPath();
         if (Files.isReadable(path) && Files.isRegularFile(path)) {
             try (BufferedReader in = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
@@ -380,7 +380,7 @@ public class Preferences {
                         mShowCollegeInSheetSpells = m.getBooleanWithDefault(SHOW_COLLEGE_IN_SHEET_SPELLS, mShowCollegeInSheetSpells);
                         mShowDifficulty = m.getBooleanWithDefault(SHOW_DIFFICULTY, mShowDifficulty);
                         mUseTitleInFooter = m.getBooleanWithDefault(USE_TITLE_IN_FOOTER, mUseTitleInFooter);
-                        mExtraSpaceAroundFP = m.getBooleanWithDefault(EXTRA_SPACE_AROUND_FP, mExtraSpaceAroundFP);
+                        mExtraSpaceAroundEncumbrance = m.getBooleanWithDefault(EXTRA_SPACE_AROUND_ENCUMBRANCE, mExtraSpaceAroundEncumbrance);
                         if (m.has(THEME)) {
                             Theme.set(new Theme(m.getMap(THEME)));
                         }
@@ -532,7 +532,7 @@ public class Preferences {
                     w.keyValue(SHOW_COLLEGE_IN_SHEET_SPELLS, mShowCollegeInSheetSpells);
                     w.keyValue(SHOW_DIFFICULTY, mShowDifficulty);
                     w.keyValue(USE_TITLE_IN_FOOTER, mUseTitleInFooter);
-                    w.keyValue(EXTRA_SPACE_AROUND_FP, mExtraSpaceAroundFP);
+                    w.keyValue(EXTRA_SPACE_AROUND_ENCUMBRANCE, mExtraSpaceAroundEncumbrance);
                     w.keyValue(AUTO_NAME_NEW_CHARACTERS, mAutoNameNewCharacters);
                     w.key(THEME);
                     Theme.current().save(w);
@@ -920,14 +920,14 @@ public class Preferences {
     }
 
     /** @return Whether or not to add extra space around FP/HP table. */
-    public boolean extraSpaceAroundFP() {
-        return mExtraSpaceAroundFP;
+    public boolean extraSpaceAroundEncumbrance() {
+        return mExtraSpaceAroundEncumbrance;
     }
 
-    public void setExtraSpaceAroundFp(boolean extraSpaceAroundFP) {
-        if (mExtraSpaceAroundFP != extraSpaceAroundFP) {
-            mExtraSpaceAroundFP = extraSpaceAroundFP;
-            mNotifier.notify(this, KEY_EXTRA_SPACE_AROUND_FP);
+    public void setExtraSpaceAroundEncumbrance(boolean extraSpaceAroundEncumbrance) {
+        if (mExtraSpaceAroundEncumbrance != extraSpaceAroundEncumbrance) {
+            mExtraSpaceAroundEncumbrance = extraSpaceAroundEncumbrance;
+            mNotifier.notify(this, KEY_EXTRA_SPACE_AROUND_ENCUMBRANCE);
         }
     }
 


### PR DESCRIPTION
Currently, when trying to fill the entire width of the page, the FP/HP panel is stretched, which results in very wide FP/HP fields. This change makes it so the encumbrance panel fills the empty space instead, which is less noticeable and that's how it was done in the old layout.