### PR TITLE
Only send deflate encoded responses when supported

### DIFF
--- a/server/sheets.go
+++ b/server/sheets.go
@@ -124,7 +124,7 @@ func (s *Server) sheetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	response := sheet.NewSheetFromEntity(entity.Entity, entity.OriginalHash != entity.CurrentHash, access.ReadOnly)
-	CompressedJSONResponse(w, http.StatusOK, response)
+	PossiblyCompressedJSONResponse(w, r, http.StatusOK, response)
 }
 
 func (s *Server) updateSheetHandler(w http.ResponseWriter, r *http.Request) {
@@ -156,7 +156,7 @@ func (s *Server) updateSheetHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	response := sheet.NewSheetFromEntity(entity.Entity, entity.OriginalHash != entity.CurrentHash, access.ReadOnly)
-	CompressedJSONResponse(w, http.StatusOK, response)
+	PossiblyCompressedJSONResponse(w, r, http.StatusOK, response)
 }
 
 func (s *Server) saveSheetHandler(w http.ResponseWriter, r *http.Request) {
@@ -180,7 +180,7 @@ func (s *Server) saveSheetHandler(w http.ResponseWriter, r *http.Request) {
 		s.sheetsLock.Unlock()
 	}
 	response := sheet.NewSheetFromEntity(entity.Entity, entity.OriginalHash != entity.CurrentHash, access.ReadOnly)
-	CompressedJSONResponse(w, http.StatusOK, response)
+	PossiblyCompressedJSONResponse(w, r, http.StatusOK, response)
 }
 
 var errInvalid = errors.New("invalid input")


### PR DESCRIPTION
deflate is normally well-supported across browsers but MapTool only supports gzip out of the box.

It indicates this correctly by only sending gzip in Accept-Encoding though so we can test for this and only compress if it includes deflate.

I have submitted https://github.com/RPTools/maptool/pull/5016 to add support to MapTool also so it can support compressed encoding when the next release comes out.