### PR TITLE
Changing metric length conversion to 25mm per inch

### DIFF
--- a/model/fxp/length_unit.go
+++ b/model/fxp/length_unit.go
@@ -33,20 +33,34 @@ func (enum LengthUnit) Format(length Length) string {
 			buffer.WriteByte('"')
 		}
 		return buffer.String()
-	case Inch:
-		return inches.String() + " " + enum.Key()
-	case Feet:
-		return inches.Div(Twelve).Comma() + " " + enum.Key()
-	case Yard, Meter:
-		return inches.Div(ThirtySix).Comma() + " " + enum.Key()
-	case Mile:
-		return inches.Div(MileInInches).Comma() + " " + enum.Key()
-	case Centimeter:
-		return inches.Div(ThirtySix).Mul(Hundred).Comma() + " " + enum.Key()
-	case Kilometer:
-		return inches.Div(ThirtySixThousand).Comma() + " " + enum.Key()
+
 	default:
-		return FeetAndInches.Format(length)
+		return enum.FromInches(inches).Comma() + " " + enum.String()
+	}
+}
+
+// FromInches converts inches to LengthUnit
+func (enum LengthUnit) FromInches(inches Int) Int {
+	switch enum {
+	case Inch:
+		return inches
+	case Feet:
+		return inches.Div(Twelve)
+	case Yard:
+		return inches.Div(ThirtySix)
+	case Mile:
+		return inches.Div(MileInInches)
+	case Centimeter:
+		// using 2.5cm per inch
+		return inches.Mul(TwoAndAHalf)
+	case Meter:
+		// forty = 100 / 2.5 cm per inch
+		return inches.Div(Forty)
+	case Kilometer:
+		// forty = 100 / 2.5 cm per inch
+		return inches.Div(Forty).Div(Thousand)
+	default:
+		return inches
 	}
 }
 
@@ -62,11 +76,14 @@ func (enum LengthUnit) ToInches(length Int) Int {
 	case Mile:
 		return length.Mul(MileInInches)
 	case Centimeter:
-		return length.Mul(ThirtySix).Div(Hundred)
-	case Kilometer:
-		return length.Mul(ThirtySixThousand)
+		// using 2.5cm per inch
+		return length.Div(TwoAndAHalf)
 	case Meter:
-		return length.Mul(ThirtySix)
+		// forty = 100 / 2.5cm per inch
+		return length.Mul(Forty)
+	case Kilometer:
+		// forty = 100 / 2.5cm per inch
+		return length.Mul(Forty).Mul(Thousand)
 	default:
 		return FeetAndInches.ToInches(length)
 	}

--- a/ux/calculator.go
+++ b/ux/calculator.go
@@ -674,6 +674,7 @@ func (c *Calculator) computeJump(broad bool) fxp.Int {
 		multiplier = fxp.Six
 		reduction = fxp.Ten
 	}
+
 	distance := (basicMove.Mul(multiplier) - reduction).Min((basicMoveWithoutRun.Mul(multiplier) - reduction).Mul(fxp.Two))
 
 	// Adjust for encumbrance
@@ -927,7 +928,7 @@ func (c *Calculator) updateHikingResult() {
 	var units string
 	if c.useMeters() {
 		// miles -> inches -> GURPS kilometers
-		distance = distance.Mul(fxp.MileInInches).Div(fxp.ThirtySixThousand)
+		distance = fxp.Kilometer.FromInches(fxp.Mile.ToInches(distance))
 		if distance == fxp.One {
 			units = i18n.Text("kilometer")
 		} else {
@@ -940,7 +941,7 @@ func (c *Calculator) updateHikingResult() {
 			units = i18n.Text("miles")
 		}
 	}
-	c.hikingResult.SetTitle(fmt.Sprintf("%s %s", distance.Comma(), units))
+	c.hikingResult.SetTitle(fmt.Sprintf("%s %s", distance.Round().Comma(), units))
 	c.hikingResult.MarkForLayoutRecursivelyUpward()
 }
 
@@ -952,7 +953,7 @@ func (c *Calculator) useMeters() bool {
 func (c *Calculator) distanceToText(inches fxp.Int) string {
 	var buffer strings.Builder
 	if c.useMeters() {
-		meters := inches.Div(fxp.ThirtySix).Mul(fxp.Hundred).Round().Div(fxp.Hundred)
+		meters := fxp.Meter.FromInches(inches).Mul(fxp.Hundred).Round().Div(fxp.Hundred)
 		if meters == fxp.One {
 			buffer.WriteString(i18n.Text("1 meter"))
 		} else {


### PR DESCRIPTION
Changed length_unit.go 
- to use 2.5cm per inch to convert to metric
- to provide LengthUnit.FromInches(int) converter
- separated conversion from formating

Changed calculator.go to use correct conversions
- also round to next whole km for hiking