### PR TITLE
Add Loadouts: Starship Crew page reference mapping

### DIFF
--- a/ux/pageref_name_mappings.go
+++ b/ux/pageref_name_mappings.go
@@ -170,6 +170,7 @@ var PageRefKeyNameMappings = map[string]string{
 	"LMM":     "Locations: Metro of Madness",
 	"LOLTA":   "Loadouts: Low-Tech Armor",
 	"LOMH":    "Loadouts: Monster Hunters",
+	"LOSC":    "Loadouts: Starship Crew",
 	"LOT":     "Lands Out of Time",
 	"LSGC":    "Locations: St. George's Cathedral",
 	"LT":      "Low-Tech",


### PR DESCRIPTION
This adds a page reference mapping for Loadouts: Starship Crew.

I haven't used any page references for my loadouts, but the section Magazine Costs and Weights (page 8) is instructive for creating ammunition magazines for ultra-tech games.