### PR TITLE
Changed how minimum weapon ST is calculated

### DIFF
--- a/model/gurps/weapon.go
+++ b/model/gurps/weapon.go
@@ -374,7 +374,16 @@ func (w *Weapon) SkillLevel(tooltip *xio.ByteBuffer) fxp.Int {
 
 func (w *Weapon) skillLevelBaseAdjustment(e *Entity, tooltip *xio.ByteBuffer) fxp.Int {
 	var adj fxp.Int
-	if minST := w.Strength.Resolve(w, nil).Min - e.StrikingStrength(); minST > 0 {
+	var minST fxp.Int
+	// If the weapon is ranged and does not use thrust/swing, we can infer that it is not muscle powered
+	// such as firearms. Melee weapons and bows use striking ST, while non-muscle-powered weapons use
+	// lifting ST.
+	if w.Type == wpn.Ranged && (w.Damage.StrengthType == stdmg.None) {
+		minST = w.Strength.Resolve(w, nil).Min - e.LiftingStrength()
+	} else {
+		minST = w.Strength.Resolve(w, nil).Min - e.StrikingStrength()
+	}
+	if minST > 0 {
 		adj -= minST
 		if tooltip != nil {
 			tooltip.WriteByte('\n')


### PR DESCRIPTION
According to rulings linked to [here](https://gurps.fandom.com/wiki/Striking_ST), GURPS should treat minimum ST for weapons differently depending on the type of weapon. Muscle-powered weapons, including all melee weapons as well as things like bows, should use Striking ST as a minimum. Non-muscle-powered weapons such as firearms should instead use Lifting ST.

This implementation covers the following cases correctly:
- All melee weapons, which should always use Striking ST.
- All muscle-powered ranged weapons such as bows, which use Striking ST.
- Most non-muscle-powered ranged weapons such as firearms, which use Lifting ST.
However, it covers some caes incorrectly, including:
- Some non-muscle-powered ranged weapons such as Crossbows, which use Lifting ST but cannot be differentiated from bows using the implemented model.

The implementation is less wrong than the current one which uses Striking ST in all cases, but currently fails to differentiate between bows and crossbows. I cannot think of a way to accomodate for this without checking against the skill used by the weapon. Doing so would cover all cases but would not be localization-friendly, so I would like to avoid it if possible.