### PR TITLE
Longer handoff timeout for app start

### DIFF
--- a/ux/handoff.go
+++ b/ux/handoff.go
@@ -11,7 +11,9 @@ package ux
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
+	"log/slog"
 	"net"
 	"path/filepath"
 	"time"
@@ -95,9 +97,12 @@ func handoff(conn net.Conn, pathsBuffer []byte) bool {
 }
 
 func waitForReady(readyChan <-chan struct{}) {
+	tStart := time.Now()
 	select {
 	case <-readyChan:
-	case <-time.After(15 * time.Second):
+		errs.LogWithLevel(context.Background(), slog.LevelInfo, slog.Default(), errs.Newf("app became ready after %fs", time.Since(tStart).Seconds()))
+		break
+	case <-time.After(120 * time.Second):
 		// This is here to try and ensure GCS doesn't hang around in the background if something goes wrong at startup.
 		// This has only ever been an issue on Windows, and I'm not sure this will actually help, but trying it anyway.
 		errs.Log(errs.New("timed out waiting for app to become ready"))


### PR DESCRIPTION
Hit #799 after 5.25, something must have gotten slower. Increasing timeout, adding a bit of extra logging.

Here is my log without and with this:

```
ERR | 2024-11-10 | 17:54:32.701 | timed out waiting for app to become ready
    [github.com/richardwilkes/gcs/v5/ux.waitForReady] C:/Users/haral/go/gcs/ux/handoff.go:103
INF | 2024-11-10 | 18:26:33.220 | app became ready after 20.396517s
    [github.com/richardwilkes/gcs/v5/ux.waitForReady] C:/Users/haral/go/gcs/ux/handoff.go:103
```