### PR TITLE
Add valid categories for freedesktop and section for dpkg/debian

### DIFF
--- a/bundler/bundler/Bundler.java
+++ b/bundler/bundler/Bundler.java
@@ -632,9 +632,9 @@ public final class Bundler {
                 args.add("--linux-deb-maintainer");
                 args.add("wilkes@me.com");
                 args.add("--linux-menu-group");
-                args.add("Roleplaying");
+                args.add("Game;Utility;RolePlaying");
                 args.add("--linux-app-category");
-                args.add("Roleplaying");
+                args.add("games");
                 args.add("--linux-rpm-license-type");
                 args.add("MPLv2.0");
                 args.add("--linux-shortcut");


### PR DESCRIPTION
Hey Rich,

I'm working on bundling GCS as an AppImage/Flatpak as we discussed in Discord and have discovered a couple of invalid settings in the Linux bundle.

The .desktop file categories are case sensitive, so `desktop-file-validate` is exiting with a code 1 when it looks at "Roleplaying" instead of "RolePlaying". This is causing `pkg2appimage` to exit as well. It's trivial, but still a problem. I'm basing the AppImage on your latest debian release so it would be helpful if these categories were updated. If you're curious about categories see the [Freedesktop Menu Spec](https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html#category-registry)

I know this debian is no ta part of any official repo, but the section is also invalid. The section is defined by `--linux-app-category` and is supposed to help people searching with `apt` find the app. Reference for valid sections [can be found here](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-section).

Please let me know if I can be of further assistance.