### PR TITLE
Add new DamageProgression of sw = thr + 2

### DIFF
--- a/com.trollworks.gcs/src/com/trollworks/gcs/settings/DamageProgression.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/settings/DamageProgression.java
@@ -131,6 +131,29 @@ public enum DamageProgression {
         public Dice calculateSwing(int strength) {
             return BASIC_SET.calculateSwing(strength);
         }
+    },
+    SWING_EQUALS_THRUST_PLUS_2 {
+        @Override
+        public String toString() {
+            return I18n.text("Swing = Thrust+2");
+        }
+
+        @Override
+        public String getFootnote() {
+            return I18n.text("Houserule originally originating with Kevyn Smith");
+        }
+
+        @Override
+        public Dice calculateThrust(int strength) {
+            return BASIC_SET.calculateThrust(strength);
+        }
+
+        @Override
+        public Dice calculateSwing(int strength) {
+            Dice dice = calculateThrust(strength);
+            dice.add(+2);
+            return dice;
+        }
     };
 
     public String getTooltip() {

--- a/com.trollworks.gcs/src/com/trollworks/gcs/settings/DamageProgression.java
+++ b/com.trollworks.gcs/src/com/trollworks/gcs/settings/DamageProgression.java
@@ -140,7 +140,7 @@ public enum DamageProgression {
 
         @Override
         public String getFootnote() {
-            return I18n.text("Houserule originally originating with Kevyn Smith");
+            return I18n.text("Houserule originating with Kevin Smyth. See https://gamingballistic.com/2020/12/04/df-eastmarch-boss-fight-and-house-rules/");
         }
 
         @Override
@@ -151,7 +151,7 @@ public enum DamageProgression {
         @Override
         public Dice calculateSwing(int strength) {
             Dice dice = calculateThrust(strength);
-            dice.add(+2);
+            dice.add(2);
             return dice;
         }
     };


### PR DESCRIPTION
Adds a new damage progression which computes sw damage as Basic Set's thr+2.

As far as I can tell, this originated with Kevin Smyth, with the goal of (a) making thr weapons competitive (and in that way working quite like `THRUST_EQUALS_SWING_MINUS_2`) and (b) making armour matter more. It's been talked about quite a bit on Douglas Cole's discord, but I don't know of any written-up post for it, just this [session recap](https://gamingballistic.com/2020/12/04/df-eastmarch-boss-fight-and-house-rules/).

Since I want to use it in my game, I thought I'd include it here.


P.S.: I really like the refactoring you did for `DamageProgression.java ` at some point after integrating the `THRUST_EQUALS_SWING_MINUS_2` pull request; that makes adding this one here a breeze!