### PR TITLE
Fix usage of external PDF readers

### DIFF
--- a/ui/workspace/settings/pageref_mappings.go
+++ b/ui/workspace/settings/pageref_mappings.go
@@ -123,7 +123,7 @@ Would you like to create one by choosing a PDF to map to this key?`), key), pdfN
 				}
 			} else {
 				var parts []string
-				parts, err = cmdline.Parse(strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(s.General.ExternalPDFCmdLine, "$FILE", pageRef.Path), "$PAGE", strconv.Itoa(page+pageRef.Offset))))
+				parts, err = cmdline.Parse(strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(s.General.ExternalPDFCmdLine, "$FILE", "\""+pageRef.Path+"\""), "$PAGE", strconv.Itoa(page+pageRef.Offset))))
 				errTitle := i18n.Text("Unable to use external PDF command line")
 				if err != nil {
 					unison.ErrorDialogWithError(errTitle, err)


### PR DESCRIPTION
The general setting for using external PDF readers is a great addition, but it didn't respect spaces in filepaths, causing it to break somewhat spectacularly if you have those - this change wraps the result of $PATH in quotation marks so that the full filepath is respected.