### PR TITLE
fixes richardwilkes/gcs#518

### DIFF
--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -223,7 +223,11 @@ func (s *Skill) CellData(column int, data *CellData) {
 	case SkillRelativeLevelColumn:
 		if !s.Container() {
 			data.Type = Text
-			data.Primary = FormatRelativeSkill(s.Entity, s.Type, s.Difficulty, s.AdjustedRelativeLevel())
+			if strings.HasPrefix(s.Type, gid.Technique) {
+				data.Primary = FormatRelativeTechniqueSkill(s.Entity, s.Type, s.SkillEditData, s.AdjustedRelativeLevel())
+			} else {
+				data.Primary = FormatRelativeSkill(s.Entity, s.Type, s.Difficulty, s.AdjustedRelativeLevel())
+			}
 		}
 	case SkillPointsColumn:
 		data.Type = Text
@@ -243,6 +247,23 @@ func FormatRelativeSkill(entity *Entity, typ string, difficulty AttributeDifficu
 		return "-"
 	case strings.HasPrefix(typ, gid.Skill) || strings.HasPrefix(typ, gid.Spell):
 		s := ResolveAttributeName(entity, difficulty.Attribute)
+		rsl = rsl.Trunc()
+		if rsl != 0 {
+			s += rsl.StringWithSign()
+		}
+		return s
+	default:
+		return rsl.Trunc().StringWithSign()
+	}
+}
+
+// FormatRelativeTechniqueSkill formats the technique's relative skill for display.
+func FormatRelativeTechniqueSkill(entity *Entity, typ string, technique SkillEditData, rsl fxp.Int) string {
+	switch {
+	case rsl == fxp.Min:
+		return "-"
+	case strings.HasPrefix(typ, gid.Technique):
+		s := ResolveAttributeName(entity, technique.TechniqueDefault.DefaultType)
 		rsl = rsl.Trunc()
 		if rsl != 0 {
 			s += rsl.StringWithSign()

--- a/ui/workspace/editors/skill.go
+++ b/ui/workspace/editors/skill.go
@@ -158,10 +158,11 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 				} else {
 					rsl := level.RelativeLevel
 					if isTechnique {
-						rsl += e.editorData.TechniqueDefault.Modifier
+						field.Text = gurps.FormatRelativeTechniqueSkill(e.target.Entity, e.target.Type, *e.editorData, rsl)
+					} else {
+						field.Text = lvl.String() + "/" + gurps.FormatRelativeSkill(e.target.Entity, e.target.Type,
+							e.editorData.Difficulty, rsl)
 					}
-					field.Text = lvl.String() + "/" + gurps.FormatRelativeSkill(e.target.Entity, e.target.Type,
-						e.editorData.Difficulty, rsl)
 				}
 				field.MarkForLayoutAndRedraw()
 			})

--- a/ui/workspace/editors/skill.go
+++ b/ui/workspace/editors/skill.go
@@ -158,7 +158,7 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 				} else {
 					rsl := level.RelativeLevel
 					if isTechnique {
-						field.Text = gurps.FormatRelativeTechniqueSkill(e.target.Entity, e.target.Type, *e.editorData, rsl)
+						field.Text = lvl.String() + "/" + gurps.FormatRelativeTechniqueSkill(e.target.Entity, e.target.Type, *e.editorData, rsl)
 					} else {
 						field.Text = lvl.String() + "/" + gurps.FormatRelativeSkill(e.target.Entity, e.target.Type,
 							e.editorData.Difficulty, rsl)


### PR DESCRIPTION
FormatRelativeSkill doesn't handle Techniques and resorts to default

Added FormatRelativeTechniqueSkill to handle calls for Techniques. If FormatRelativeSkill can be safely changed to take string instead of Difficulty,  the skills could be consolidated, but wasn't sure if that would cause problems elsewhere.