### PR TITLE
Save GCS version to data files

### DIFF
--- a/model/gurps/campaign.go
+++ b/model/gurps/campaign.go
@@ -19,6 +19,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/kinds"
 	"github.com/richardwilkes/toolbox/v2/errs"
 	"github.com/richardwilkes/toolbox/v2/tid"
+	"github.com/richardwilkes/toolbox/v2/xos"
 )
 
 // Campaign holds the data set to be used for a campaign.
@@ -29,6 +30,7 @@ type Campaign struct {
 // CampaignData holds the campaign file data.
 type CampaignData struct {
 	Version       int            `json:"version"`
+	GCSVersion    string         `json:"gcs_version,omitzero"`
 	ID            tid.TID        `json:"id"`
 	SheetSettings *SheetSettings `json:"settings,omitzero"`
 	Traits        []*Trait       `json:"traits,omitzero"`
@@ -71,6 +73,7 @@ func (c *Campaign) Save(filePath string) error {
 // MarshalJSONTo implements json.MarshalerTo.
 func (c *Campaign) MarshalJSONTo(enc *jsontext.Encoder) error {
 	c.Version = jio.CurrentDataVersion
+	c.GCSVersion = xos.AppVersion
 	return json.MarshalEncode(enc, &c.CampaignData)
 }
 

--- a/model/gurps/entity.go
+++ b/model/gurps/entity.go
@@ -71,6 +71,7 @@ func (pb *PointsBreakdown) Total() fxp.Int {
 // EntityData holds the Entity data that is written to disk.
 type EntityData struct {
 	Version          int             `json:"version"`
+	GCSVersion       string          `json:"gcs_version,omitzero"`
 	ID               tid.TID         `json:"id"`
 	TotalPoints      fxp.Int         `json:"total_points"`
 	PointsRecord     []*PointsRecord `json:"points_record,omitzero"`
@@ -225,6 +226,7 @@ func (e *Entity) MarshalJSONTo(enc *jsontext.Encoder) error {
 		},
 	}
 	data.Version = jio.CurrentDataVersion
+	data.GCSVersion = xos.AppVersion
 	for i, one := range encumbrance.Levels {
 		data.Calc.Move[i] = e.Move(one)
 		data.Calc.Dodge[i] = e.Dodge(one)

--- a/model/gurps/loot.go
+++ b/model/gurps/loot.go
@@ -20,6 +20,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/kinds"
 	"github.com/richardwilkes/toolbox/v2/errs"
 	"github.com/richardwilkes/toolbox/v2/tid"
+	"github.com/richardwilkes/toolbox/v2/xos"
 )
 
 var (
@@ -38,6 +39,7 @@ type Loot struct {
 // LootData holds the Loot data that is written to disk.
 type LootData struct {
 	Version    int          `json:"version"`
+	GCSVersion string       `json:"gcs_version,omitzero"`
 	ID         tid.TID      `json:"id"`
 	Name       string       `json:"name,omitzero"`
 	Location   string       `json:"location,omitzero"`
@@ -76,6 +78,7 @@ func (l *Loot) Save(filePath string) error {
 func (l *Loot) MarshalJSONTo(enc *jsontext.Encoder) error {
 	l.EnsureAttachments()
 	l.Version = jio.CurrentDataVersion
+	l.GCSVersion = xos.AppVersion
 	return json.MarshalEncode(enc, &l.LootData)
 }
 

--- a/model/gurps/template.go
+++ b/model/gurps/template.go
@@ -20,6 +20,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/kinds"
 	"github.com/richardwilkes/toolbox/v2/errs"
 	"github.com/richardwilkes/toolbox/v2/tid"
+	"github.com/richardwilkes/toolbox/v2/xos"
 )
 
 var (
@@ -38,14 +39,15 @@ type Template struct {
 
 // TemplateData holds the GURPS Template data that is written to disk.
 type TemplateData struct {
-	Version   int          `json:"version"`
-	ID        tid.TID      `json:"id"`
-	Traits    []*Trait     `json:"traits,omitzero"`
-	Skills    []*Skill     `json:"skills,omitzero"`
-	Spells    []*Spell     `json:"spells,omitzero"`
-	Equipment []*Equipment `json:"equipment,omitzero"`
-	Notes     []*Note      `json:"notes,omitzero"`
-	BodyType  *Body        `json:"body_type,omitzero"`
+	Version    int          `json:"version"`
+	GCSVersion string       `json:"gcs_version,omitzero"`
+	ID         tid.TID      `json:"id"`
+	Traits     []*Trait     `json:"traits,omitzero"`
+	Skills     []*Skill     `json:"skills,omitzero"`
+	Spells     []*Spell     `json:"spells,omitzero"`
+	Equipment  []*Equipment `json:"equipment,omitzero"`
+	Notes      []*Note      `json:"notes,omitzero"`
+	BodyType   *Body        `json:"body_type,omitzero"`
 }
 
 // NewTemplateFromFile loads a Template from a file.
@@ -71,6 +73,7 @@ func NewTemplate() *Template {
 func (t *Template) MarshalJSONTo(enc *jsontext.Encoder) error {
 	t.EnsureAttachments()
 	t.Version = jio.CurrentDataVersion
+	t.GCSVersion = xos.AppVersion
 	return json.MarshalEncode(enc, &t.TemplateData)
 }
 


### PR DESCRIPTION
Fixes #1027

Stores the GCS version in the saved Campaign, Entity, and Loot files. Useful for tracking which version created each file. Just populates gcs_version from xos.AppVersion on save.