### PR TITLE
Feature: Support for Optional Specialties

### DIFF
--- a/model/gurps/entity.go
+++ b/model/gurps/entity.go
@@ -1062,7 +1062,7 @@ func (e *Entity) SkillNamed(name, specialization string, requirePoints bool, exc
 // BestSkillMatching returns the highest-level skill whose name and specialization match the given criteria.
 func (e *Entity) BestSkillMatching(nameCriteria, specializationCriteria criteria.Text, replacements map[string]string, requirePoints bool, excludes map[string]bool) *Skill {
 	var best *Skill
-	level := fxp.Min
+	level := fxp.FromInteger(0)
 	for _, sk := range e.SkillMatching(nameCriteria, specializationCriteria, replacements, requirePoints, excludes) {
 		skillLevel := sk.CalculateLevel(excludes).Level
 		if best == nil || level < skillLevel {

--- a/model/gurps/entity.go
+++ b/model/gurps/entity.go
@@ -1081,9 +1081,7 @@ func (e *Entity) SkillMatching(nameCriteria, specializationCriteria criteria.Tex
 		if !excludes[sk.String()] {
 			if !requirePoints || sk.IsTechnique() || sk.AdjustedPoints(nil) > 0 {
 				if nameCriteria.Matches(replacements, sk.NameWithReplacements()) &&
-					(specializationCriteria.Matches(replacements, sk.SpecializationWithReplacements()) ||
-						(sk.SpecializationWithReplacements() == "" &&
-							specializationCriteria.Matches(replacements, sk.OptionalSpecializationWithReplacements()))) {
+					(specializationCriteria.Matches(replacements, sk.SpecializationWithReplacements()) || specializationCriteria.Matches(replacements, sk.OptionalSpecializationWithReplacements())) {
 					list = append(list, sk)
 				}
 			}

--- a/model/gurps/entity.go
+++ b/model/gurps/entity.go
@@ -511,6 +511,7 @@ func (e *Entity) processPrereqs() {
 					penalty.NameCriteria.Qualifier = s.NameWithReplacements()
 					penalty.SpecializationCriteria.Compare = criteria.IsText
 					penalty.SpecializationCriteria.Qualifier = s.SpecializationWithReplacements()
+					penalty.OptionalSpecializationCriteria.Qualifier = s.OptionalSpecializationWithReplacements()
 					if s.TechLevel != nil && *s.TechLevel != "" {
 						penalty.Amount = -fxp.Ten
 					} else {
@@ -830,7 +831,7 @@ func (e *Entity) AddDRBonusesFor(locationID string, tooltip *xbytes.InsertBuffer
 }
 
 // SkillBonusFor returns the total bonus for the matching skill bonuses.
-func (e *Entity) SkillBonusFor(name, specialization string, tags []string, tooltip *xbytes.InsertBuffer) fxp.Int {
+func (e *Entity) SkillBonusFor(name, specialization, optionalSpecialization string, tags []string, tooltip *xbytes.InsertBuffer) fxp.Int {
 	var total fxp.Int
 	for _, bonus := range e.features.skillBonuses {
 		if bonus.SelectionType == skillsel.Name {
@@ -840,6 +841,7 @@ func (e *Entity) SkillBonusFor(name, specialization string, tags []string, toolt
 			}
 			if bonus.NameCriteria.Matches(replacements, name) &&
 				bonus.SpecializationCriteria.Matches(replacements, specialization) &&
+				bonus.OptionalSpecializationCriteria.Matches(replacements, optionalSpecialization) &&
 				bonus.TagsCriteria.MatchesList(replacements, tags...) {
 				total += bonus.AdjustedAmount()
 				bonus.AddToTooltip(tooltip)
@@ -850,7 +852,7 @@ func (e *Entity) SkillBonusFor(name, specialization string, tags []string, toolt
 }
 
 // SkillPointBonusFor returns the total point bonus for the matching skill point bonuses.
-func (e *Entity) SkillPointBonusFor(name, specialization string, tags []string, tooltip *xbytes.InsertBuffer) fxp.Int {
+func (e *Entity) SkillPointBonusFor(name, specialization, optionalSpecialization string, tags []string, tooltip *xbytes.InsertBuffer) fxp.Int {
 	var total fxp.Int
 	for _, bonus := range e.features.skillPointBonuses {
 		var replacements map[string]string
@@ -859,6 +861,7 @@ func (e *Entity) SkillPointBonusFor(name, specialization string, tags []string, 
 		}
 		if bonus.NameCriteria.Matches(replacements, name) &&
 			bonus.SpecializationCriteria.Matches(replacements, specialization) &&
+			bonus.OptionalSpecializationCriteria.Matches(replacements, optionalSpecialization) &&
 			bonus.TagsCriteria.MatchesList(replacements, tags...) {
 			total += bonus.AdjustedAmount()
 			bonus.AddToTooltip(tooltip)
@@ -1038,7 +1041,7 @@ func (e *Entity) BestSkillNamed(name, specialization string, requirePoints bool,
 	return best
 }
 
-// SkillNamed returns a list of skills that match.
+// SkillNamed returns a list of skills that match by exact (case-insensitive) name and specialization.
 func (e *Entity) SkillNamed(name, specialization string, requirePoints bool, excludes map[string]bool) []*Skill {
 	var list []*Skill
 	Traverse(func(sk *Skill) bool {
@@ -1048,6 +1051,37 @@ func (e *Entity) SkillNamed(name, specialization string, requirePoints bool, exc
 					if specialization == "" || strings.EqualFold(sk.SpecializationWithReplacements(), specialization) {
 						list = append(list, sk)
 					}
+				}
+			}
+		}
+		return false
+	}, false, true, e.Skills...)
+	return list
+}
+
+// BestSkillMatching returns the highest-level skill whose name and specialization match the given criteria.
+func (e *Entity) BestSkillMatching(nameCriteria, specializationCriteria criteria.Text, replacements map[string]string, requirePoints bool, excludes map[string]bool) *Skill {
+	var best *Skill
+	level := fxp.Min
+	for _, sk := range e.SkillMatching(nameCriteria, specializationCriteria, replacements, requirePoints, excludes) {
+		skillLevel := sk.CalculateLevel(excludes).Level
+		if best == nil || level < skillLevel {
+			best = sk
+			level = skillLevel
+		}
+	}
+	return best
+}
+
+// SkillMatching returns a list of skills whose name and specialization match the given criteria.
+func (e *Entity) SkillMatching(nameCriteria, specializationCriteria criteria.Text, replacements map[string]string, requirePoints bool, excludes map[string]bool) []*Skill {
+	var list []*Skill
+	Traverse(func(sk *Skill) bool {
+		if !excludes[sk.String()] {
+			if !requirePoints || sk.IsTechnique() || sk.AdjustedPoints(nil) > 0 {
+				if nameCriteria.Matches(replacements, sk.NameWithReplacements()) &&
+					specializationCriteria.Matches(replacements, sk.SpecializationWithReplacements()) {
+					list = append(list, sk)
 				}
 			}
 		}
@@ -1193,11 +1227,14 @@ func (e *Entity) BasicLiftForST(st fxp.Int) fxp.Weight {
 	return fxp.Weight(v.Mul(fxp.Ten).Floor().Div(fxp.Ten))
 }
 
-func (e *Entity) isSkillLevelResolutionExcluded(name, specialization string) bool {
-	if e.skillResolverExclusions[e.skillLevelResolutionKey(name, specialization)] {
+func (e *Entity) isSkillLevelResolutionExcluded(name, specialization, optionalSpecialization string) bool {
+	if e.skillResolverExclusions[e.skillLevelResolutionKey(name, specialization, optionalSpecialization)] {
 		args := []any{"name", name}
 		if specialization != "" {
 			args = append(args, "specialization", specialization)
+		}
+		if optionalSpecialization != "" {
+			args = append(args, "optionalSpecialization", optionalSpecialization)
 		}
 		slog.Error("attempt to resolve skill level via itself", args...)
 		return true
@@ -1205,16 +1242,16 @@ func (e *Entity) isSkillLevelResolutionExcluded(name, specialization string) boo
 	return false
 }
 
-func (e *Entity) registerSkillLevelResolutionExclusion(name, specialization string) {
-	e.skillResolverExclusions[e.skillLevelResolutionKey(name, specialization)] = true
+func (e *Entity) registerSkillLevelResolutionExclusion(name, specialization, optionalSpecialization string) {
+	e.skillResolverExclusions[e.skillLevelResolutionKey(name, specialization, optionalSpecialization)] = true
 }
 
-func (e *Entity) unregisterSkillLevelResolutionExclusion(name, specialization string) {
-	delete(e.skillResolverExclusions, e.skillLevelResolutionKey(name, specialization))
+func (e *Entity) unregisterSkillLevelResolutionExclusion(name, specialization, optionalSpecialization string) {
+	delete(e.skillResolverExclusions, e.skillLevelResolutionKey(name, specialization, optionalSpecialization))
 }
 
-func (e *Entity) skillLevelResolutionKey(name, specialization string) string {
-	return name + "\u0000" + specialization
+func (e *Entity) skillLevelResolutionKey(name, specialization, optionalSpecialization string) string {
+	return name + "\u0000" + specialization + "\u0000" + optionalSpecialization
 }
 
 // ResolveVariable resolves a variable to a value.

--- a/model/gurps/entity.go
+++ b/model/gurps/entity.go
@@ -1062,7 +1062,7 @@ func (e *Entity) SkillNamed(name, specialization string, requirePoints bool, exc
 // BestSkillMatching returns the highest-level skill whose name and specialization match the given criteria.
 func (e *Entity) BestSkillMatching(nameCriteria, specializationCriteria criteria.Text, replacements map[string]string, requirePoints bool, excludes map[string]bool) *Skill {
 	var best *Skill
-	level := fxp.FromInteger(0)
+	var level fxp.Int
 	for _, sk := range e.SkillMatching(nameCriteria, specializationCriteria, replacements, requirePoints, excludes) {
 		skillLevel := sk.CalculateLevel(excludes).Level
 		if best == nil || level < skillLevel {

--- a/model/gurps/entity.go
+++ b/model/gurps/entity.go
@@ -1082,7 +1082,8 @@ func (e *Entity) SkillMatching(nameCriteria, specializationCriteria criteria.Tex
 			if !requirePoints || sk.IsTechnique() || sk.AdjustedPoints(nil) > 0 {
 				if nameCriteria.Matches(replacements, sk.NameWithReplacements()) &&
 					(specializationCriteria.Matches(replacements, sk.SpecializationWithReplacements()) ||
-						specializationCriteria.Matches(replacements, sk.OptionalSpecializationWithReplacements())) {
+						(sk.SpecializationWithReplacements() == "" &&
+							specializationCriteria.Matches(replacements, sk.OptionalSpecializationWithReplacements()))) {
 					list = append(list, sk)
 				}
 			}

--- a/model/gurps/entity.go
+++ b/model/gurps/entity.go
@@ -1048,7 +1048,8 @@ func (e *Entity) SkillNamed(name, specialization string, requirePoints bool, exc
 		if !excludes[sk.String()] {
 			if !requirePoints || sk.IsTechnique() || sk.AdjustedPoints(nil) > 0 {
 				if strings.EqualFold(sk.NameWithReplacements(), name) {
-					if specialization == "" || strings.EqualFold(sk.SpecializationWithReplacements(), specialization) {
+					if specialization == "" || strings.EqualFold(sk.SpecializationWithReplacements(), specialization) ||
+						strings.EqualFold(sk.OptionalSpecializationWithReplacements(), specialization) {
 						list = append(list, sk)
 					}
 				}
@@ -1080,7 +1081,8 @@ func (e *Entity) SkillMatching(nameCriteria, specializationCriteria criteria.Tex
 		if !excludes[sk.String()] {
 			if !requirePoints || sk.IsTechnique() || sk.AdjustedPoints(nil) > 0 {
 				if nameCriteria.Matches(replacements, sk.NameWithReplacements()) &&
-					specializationCriteria.Matches(replacements, sk.SpecializationWithReplacements()) {
+					(specializationCriteria.Matches(replacements, sk.SpecializationWithReplacements()) ||
+						specializationCriteria.Matches(replacements, sk.OptionalSpecializationWithReplacements())) {
 					list = append(list, sk)
 				}
 			}

--- a/model/gurps/natural_attacks.go
+++ b/model/gurps/natural_attacks.go
@@ -10,10 +10,15 @@
 package gurps
 
 import (
+	"github.com/richardwilkes/gcs/v5/model/criteria"
 	"github.com/richardwilkes/gcs/v5/model/fxp"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/stdmg"
 	"github.com/richardwilkes/toolbox/v2/i18n"
 )
+
+func skillName(name string) criteria.Text {
+	return criteria.Text{TextData: criteria.TextData{Compare: criteria.IsText, Qualifier: name}}
+}
 
 // NewNaturalAttacks creates a new "Natural Attacks" trait.
 func NewNaturalAttacks(entity *Entity, parent *Trait) *Trait {
@@ -36,7 +41,7 @@ func newBite(owner WeaponOwner) *Weapon {
 		},
 		{
 			DefaultType: SkillID,
-			Name:        "Brawling",
+			Name:        skillName("Brawling"),
 		},
 	}
 	bite.Damage.Type = "cr"
@@ -61,15 +66,15 @@ func newPunch(owner WeaponOwner) *Weapon {
 		},
 		{
 			DefaultType: SkillID,
-			Name:        "Boxing",
+			Name:        skillName("Boxing"),
 		},
 		{
 			DefaultType: SkillID,
-			Name:        "Brawling",
+			Name:        skillName("Brawling"),
 		},
 		{
 			DefaultType: SkillID,
-			Name:        "Karate",
+			Name:        skillName("Karate"),
 		},
 	}
 	punch.Damage.Type = "cr"
@@ -94,16 +99,16 @@ func newKick(owner WeaponOwner) *Weapon {
 		},
 		{
 			DefaultType: SkillID,
-			Name:        "Brawling",
+			Name:        skillName("Brawling"),
 			Modifier:    -fxp.Two,
 		},
 		{
 			DefaultType: SkillID,
-			Name:        "Kicking",
+			Name:        skillName("Kicking"),
 		},
 		{
 			DefaultType: SkillID,
-			Name:        "Karate",
+			Name:        skillName("Karate"),
 			Modifier:    -fxp.Two,
 		},
 	}

--- a/model/gurps/scripting_entity.go
+++ b/model/gurps/scripting_entity.go
@@ -156,11 +156,12 @@ func newScriptEntity(r *goja.Runtime, entity *Entity) *goja.Object {
 			return r.ToValue(func(call goja.FunctionCall) goja.Value {
 				name := callArgAsTrimmedString(call, 0)
 				specialization := callArgAsTrimmedString(call, 1)
-				if entity.isSkillLevelResolutionExcluded(name, specialization) {
+				optionalSpecialization := callArgAsTrimmedString(call, 2)
+				if entity.isSkillLevelResolutionExcluded(name, specialization, optionalSpecialization) {
 					return r.ToValue(0)
 				}
-				entity.registerSkillLevelResolutionExclusion(name, specialization)
-				defer entity.unregisterSkillLevelResolutionExclusion(name, specialization)
+				entity.registerSkillLevelResolutionExclusion(name, specialization, optionalSpecialization)
+				defer entity.unregisterSkillLevelResolutionExclusion(name, specialization, optionalSpecialization)
 				relative := call.Argument(2).ToBoolean()
 				var level int
 				Traverse(func(s *Skill) bool {

--- a/model/gurps/scripting_skill.go
+++ b/model/gurps/scripting_skill.go
@@ -89,10 +89,10 @@ func newScriptSkill(r *goja.Runtime, skill *Skill) *goja.Object {
 			if entity == nil {
 				return r.ToValue(0)
 			}
-			if !entity.isSkillLevelResolutionExcluded(skill.Name, skill.Specialization) {
-				entity.registerSkillLevelResolutionExclusion(skill.Name, skill.Specialization)
+			if !entity.isSkillLevelResolutionExcluded(skill.Name, skill.Specialization, skill.OptionalSpecialization) {
+				entity.registerSkillLevelResolutionExclusion(skill.Name, skill.Specialization, skill.OptionalSpecialization)
 				skill.UpdateLevel()
-				entity.unregisterSkillLevelResolutionExclusion(skill.Name, skill.Specialization)
+				entity.unregisterSkillLevelResolutionExclusion(skill.Name, skill.Specialization, skill.OptionalSpecialization)
 			}
 			return r.ToValue(fxp.AsInteger[int](skill.LevelData.Level))
 		}
@@ -101,10 +101,10 @@ func newScriptSkill(r *goja.Runtime, skill *Skill) *goja.Object {
 			if entity == nil {
 				return r.ToValue(0)
 			}
-			if !entity.isSkillLevelResolutionExcluded(skill.Name, skill.Specialization) {
-				entity.registerSkillLevelResolutionExclusion(skill.Name, skill.Specialization)
+			if !entity.isSkillLevelResolutionExcluded(skill.Name, skill.Specialization, skill.OptionalSpecialization) {
+				entity.registerSkillLevelResolutionExclusion(skill.Name, skill.Specialization, skill.OptionalSpecialization)
 				skill.UpdateLevel()
-				entity.unregisterSkillLevelResolutionExclusion(skill.Name, skill.Specialization)
+				entity.unregisterSkillLevelResolutionExclusion(skill.Name, skill.Specialization, skill.OptionalSpecialization)
 			}
 			return r.ToValue(fxp.AsInteger[int](skill.LevelData.RelativeLevel))
 		}

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -548,7 +548,8 @@ func (s *Skill) HasDefaultTo(other *Skill) bool {
 	for _, def := range s.resolveToSpecificDefaults() {
 		if def.SkillBased() && def.NameWithReplacements(s.Replacements) == other.NameWithReplacements() {
 			specialization := def.SpecializationWithReplacements(s.Replacements)
-			if specialization == "" || specialization == other.SpecializationWithReplacements() {
+			if specialization == "" || specialization == other.SpecializationWithReplacements() ||
+				specialization == other.OptionalSpecializationWithReplacements() {
 				return true
 			}
 		}
@@ -1002,7 +1003,11 @@ func (s *Skill) resolveToSpecificDefaults() []*SkillDefault {
 				local.Name.Compare = criteria.IsText
 				local.Name.Qualifier = one.NameWithReplacements()
 				local.Specialization.Compare = criteria.IsText
-				local.Specialization.Qualifier = one.SpecializationWithReplacements()
+				if spec := one.SpecializationWithReplacements(); spec != "" {
+					local.Specialization.Qualifier = spec
+				} else {
+					local.Specialization.Qualifier = one.OptionalSpecializationWithReplacements()
+				}
 				if one.OptionalSpecializationWithReplacements() != "" {
 					local.Modifier -= fxp.Two
 				}
@@ -1019,7 +1024,11 @@ func (s *Skill) resolveToSpecificDefaults() []*SkillDefault {
 				def.Name.Compare = criteria.IsText
 				def.Name.Qualifier = one.NameWithReplacements()
 				def.Specialization.Compare = criteria.IsText
-				def.Specialization.Qualifier = one.SpecializationWithReplacements()
+				if spec := one.SpecializationWithReplacements(); spec != "" {
+					def.Specialization.Qualifier = spec
+				} else {
+					def.Specialization.Qualifier = one.OptionalSpecializationWithReplacements()
+				}
 				result = append(result, def)
 			}
 		}

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -185,19 +185,18 @@ func skillKind(container bool) byte {
 }
 
 // NewTechnique creates a new technique (i.e. a specialized use of a Skill). All parameters may be nil or empty.
-func NewTechnique(owner DataOwner, parent *Skill, skillName string) *Skill {
+func NewTechnique(owner DataOwner, parent *Skill, skillName criteria.Text) *Skill {
 	var s Skill
 	s.TID = tid.MustNewTID(kinds.Technique)
 	s.parent = parent
 	s.owner = owner
 	s.Difficulty.Difficulty = difficulty.Average
 	s.Points = fxp.One
-	if skillName == "" {
-		skillName = i18n.Text("Skill")
+	if skillName.Qualifier == "" {
+		skillName.Qualifier = i18n.Text("Skill")
 	}
 	s.TechniqueDefault = &SkillDefault{DefaultType: SkillID}
-	s.TechniqueDefault.Name.Compare = criteria.IsText
-	s.TechniqueDefault.Name.Qualifier = skillName
+	s.TechniqueDefault.Name = skillName
 	s.Name = s.Kind()
 	return &s
 }
@@ -256,7 +255,7 @@ func (s *Skill) IsTechnique() bool {
 func (s *Skill) Clone(from LibraryFile, owner DataOwner, parent *Skill, preserveID bool) *Skill {
 	var other *Skill
 	if s.IsTechnique() {
-		other = NewTechnique(owner, parent, s.TechniqueDefault.Name.Qualifier)
+		other = NewTechnique(owner, parent, s.TechniqueDefault.Name)
 	} else {
 		other = NewSkill(owner, parent, s.Container())
 		other.SetOpen(s.IsOpen())

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -943,7 +943,7 @@ func (s *Skill) bestDefault(excluded *SkillDefault) *SkillDefault {
 	best := fxp.Min
 	for _, def := range s.resolveToSpecificDefaults() {
 		// For skill-based defaults, prune out any that already use a default that we are involved with
-		if def.Equivalent(s.Replacements, excluded) || s.inDefaultChain(def, make(map[*Skill]bool), excludes) {
+		if def.Equivalent(s.Replacements, excluded) || s.inDefaultChain(def, make(map[*Skill]bool)) {
 			continue
 		}
 		if level := s.calcSkillDefaultLevel(def, excludes); best < level {
@@ -970,18 +970,18 @@ func (s *Skill) calcSkillDefaultLevel(def *SkillDefault, excludes map[string]boo
 	return level
 }
 
-func (s *Skill) inDefaultChain(def *SkillDefault, lookedAt map[*Skill]bool, excludes map[string]bool) bool {
+func (s *Skill) inDefaultChain(def *SkillDefault, lookedAt map[*Skill]bool) bool {
 	e := EntityFromNode(s)
 	if e == nil || def == nil || !def.SkillBased() {
 		return false
 	}
-	for _, one := range e.SkillMatching(def.Name, def.Specialization, s.Replacements, true, excludes) {
+	for _, one := range e.SkillMatching(def.Name, def.Specialization, s.Replacements, true, nil) {
 		if one == s {
 			return true
 		}
 		if !lookedAt[one] {
 			lookedAt[one] = true
-			if s.inDefaultChain(one.DefaultedFrom, lookedAt, excludes) {
+			if s.inDefaultChain(one.DefaultedFrom, lookedAt) {
 				return true
 			}
 		}

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -105,6 +105,7 @@ type SkillSyncData struct {
 // SkillNonContainerOnlySyncData holds the Skill sync data that is only applicable to skills that aren't containers.
 type SkillNonContainerOnlySyncData struct {
 	Specialization               string              `json:"specialization,omitzero"`
+	OptionalSpecialization       string              `json:"optional_specialization,omitzero"`
 	Difficulty                   AttributeDifficulty `json:"difficulty,omitzero"`
 	EncumbrancePenaltyMultiplier fxp.Int             `json:"encumbrance_penalty_multiplier,omitzero"`
 	Defaults                     []*SkillDefault     `json:"defaults,omitzero"`
@@ -410,7 +411,8 @@ func (s *Skill) CellData(columnID int, data *CellData) {
 	case SkillDifficultyColumn:
 		if !s.Container() {
 			data.Type = cell.Text
-			data.Primary = s.Difficulty.Description(EntityFromNode(s))
+			diff := s.AdjustedDifficulty()
+			data.Primary = diff.Description(EntityFromNode(s))
 		}
 	case SkillTagsColumn:
 		data.Type = cell.Tags
@@ -436,7 +438,7 @@ func (s *Skill) CellData(columnID int, data *CellData) {
 	case SkillRelativeLevelColumn:
 		if !s.Container() {
 			data.Type = cell.Text
-			data.Primary = FormatRelativeSkill(EntityFromNode(s), s.IsTechnique(), s.Difficulty,
+			data.Primary = FormatRelativeSkill(EntityFromNode(s), s.IsTechnique(), s.AdjustedDifficulty(),
 				s.AdjustedRelativeLevel())
 			if tooltip := s.CalculateLevel(nil).Tooltip; tooltip != "" {
 				data.Tooltip = IncludesModifiersFrom() + ":" + tooltip
@@ -602,9 +604,18 @@ func (s *Skill) String() string {
 			buffer.WriteString("/TL")
 			buffer.WriteString(*s.TechLevel)
 		}
-		if s.Specialization != "" {
+		if s.Specialization != "" || s.OptionalSpecialization != "" {
 			buffer.WriteString(" (")
-			buffer.WriteString(s.SpecializationWithReplacements())
+			if s.Specialization != "" {
+				buffer.WriteString(s.SpecializationWithReplacements())
+
+				if s.OptionalSpecialization != "" {
+					buffer.WriteString(", ")
+				}
+			}
+			if s.OptionalSpecialization != "" {
+				buffer.WriteString(s.OptionalSpecializationWithReplacements())
+			}
 			buffer.WriteByte(')')
 		}
 	}
@@ -633,7 +644,7 @@ func (s *Skill) RelativeLevel() string {
 	case s.IsTechnique():
 		return rsl.StringWithSign()
 	default:
-		return ResolveAttributeName(EntityFromNode(s), s.Difficulty.Attribute) + rsl.StringWithSign()
+		return ResolveAttributeName(EntityFromNode(s), s.AdjustedDifficulty().Attribute) + rsl.StringWithSign()
 	}
 }
 
@@ -673,6 +684,19 @@ func (s *Skill) AdjustedPoints(tooltip *xbytes.InsertBuffer) fxp.Int {
 	}
 	return AdjustedPointsForNonContainerSkillOrTechnique(EntityFromNode(s), s.Points, s.NameWithReplacements(),
 		s.SpecializationWithReplacements(), s.Tags, tooltip)
+}
+
+// AdjustedDifficulty returns the difficulty, adjusted in case of an optional specialization.
+func (s *Skill) AdjustedDifficulty() AttributeDifficulty {
+	diff := s.Difficulty
+
+	if s.OptionalSpecializationWithReplacements() != "" {
+		if diff.Difficulty > difficulty.Easy && diff.Difficulty != difficulty.Wildcard {
+			diff.Difficulty--
+		}
+	}
+
+	return diff
 }
 
 // AdjustedPointsForNonContainerSkillOrTechnique returns the points, adjusted for any bonuses.
@@ -1028,6 +1052,11 @@ func (s *Skill) NameWithReplacements() string {
 // SpecializationWithReplacements returns the specialization with any replacements applied.
 func (s *Skill) SpecializationWithReplacements() string {
 	return nameable.Apply(s.Specialization, s.Replacements)
+}
+
+// OptionalSpecializationWithReplacements returns the optional specialization with any replacements applied.
+func (s *Skill) OptionalSpecializationWithReplacements() string {
+	return nameable.Apply(s.OptionalSpecialization, s.Replacements)
 }
 
 // LocalNotesWithReplacements returns the local notes with any replacements applied.

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -185,18 +185,25 @@ func skillKind(container bool) byte {
 }
 
 // NewTechnique creates a new technique (i.e. a specialized use of a Skill). All parameters may be nil or empty.
-func NewTechnique(owner DataOwner, parent *Skill, skillName criteria.Text) *Skill {
+func NewTechnique(owner DataOwner, parent *Skill, skillName string) *Skill {
 	var s Skill
 	s.TID = tid.MustNewTID(kinds.Technique)
 	s.parent = parent
 	s.owner = owner
 	s.Difficulty.Difficulty = difficulty.Average
 	s.Points = fxp.One
-	if skillName.Qualifier == "" {
-		skillName.Qualifier = i18n.Text("Skill")
+	if skillName == "" {
+		skillName = i18n.Text("Skill")
 	}
-	s.TechniqueDefault = &SkillDefault{DefaultType: SkillID}
-	s.TechniqueDefault.Name = skillName
+	s.TechniqueDefault = &SkillDefault{
+		DefaultType: SkillID,
+		Name: criteria.Text{
+			TextData: criteria.TextData{
+				Qualifier: skillName,
+				Compare:   criteria.IsText,
+			},
+		},
+	}
 	s.Name = s.Kind()
 	return &s
 }
@@ -255,7 +262,7 @@ func (s *Skill) IsTechnique() bool {
 func (s *Skill) Clone(from LibraryFile, owner DataOwner, parent *Skill, preserveID bool) *Skill {
 	var other *Skill
 	if s.IsTechnique() {
-		other = NewTechnique(owner, parent, s.TechniqueDefault.Name)
+		other = NewTechnique(owner, parent, s.TechniqueDefault.Name.Qualifier)
 	} else {
 		other = NewSkill(owner, parent, s.Container())
 		other.SetOpen(s.IsOpen())
@@ -341,6 +348,9 @@ func (s *Skill) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 		setOpen = localData.IsOpen
 	}
 	s.SkillData = localData.SkillData
+	if s.TechniqueDefault != nil {
+		s.TechniqueDefault.Name.Compare = criteria.IsText
+	}
 	if s.LocalNotes == "" && localData.ExprNotes != "" {
 		s.LocalNotes = EmbeddedExprToScript(localData.ExprNotes)
 	}

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -19,6 +19,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/richardwilkes/gcs/v5/model/criteria"
 	"github.com/richardwilkes/gcs/v5/model/fxp"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/cell"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/difficulty"
@@ -194,10 +195,9 @@ func NewTechnique(owner DataOwner, parent *Skill, skillName string) *Skill {
 	if skillName == "" {
 		skillName = i18n.Text("Skill")
 	}
-	s.TechniqueDefault = &SkillDefault{
-		DefaultType: SkillID,
-		Name:        skillName,
-	}
+	s.TechniqueDefault = &SkillDefault{DefaultType: SkillID}
+	s.TechniqueDefault.Name.Compare = criteria.IsText
+	s.TechniqueDefault.Name.Qualifier = skillName
 	s.Name = s.Kind()
 	return &s
 }
@@ -256,7 +256,7 @@ func (s *Skill) IsTechnique() bool {
 func (s *Skill) Clone(from LibraryFile, owner DataOwner, parent *Skill, preserveID bool) *Skill {
 	var other *Skill
 	if s.IsTechnique() {
-		other = NewTechnique(owner, parent, s.TechniqueDefault.Name)
+		other = NewTechnique(owner, parent, s.TechniqueDefault.Name.Qualifier)
 	} else {
 		other = NewSkill(owner, parent, s.Container())
 		other.SetOpen(s.IsOpen())
@@ -683,7 +683,7 @@ func (s *Skill) AdjustedPoints(tooltip *xbytes.InsertBuffer) fxp.Int {
 		return total
 	}
 	return AdjustedPointsForNonContainerSkillOrTechnique(EntityFromNode(s), s.Points, s.NameWithReplacements(),
-		s.SpecializationWithReplacements(), s.Tags, tooltip)
+		s.SpecializationWithReplacements(), s.OptionalSpecializationWithReplacements(), s.Tags, tooltip)
 }
 
 // AdjustedDifficulty returns the difficulty, adjusted in case of an optional specialization.
@@ -700,9 +700,9 @@ func (s *Skill) AdjustedDifficulty() AttributeDifficulty {
 }
 
 // AdjustedPointsForNonContainerSkillOrTechnique returns the points, adjusted for any bonuses.
-func AdjustedPointsForNonContainerSkillOrTechnique(e *Entity, points fxp.Int, name, specialization string, tags []string, tooltip *xbytes.InsertBuffer) fxp.Int {
+func AdjustedPointsForNonContainerSkillOrTechnique(e *Entity, points fxp.Int, name, specialization string, optionalSpecialization string, tags []string, tooltip *xbytes.InsertBuffer) fxp.Int {
 	if e != nil {
-		points += e.SkillPointBonusFor(name, specialization, tags, tooltip)
+		points += e.SkillPointBonusFor(name, specialization, optionalSpecialization, tags, tooltip)
 		points = points.Max(0)
 	}
 	return points
@@ -713,7 +713,7 @@ func (s *Skill) IncrementSkillLevel() {
 	if !s.Container() {
 		basePoints := s.Points.Floor() + fxp.One
 		maxPoints := basePoints
-		if s.Difficulty.Difficulty == difficulty.Wildcard {
+		if s.AdjustedDifficulty().Difficulty == difficulty.Wildcard {
 			maxPoints += fxp.Twelve
 		} else {
 			maxPoints += fxp.Four
@@ -733,7 +733,7 @@ func (s *Skill) DecrementSkillLevel() {
 	if !s.Container() && s.Points > 0 {
 		basePoints := s.Points.Floor()
 		minPoints := basePoints
-		if s.Difficulty.Difficulty == difficulty.Wildcard {
+		if s.AdjustedDifficulty().Difficulty == difficulty.Wildcard {
 			minPoints -= fxp.Twelve
 		} else {
 			minPoints -= fxp.Four
@@ -764,15 +764,15 @@ func (s *Skill) CalculateLevel(excludes map[string]bool) Level {
 	points := s.AdjustedPoints(nil)
 	if s.IsTechnique() {
 		return CalculateTechniqueLevel(EntityFromNode(s), s.Replacements, s.NameWithReplacements(),
-			s.SpecializationWithReplacements(), s.Tags, s.TechniqueDefault, s.Difficulty.Difficulty, points, true,
+			s.SpecializationWithReplacements(), s.Tags, s.TechniqueDefault, s.AdjustedDifficulty().Difficulty, points, true,
 			s.TechniqueLimitModifier, excludes)
 	}
-	return CalculateSkillLevel(EntityFromNode(s), s.NameWithReplacements(), s.SpecializationWithReplacements(), s.Tags,
-		s.DefaultedFrom, s.Difficulty, points, s.EncumbrancePenaltyMultiplier)
+	return CalculateSkillLevel(EntityFromNode(s), s.NameWithReplacements(), s.SpecializationWithReplacements(), s.OptionalSpecializationWithReplacements(), s.Tags,
+		s.DefaultedFrom, s.AdjustedDifficulty(), points, s.EncumbrancePenaltyMultiplier)
 }
 
 // CalculateSkillLevel returns the calculated level for a skill.
-func CalculateSkillLevel(e *Entity, name, specialization string, tags []string, def *SkillDefault, attrDiff AttributeDifficulty, points, encumbrancePenaltyMultiplier fxp.Int) Level {
+func CalculateSkillLevel(e *Entity, name, specialization string, optionalSpecialization string, tags []string, def *SkillDefault, attrDiff AttributeDifficulty, points, encumbrancePenaltyMultiplier fxp.Int) Level {
 	var tooltip xbytes.InsertBuffer
 	relativeLevel := attrDiff.Difficulty.BaseRelativeLevel()
 	level := e.ResolveAttributeCurrent(attrDiff.Attribute)
@@ -805,7 +805,7 @@ func CalculateSkillLevel(e *Entity, name, specialization string, tags []string, 
 				level = def.AdjLevel
 			}
 			if e != nil {
-				bonus := e.SkillBonusFor(name, specialization, tags, &tooltip)
+				bonus := e.SkillBonusFor(name, specialization, optionalSpecialization, tags, &tooltip)
 				level += bonus
 				relativeLevel += bonus
 				bonus = e.EncumbranceLevel(true).Penalty().Mul(encumbrancePenaltyMultiplier)
@@ -873,7 +873,7 @@ func CalculateTechniqueLevel(e *Entity, replacements map[string]string, name, sp
 				relativeLevel = points
 			}
 			if level != fxp.Min {
-				relativeLevel += e.SkillBonusFor(name, specialization, tags, &tooltip)
+				relativeLevel += e.SkillBonusFor(name, specialization, "", tags, &tooltip)
 				level += relativeLevel
 			}
 			if limitModifier != nil {
@@ -905,8 +905,8 @@ func (s *Skill) bestDefaultWithPoints(excluded *SkillDefault) *SkillDefault {
 	}
 	best := s.bestDefault(excluded)
 	if best != nil {
-		baseLine := (EntityFromNode(s).ResolveAttributeCurrent(s.Difficulty.Attribute) +
-			s.Difficulty.Difficulty.BaseRelativeLevel()).Floor()
+		baseLine := (EntityFromNode(s).ResolveAttributeCurrent(s.AdjustedDifficulty().Attribute) +
+			s.AdjustedDifficulty().Difficulty.BaseRelativeLevel()).Floor()
 		level := best.Level.Floor()
 		best.AdjLevel = level
 		switch {
@@ -924,7 +924,7 @@ func (s *Skill) bestDefaultWithPoints(excluded *SkillDefault) *SkillDefault {
 }
 
 func (s *Skill) bestDefault(excluded *SkillDefault) *SkillDefault {
-	if EntityFromNode(s) == nil || len(s.Defaults) == 0 {
+	if EntityFromNode(s) == nil {
 		return nil
 	}
 	excludes := make(map[string]bool)
@@ -933,7 +933,7 @@ func (s *Skill) bestDefault(excluded *SkillDefault) *SkillDefault {
 	best := fxp.Min
 	for _, def := range s.resolveToSpecificDefaults() {
 		// For skill-based defaults, prune out any that already use a default that we are involved with
-		if def.Equivalent(s.Replacements, excluded) || s.inDefaultChain(def, make(map[*Skill]bool)) {
+		if def.Equivalent(s.Replacements, excluded) || s.inDefaultChain(def, make(map[*Skill]bool), excludes) {
 			continue
 		}
 		if level := s.calcSkillDefaultLevel(def, excludes); best < level {
@@ -949,28 +949,26 @@ func (s *Skill) calcSkillDefaultLevel(def *SkillDefault, excludes map[string]boo
 	e := EntityFromNode(s)
 	level := def.SkillLevel(e, s.Replacements, true, excludes, !s.IsTechnique())
 	if def.SkillBased() {
-		defName := def.NameWithReplacements(s.Replacements)
-		defSpec := def.SpecializationWithReplacements(s.Replacements)
-		if other := e.BestSkillNamed(defName, defSpec, true, excludes); other != nil {
-			level -= e.SkillBonusFor(defName, defSpec, s.Tags, nil)
+		if other := e.BestSkillMatching(def.Name, def.Specialization, s.Replacements, true, excludes); other != nil {
+			level -= e.SkillBonusFor(other.NameWithReplacements(), other.SpecializationWithReplacements(),
+				other.OptionalSpecializationWithReplacements(), s.Tags, nil)
 		}
 	}
 	return level
 }
 
-func (s *Skill) inDefaultChain(def *SkillDefault, lookedAt map[*Skill]bool) bool {
+func (s *Skill) inDefaultChain(def *SkillDefault, lookedAt map[*Skill]bool, excludes map[string]bool) bool {
 	e := EntityFromNode(s)
 	if e == nil || def == nil || !def.SkillBased() {
 		return false
 	}
-	for _, one := range e.SkillNamed(def.NameWithReplacements(s.Replacements),
-		def.SpecializationWithReplacements(s.Replacements), true, nil) {
+	for _, one := range e.SkillMatching(def.Name, def.Specialization, s.Replacements, true, excludes) {
 		if one == s {
 			return true
 		}
 		if !lookedAt[one] {
 			lookedAt[one] = true
-			if s.inDefaultChain(one.DefaultedFrom, lookedAt) {
+			if s.inDefaultChain(one.DefaultedFrom, lookedAt, nil) {
 				return true
 			}
 		}
@@ -980,21 +978,41 @@ func (s *Skill) inDefaultChain(def *SkillDefault, lookedAt map[*Skill]bool) bool
 
 func (s *Skill) resolveToSpecificDefaults() []*SkillDefault {
 	e := EntityFromNode(s)
+
 	result := make([]*SkillDefault, 0, len(s.Defaults))
 	for _, def := range s.Defaults {
 		if e == nil || def == nil || !def.SkillBased() {
 			result = append(result, def)
 		} else {
-			for _, one := range e.SkillNamed(def.NameWithReplacements(s.Replacements),
-				def.SpecializationWithReplacements(s.Replacements), true,
+			for _, one := range e.SkillMatching(def.Name, def.Specialization, s.Replacements, true,
 				map[string]bool{s.String(): true}) {
 				local := *def
-				local.Name = one.NameWithReplacements()
-				local.Specialization = one.SpecializationWithReplacements()
+				local.Name.Compare = criteria.IsText
+				local.Name.Qualifier = one.NameWithReplacements()
+				local.Specialization.Compare = criteria.IsText
+				local.Specialization.Qualifier = one.SpecializationWithReplacements()
+				if one.OptionalSpecializationWithReplacements() != "" {
+					local.Modifier -= fxp.Two
+				}
 				result = append(result, &local)
 			}
 		}
 	}
+
+	if e != nil && s.OptionalSpecializationWithReplacements() == "" {
+		excludes := map[string]bool{s.String(): true}
+		for _, one := range e.SkillNamed(s.NameWithReplacements(), s.SpecializationWithReplacements(), true, excludes) {
+			if one.OptionalSpecializationWithReplacements() != "" {
+				def := &SkillDefault{DefaultType: SkillID, Modifier: -fxp.Two}
+				def.Name.Compare = criteria.IsText
+				def.Name.Qualifier = one.NameWithReplacements()
+				def.Specialization.Compare = criteria.IsText
+				def.Specialization.Qualifier = one.SpecializationWithReplacements()
+				result = append(result, def)
+			}
+		}
+	}
+
 	return result
 }
 
@@ -1075,7 +1093,7 @@ func (s *Skill) ModifierNotes() string {
 		return i18n.Text("Default: ") + s.TechniqueDefault.FullName(EntityFromNode(s), s.Replacements) +
 			s.TechniqueDefault.ModifierAsString()
 	}
-	if s.Difficulty.Difficulty != difficulty.Wildcard {
+	if s.AdjustedDifficulty().Difficulty != difficulty.Wildcard {
 		defSkill := s.DefaultSkill()
 		if defSkill != nil && s.DefaultedFrom != nil {
 			return i18n.Text("Default: ") + defSkill.String() + s.DefaultedFrom.ModifierAsString()
@@ -1235,8 +1253,8 @@ func (s *Skill) SyncWithSource() {
 						def := *other.TechniqueDefault
 						s.TechniqueDefault = &def
 						if !DefaultTypeIsSkillBased(other.TechniqueDefault.DefaultType) {
-							s.TechniqueDefault.Name = ""
-							s.TechniqueDefault.Specialization = ""
+							s.TechniqueDefault.Name = criteria.Text{}
+							s.TechniqueDefault.Specialization = criteria.Text{}
 						}
 					}
 					if other.TechniqueLimitModifier != nil {
@@ -1337,8 +1355,8 @@ func (s *SkillEditData) copyFrom(other *SkillEditData, isContainer, isApply, isT
 			def := *other.TechniqueDefault
 			s.TechniqueDefault = &def
 			if !DefaultTypeIsSkillBased(other.TechniqueDefault.DefaultType) {
-				s.TechniqueDefault.Name = ""
-				s.TechniqueDefault.Specialization = ""
+				s.TechniqueDefault.Name.Qualifier = ""
+				s.TechniqueDefault.Specialization.Qualifier = ""
 			}
 		}
 		if other.TechniqueLimitModifier != nil {

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -713,7 +713,7 @@ func (s *Skill) IncrementSkillLevel() {
 	if !s.Container() {
 		basePoints := s.Points.Floor() + fxp.One
 		maxPoints := basePoints
-		if s.AdjustedDifficulty().Difficulty == difficulty.Wildcard {
+		if s.Difficulty.Difficulty == difficulty.Wildcard {
 			maxPoints += fxp.Twelve
 		} else {
 			maxPoints += fxp.Four
@@ -733,7 +733,7 @@ func (s *Skill) DecrementSkillLevel() {
 	if !s.Container() && s.Points > 0 {
 		basePoints := s.Points.Floor()
 		minPoints := basePoints
-		if s.AdjustedDifficulty().Difficulty == difficulty.Wildcard {
+		if s.Difficulty.Difficulty == difficulty.Wildcard {
 			minPoints -= fxp.Twelve
 		} else {
 			minPoints -= fxp.Four

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -1008,7 +1008,8 @@ func (s *Skill) resolveToSpecificDefaults() []*SkillDefault {
 				} else {
 					local.Specialization.Qualifier = one.OptionalSpecializationWithReplacements()
 				}
-				if one.OptionalSpecializationWithReplacements() != "" {
+				if one.OptionalSpecializationWithReplacements() != "" &&
+					def.Specialization.Matches(s.Replacements, one.SpecializationWithReplacements()) {
 					local.Modifier -= fxp.Two
 				}
 				result = append(result, &local)

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -968,7 +968,7 @@ func (s *Skill) inDefaultChain(def *SkillDefault, lookedAt map[*Skill]bool, excl
 		}
 		if !lookedAt[one] {
 			lookedAt[one] = true
-			if s.inDefaultChain(one.DefaultedFrom, lookedAt, nil) {
+			if s.inDefaultChain(one.DefaultedFrom, lookedAt, excludes) {
 				return true
 			}
 		}

--- a/model/gurps/skill_bonus.go
+++ b/model/gurps/skill_bonus.go
@@ -32,11 +32,12 @@ type SkillBonus struct {
 
 // SkillBonusData holds an adjustment to a skill which is persisted.
 type SkillBonusData struct {
-	Type                   feature.Type  `json:"type"`
-	SelectionType          skillsel.Type `json:"selection_type"`
-	NameCriteria           criteria.Text `json:"name,omitzero"`
-	SpecializationCriteria criteria.Text `json:"specialization,omitzero"`
-	TagsCriteria           criteria.Text `json:"tags,omitzero"`
+	Type                           feature.Type  `json:"type"`
+	SelectionType                  skillsel.Type `json:"selection_type"`
+	NameCriteria                   criteria.Text `json:"name,omitzero"`
+	SpecializationCriteria         criteria.Text `json:"specialization,omitzero"`
+	OptionalSpecializationCriteria criteria.Text `json:"optional_specialization,omitzero"`
+	TagsCriteria                   criteria.Text `json:"tags,omitzero"`
 	LeveledAmount
 	BonusOwner `json:"-"`
 }
@@ -48,6 +49,7 @@ func NewSkillBonus() *SkillBonus {
 	s.SelectionType = skillsel.Name
 	s.NameCriteria.Compare = criteria.IsText
 	s.SpecializationCriteria.Compare = criteria.AnyText
+	s.OptionalSpecializationCriteria.Compare = criteria.AnyText
 	s.TagsCriteria.Compare = criteria.AnyText
 	s.Amount = fxp.One
 	return &s
@@ -67,6 +69,7 @@ func (s *SkillBonus) Clone() Feature {
 // FillWithNameableKeys implements Feature.
 func (s *SkillBonus) FillWithNameableKeys(m, existing map[string]string) {
 	nameable.Extract(s.SpecializationCriteria.Qualifier, m, existing)
+	nameable.Extract(s.OptionalSpecializationCriteria.Qualifier, m, existing)
 	if s.SelectionType != skillsel.ThisWeapon {
 		nameable.Extract(s.NameCriteria.Qualifier, m, existing)
 		nameable.Extract(s.TagsCriteria.Qualifier, m, existing)
@@ -93,6 +96,7 @@ func (s *SkillBonus) Hash(h hash.Hash) {
 	xhash.Num8(h, s.SelectionType)
 	s.NameCriteria.Hash(h)
 	s.SpecializationCriteria.Hash(h)
+	s.OptionalSpecializationCriteria.Hash(h)
 	s.TagsCriteria.Hash(h)
 	s.LeveledAmount.Hash(h)
 }

--- a/model/gurps/skill_default.go
+++ b/model/gurps/skill_default.go
@@ -10,6 +10,8 @@
 package gurps
 
 import (
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"hash"
 	"strings"
 
@@ -29,13 +31,31 @@ var skillBasedDefaultTypes = map[string]bool{
 // SkillDefault holds data for a Skill default.
 type SkillDefault struct {
 	DefaultType    string          `json:"type"`
-	Name           string          `json:"name,omitzero"`
-	Specialization string          `json:"specialization,omitzero"`
+	Name           criteria.Text   `json:"name,omitzero"`
+	Specialization criteria.Text   `json:"specialization,omitzero"`
 	Modifier       fxp.Int         `json:"modifier,omitzero"`
 	Level          fxp.Int         `json:"level,omitzero"`
 	AdjLevel       fxp.Int         `json:"adjusted_level,omitzero"`
 	Points         fxp.Int         `json:"points,omitzero"`
 	WhenTL         criteria.Number `json:"when_tl,omitzero"`
+}
+
+func migrateStringToCriteriaText(raw jsontext.Value, dst *criteria.Text) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	if raw[0] == '"' {
+		var str string
+		if err := json.Unmarshal(raw, &str); err != nil {
+			return err
+		}
+		if str != "" {
+			dst.Compare = criteria.IsText
+			dst.Qualifier = str
+		}
+		return nil
+	}
+	return json.Unmarshal(raw, dst)
 }
 
 // DefaultTypeIsSkillBased returns true if the SkillDefault type is Skill-based.
@@ -50,6 +70,36 @@ func (s *SkillDefault) CloneWithoutLevelOrPoints() *SkillDefault {
 	clone.AdjLevel = 0
 	clone.Points = 0
 	return &clone
+}
+
+// UnmarshalJSONFrom implements json.UnmarshalerFrom.
+func (s *SkillDefault) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	var localData struct {
+		DefaultType    string          `json:"type"`
+		Name           jsontext.Value  `json:"name,omitzero"`
+		Specialization jsontext.Value  `json:"specialization,omitzero"`
+		Modifier       fxp.Int         `json:"modifier,omitzero"`
+		Level          fxp.Int         `json:"level,omitzero"`
+		AdjLevel       fxp.Int         `json:"adjusted_level,omitzero"`
+		Points         fxp.Int         `json:"points,omitzero"`
+		WhenTL         criteria.Number `json:"when_tl,omitzero"`
+	}
+	if err := json.UnmarshalDecode(dec, &localData); err != nil {
+		return err
+	}
+	s.DefaultType = localData.DefaultType
+	s.Modifier = localData.Modifier
+	s.Level = localData.Level
+	s.AdjLevel = localData.AdjLevel
+	s.Points = localData.Points
+	s.WhenTL = localData.WhenTL
+	if err := migrateStringToCriteriaText(localData.Name, &s.Name); err != nil {
+		return err
+	}
+	if err := migrateStringToCriteriaText(localData.Specialization, &s.Specialization); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Equivalent returns true if this can be considered equivalent to other.
@@ -77,7 +127,7 @@ func (s *SkillDefault) FullName(entity *Entity, replacements map[string]string) 
 	if s.SkillBased() {
 		var buffer strings.Builder
 		buffer.WriteString(s.NameWithReplacements(replacements))
-		if s.Specialization != "" {
+		if s.Specialization.Qualifier != "" {
 			buffer.WriteString(" (")
 			buffer.WriteString(s.SpecializationWithReplacements(replacements))
 			buffer.WriteByte(')')
@@ -97,19 +147,19 @@ func (s *SkillDefault) FullName(entity *Entity, replacements map[string]string) 
 
 // NameWithReplacements returns the name of the skill to default from with any nameable keys replaced.
 func (s *SkillDefault) NameWithReplacements(replacements map[string]string) string {
-	return nameable.Apply(s.Name, replacements)
+	return nameable.Apply(s.Name.Qualifier, replacements)
 }
 
 // SpecializationWithReplacements returns the specialization of the skill to default from with any nameable keys
 // replaced.
 func (s *SkillDefault) SpecializationWithReplacements(replacements map[string]string) string {
-	return nameable.Apply(s.Specialization, replacements)
+	return nameable.Apply(s.Specialization.Qualifier, replacements)
 }
 
 // FillWithNameableKeys adds any nameable keys found in this SkillDefault to the provided map.
 func (s *SkillDefault) FillWithNameableKeys(m, existing map[string]string) {
-	nameable.Extract(s.Name, m, existing)
-	nameable.Extract(s.Specialization, m, existing)
+	nameable.Extract(s.Name.Qualifier, m, existing)
+	nameable.Extract(s.Specialization.Qualifier, m, existing)
 }
 
 // ModifierAsString returns the modifier as a string suitable for appending.
@@ -163,8 +213,7 @@ func (s *SkillDefault) isTLPermitted(entity *Entity) bool {
 
 func (s *SkillDefault) best(entity *Entity, replacements map[string]string, requirePoints bool, excludes map[string]bool) fxp.Int {
 	best := fxp.Min
-	for _, sk := range entity.SkillNamed(s.NameWithReplacements(replacements),
-		s.SpecializationWithReplacements(replacements), requirePoints, excludes) {
+	for _, sk := range entity.SkillMatching(s.Name, s.Specialization, replacements, requirePoints, excludes) {
 		if best < sk.LevelData.Level {
 			level := sk.CalculateLevel(excludes).Level
 			if best < level {
@@ -215,8 +264,7 @@ func (s *SkillDefault) SkillLevelFast(entity *Entity, replacements map[string]st
 
 func (s *SkillDefault) bestFast(entity *Entity, replacements map[string]string, requirePoints bool, excludes map[string]bool) fxp.Int {
 	best := fxp.Min
-	for _, sk := range entity.SkillNamed(s.NameWithReplacements(replacements),
-		s.SpecializationWithReplacements(replacements), requirePoints, excludes) {
+	for _, sk := range entity.SkillMatching(s.Name, s.Specialization, replacements, requirePoints, excludes) {
 		if best < sk.LevelData.Level {
 			best = sk.LevelData.Level
 		}
@@ -235,9 +283,14 @@ func (s *SkillDefault) finalLevel(level fxp.Int) fxp.Int {
 // "source" data, i.e. not expected to be modified by the user after copying from a library.
 func (s *SkillDefault) Hash(h hash.Hash) {
 	xhash.StringWithLen(h, s.DefaultType)
-	xhash.StringWithLen(h, s.Name)
-	xhash.StringWithLen(h, s.Specialization)
 	xhash.Num64(h, s.Modifier)
+	if !s.Name.IsZero() {
+		s.Name.Hash(h)
+	}
+	if !s.Specialization.IsZero() {
+		// Only hash this when its not the default, so that old files don't suddenly become marked as modified.
+		s.Specialization.Hash(h)
+	}
 	if !s.WhenTL.IsZero() {
 		// Only hash this when its not the default, so that old files don't suddenly become marked as modified.
 		s.WhenTL.Hash(h)

--- a/model/gurps/skill_default.go
+++ b/model/gurps/skill_default.go
@@ -284,13 +284,8 @@ func (s *SkillDefault) finalLevel(level fxp.Int) fxp.Int {
 func (s *SkillDefault) Hash(h hash.Hash) {
 	xhash.StringWithLen(h, s.DefaultType)
 	xhash.Num64(h, s.Modifier)
-	if !s.Name.IsZero() {
-		s.Name.Hash(h)
-	}
-	if !s.Specialization.IsZero() {
-		// Only hash this when its not the default, so that old files don't suddenly become marked as modified.
-		s.Specialization.Hash(h)
-	}
+	s.Name.Hash(h)
+	s.Specialization.Hash(h)
 	if !s.WhenTL.IsZero() {
 		// Only hash this when its not the default, so that old files don't suddenly become marked as modified.
 		s.WhenTL.Hash(h)

--- a/model/gurps/skill_point_bonus.go
+++ b/model/gurps/skill_point_bonus.go
@@ -32,10 +32,11 @@ type SkillPointBonus struct {
 
 // SkillPointBonusData holds an adjustment to a skill's points which is persisted.
 type SkillPointBonusData struct {
-	Type                   feature.Type  `json:"type"`
-	NameCriteria           criteria.Text `json:"name,omitzero"`
-	SpecializationCriteria criteria.Text `json:"specialization,omitzero"`
-	TagsCriteria           criteria.Text `json:"tags,omitzero"`
+	Type                           feature.Type  `json:"type"`
+	NameCriteria                   criteria.Text `json:"name,omitzero"`
+	SpecializationCriteria         criteria.Text `json:"specialization,omitzero"`
+	OptionalSpecializationCriteria criteria.Text `json:"optional_specialization,omitzero"`
+	TagsCriteria                   criteria.Text `json:"tags,omitzero"`
 	LeveledAmount
 	BonusOwner `json:"-"`
 }
@@ -46,6 +47,7 @@ func NewSkillPointBonus() *SkillPointBonus {
 	s.Type = feature.SkillPointBonus
 	s.NameCriteria.Compare = criteria.IsText
 	s.SpecializationCriteria.Compare = criteria.AnyText
+	s.OptionalSpecializationCriteria.Compare = criteria.AnyText
 	s.TagsCriteria.Compare = criteria.AnyText
 	s.Amount = fxp.One
 	return &s
@@ -66,6 +68,7 @@ func (s *SkillPointBonus) Clone() Feature {
 func (s *SkillPointBonus) FillWithNameableKeys(m, existing map[string]string) {
 	nameable.Extract(s.NameCriteria.Qualifier, m, existing)
 	nameable.Extract(s.SpecializationCriteria.Qualifier, m, existing)
+	nameable.Extract(s.OptionalSpecializationCriteria.Qualifier, m, existing)
 	nameable.Extract(s.TagsCriteria.Qualifier, m, existing)
 }
 
@@ -98,6 +101,7 @@ func (s *SkillPointBonus) Hash(h hash.Hash) {
 	xhash.Num8(h, s.Type)
 	s.NameCriteria.Hash(h)
 	s.SpecializationCriteria.Hash(h)
+	s.OptionalSpecializationCriteria.Hash(h)
 	s.TagsCriteria.Hash(h)
 	s.LeveledAmount.Hash(h)
 }

--- a/model/gurps/skill_prereq.go
+++ b/model/gurps/skill_prereq.go
@@ -24,12 +24,13 @@ var _ Prereq = &SkillPrereq{}
 
 // SkillPrereq holds a prerequisite for a skill.
 type SkillPrereq struct {
-	Parent                 *PrereqList     `json:"-"`
-	Type                   prereq.Type     `json:"type"`
-	Has                    bool            `json:"has"`
-	NameCriteria           criteria.Text   `json:"name,omitzero"`
-	LevelCriteria          criteria.Number `json:"level,omitzero"`
-	SpecializationCriteria criteria.Text   `json:"specialization,omitzero"`
+	Parent                         *PrereqList     `json:"-"`
+	Type                           prereq.Type     `json:"type"`
+	Has                            bool            `json:"has"`
+	NameCriteria                   criteria.Text   `json:"name,omitzero"`
+	LevelCriteria                  criteria.Number `json:"level,omitzero"`
+	SpecializationCriteria         criteria.Text   `json:"specialization,omitzero"`
+	OptionalSpecializationCriteria criteria.Text   `json:"optional_specialization,omitzero"`
 }
 
 // NewSkillPrereq creates a new SkillPrereq.
@@ -39,6 +40,7 @@ func NewSkillPrereq() *SkillPrereq {
 	p.NameCriteria.Compare = criteria.IsText
 	p.LevelCriteria.Compare = criteria.AtLeastNumber
 	p.SpecializationCriteria.Compare = criteria.AnyText
+	p.OptionalSpecializationCriteria.Compare = criteria.AnyText
 	p.Has = true
 	return &p
 }
@@ -64,6 +66,7 @@ func (p *SkillPrereq) Clone(parent *PrereqList) Prereq {
 func (p *SkillPrereq) FillWithNameableKeys(m, existing map[string]string) {
 	nameable.Extract(p.NameCriteria.Qualifier, m, existing)
 	nameable.Extract(p.SpecializationCriteria.Qualifier, m, existing)
+	nameable.Extract(p.OptionalSpecializationCriteria.Qualifier, m, existing)
 }
 
 // Satisfied implements Prereq.
@@ -79,7 +82,8 @@ func (p *SkillPrereq) Satisfied(entity *Entity, exclude any, tooltip *xbytes.Ins
 	}
 	Traverse(func(sk *Skill) bool {
 		if exclude == sk || !p.NameCriteria.Matches(replacements, sk.NameWithReplacements()) ||
-			!p.SpecializationCriteria.Matches(replacements, sk.SpecializationWithReplacements()) {
+			!p.SpecializationCriteria.Matches(replacements, sk.SpecializationWithReplacements()) ||
+			!p.OptionalSpecializationCriteria.Matches(replacements, sk.OptionalSpecializationWithReplacements()) {
 			return false
 		}
 		satisfied = p.LevelCriteria.Matches(sk.LevelData.Level)
@@ -101,11 +105,16 @@ func (p *SkillPrereq) Satisfied(entity *Entity, exclude any, tooltip *xbytes.Ins
 			tooltip.WriteString(p.SpecializationCriteria.String(replacements))
 			tooltip.WriteByte(',')
 		}
+		if p.OptionalSpecializationCriteria.Compare != criteria.AnyText {
+			tooltip.WriteString(i18n.Text(", optional specialization "))
+			tooltip.WriteString(p.OptionalSpecializationCriteria.String(replacements))
+			tooltip.WriteByte(',')
+		}
 		if techLevel == nil {
 			tooltip.WriteString(i18n.Text(" and level "))
 			tooltip.WriteString(p.LevelCriteria.String())
 		} else {
-			if p.SpecializationCriteria.Compare != criteria.AnyText {
+			if p.SpecializationCriteria.Compare != criteria.AnyText || p.OptionalSpecializationCriteria.Compare != criteria.AnyText {
 				tooltip.WriteByte(',')
 			}
 			tooltip.WriteString(i18n.Text(" level "))
@@ -127,4 +136,5 @@ func (p *SkillPrereq) Hash(h hash.Hash) {
 	p.NameCriteria.Hash(h)
 	p.LevelCriteria.Hash(h)
 	p.SpecializationCriteria.Hash(h)
+	p.OptionalSpecializationCriteria.Hash(h)
 }

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/richardwilkes/gcs/v5/model/criteria"
 	"github.com/richardwilkes/gcs/v5/model/fxp"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/cell"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/difficulty"
@@ -767,19 +768,19 @@ func CalculateRitualMagicSpellLevel(e *Entity, name, powerSource, ritualSkillNam
 func determineRitualMagicSkillLevelForCollege(e *Entity, name, college, ritualSkillName string, prereqCount int, tags []string, diff AttributeDifficulty, points fxp.Int) Level {
 	def := &SkillDefault{
 		DefaultType:    SkillID,
-		Name:           ritualSkillName,
-		Specialization: college,
+		Specialization: criteria.Text{TextData: criteria.TextData{Compare: criteria.IsText, Qualifier: college}},
 		Modifier:       fxp.FromInteger(-prereqCount),
 	}
-	if college == "" {
-		def.Name = ""
+	if ritualSkillName != "" {
+		def.Name.Compare = criteria.IsText
+		def.Name.Qualifier = ritualSkillName
 	}
 	var limit fxp.Int
 	skillLevel := CalculateTechniqueLevel(e, nil, name, college, tags, def, diff.Difficulty, points, false,
 		&limit, nil)
 	// CalculateTechniqueLevel() does not add the default skill modifier to the relative level, only to the final level
 	skillLevel.RelativeLevel += def.Modifier
-	def.Specialization = ""
+	def.Specialization.Qualifier = ""
 	def.Modifier -= fxp.Six
 	fallback := CalculateTechniqueLevel(e, nil, name, college, tags, def, diff.Difficulty, points, false,
 		&limit, nil)

--- a/model/gurps/weapon_bonus.go
+++ b/model/gurps/weapon_bonus.go
@@ -36,22 +36,23 @@ type WeaponBonus struct {
 
 // WeaponBonusData holds the data for an adjustment to weapon stats which are persisted.
 type WeaponBonusData struct { //nolint:govet // The field alignment here is poor, but kept to reduce diffs in the data
-	Type                   feature.Type    `json:"type"`
-	Percent                bool            `json:"percent,omitzero"`
-	SelectionType          wsel.Type       `json:"selection_type"`
-	SwitchType             wswitch.Type    `json:"switch_type,omitzero"`
-	SwitchTypeValue        bool            `json:"switch_type_value,omitzero"`
-	NameCriteria           criteria.Text   `json:"name,omitzero"`
-	SpecializationCriteria criteria.Text   `json:"specialization,omitzero"`
-	RelativeLevelCriteria  criteria.Number `json:"level,omitzero"`
-	UsageCriteria          criteria.Text   `json:"usage,omitzero"`
-	TagsCriteria           criteria.Text   `json:"tags,omitzero"`
-	LeveledOwner           LeveledOwner    `json:"-"`
-	DieCount               fxp.Int         `json:"-"`
-	Amount                 fxp.Int         `json:"amount"`
-	PerLevel               bool            `json:"leveled,omitzero"`
-	PerDie                 bool            `json:"per_die,omitzero"`
-	BonusOwner             `json:"-"`
+	Type                           feature.Type    `json:"type"`
+	Percent                        bool            `json:"percent,omitzero"`
+	SelectionType                  wsel.Type       `json:"selection_type"`
+	SwitchType                     wswitch.Type    `json:"switch_type,omitzero"`
+	SwitchTypeValue                bool            `json:"switch_type_value,omitzero"`
+	NameCriteria                   criteria.Text   `json:"name,omitzero"`
+	SpecializationCriteria         criteria.Text   `json:"specialization,omitzero"`
+	OptionalSpecializationCriteria criteria.Text   `json:"optional_specialization,omitzero"`
+	RelativeLevelCriteria          criteria.Number `json:"level,omitzero"`
+	UsageCriteria                  criteria.Text   `json:"usage,omitzero"`
+	TagsCriteria                   criteria.Text   `json:"tags,omitzero"`
+	LeveledOwner                   LeveledOwner    `json:"-"`
+	DieCount                       fxp.Int         `json:"-"`
+	Amount                         fxp.Int         `json:"amount"`
+	PerLevel                       bool            `json:"leveled,omitzero"`
+	PerDie                         bool            `json:"per_die,omitzero"`
+	BonusOwner                     `json:"-"`
 }
 
 // NewWeaponDamageBonus creates a new weapon damage bonus.
@@ -180,6 +181,7 @@ func newWeaponBonus(t feature.Type) *WeaponBonus {
 	w.SelectionType = wsel.WithRequiredSkill
 	w.NameCriteria.Compare = criteria.IsText
 	w.SpecializationCriteria.Compare = criteria.AnyText
+	w.OptionalSpecializationCriteria.Compare = criteria.AnyText
 	w.RelativeLevelCriteria.Compare = criteria.AtLeastNumber
 	w.UsageCriteria.Compare = criteria.AnyText
 	w.TagsCriteria.Compare = criteria.AnyText
@@ -236,6 +238,7 @@ func (w *WeaponBonus) AdjustedAmount() fxp.Int {
 // FillWithNameableKeys implements Feature.
 func (w *WeaponBonus) FillWithNameableKeys(m, existing map[string]string) {
 	nameable.Extract(w.SpecializationCriteria.Qualifier, m, existing)
+	nameable.Extract(w.OptionalSpecializationCriteria.Qualifier, m, existing)
 	if w.SelectionType != wsel.ThisWeapon {
 		nameable.Extract(w.NameCriteria.Qualifier, m, existing)
 		nameable.Extract(w.UsageCriteria.Qualifier, m, existing)
@@ -339,6 +342,7 @@ func (w *WeaponBonus) Hash(h hash.Hash) {
 	xhash.Bool(h, w.SwitchTypeValue)
 	w.NameCriteria.Hash(h)
 	w.SpecializationCriteria.Hash(h)
+	w.OptionalSpecializationCriteria.Hash(h)
 	w.RelativeLevelCriteria.Hash(h)
 	w.UsageCriteria.Hash(h)
 	w.TagsCriteria.Hash(h)

--- a/ux/defaults_panel.go
+++ b/ux/defaults_panel.go
@@ -77,7 +77,7 @@ func newDefaultsPanel(entity *gurps.Entity, defaults *[]*gurps.SkillDefault) *de
 func (p *defaultsPanel) insertDefaultsPanel(index int, def *gurps.SkillDefault) {
 	panel := unison.NewPanel()
 	panel.SetLayout(&unison.FlexLayout{
-		Columns:  5,
+		Columns:  4,
 		HAlign:   align.Fill,
 		HSpacing: unison.StdHSpacing,
 		VSpacing: unison.StdVSpacing,
@@ -101,37 +101,35 @@ func (p *defaultsPanel) insertDefaultsPanel(index int, def *gurps.SkillDefault) 
 	}
 	panel.AddChild(deleteButton)
 
-	name := i18n.Text("Name")
-	nameField := NewStringField(nil, "", name, func() string { return def.Name },
-		func(s string) { def.Name = s })
-	nameField.Watermark = name
-	specialization := i18n.Text("Specialization")
-	specializationField := NewStringField(nil, "", specialization,
-		func() string { return def.Specialization }, func(s string) { def.Specialization = s })
-	specializationField.Watermark = specialization
-	modifierField := NewDecimalField(nil, "", i18n.Text("Modifier"),
-		func() fxp.Int { return def.Modifier },
-		func(v fxp.Int) { def.Modifier = v },
-		-fxp.Thousand, fxp.Thousand, true, false)
 	attrChoicePopup := addAttributeChoicePopup(panel, p.entity, "", &def.DefaultType,
 		gurps.TenFlag|gurps.ParryFlag|gurps.BlockFlag|gurps.SkillFlag)
+	addLabel(panel, i18n.Text("Modifier"), "")
+	addDecimalFieldWithSign(panel, nil, "", i18n.Text("Modifier"), "", &def.Modifier, -fxp.Thousand, fxp.Thousand)
+
+	// Rows after the first are rebuilt whenever the type changes.
+	rebuildDynamicRows := func() {
+		for len(panel.Children()) > 4 {
+			panel.RemoveChildAtIndex(len(panel.Children()) - 1)
+		}
+		if def.DefaultType == gurps.SkillID {
+			panel.AddChild(unison.NewPanel())
+			addNameCriteriaPanel(panel, &def.Name, 3, false)
+			panel.AddChild(unison.NewPanel())
+			addSpecializationCriteriaPanel(panel, &def.Specialization, 3, false)
+		}
+		addNumericCriteriaPanel(panel, nil, "", i18n.Text("when the Tech Level"), i18n.Text("When Tech Level"),
+			&def.WhenTL, 0, fxp.Twelve, 3, true, true)
+	}
 	callback := attrChoicePopup.SelectionChangedCallback
 	attrChoicePopup.SelectionChangedCallback = func(popup *unison.PopupMenu[*gurps.AttributeChoice]) {
 		if item, ok := popup.Selected(); ok {
 			lastDefaultTypeUsed = item.Key
 			callback(popup)
-			adjustFieldBlank(nameField, item.Key != gurps.SkillID)
-			adjustFieldBlank(specializationField, item.Key != gurps.SkillID)
+			rebuildDynamicRows()
+			MarkRootAncestorForLayoutRecursively(p)
 		}
 	}
-	panel.AddChild(nameField)
-	panel.AddChild(specializationField)
-	panel.AddChild(modifierField)
-	adjustFieldBlank(nameField, def.DefaultType != gurps.SkillID)
-	adjustFieldBlank(specializationField, def.DefaultType != gurps.SkillID)
-
-	addNumericCriteriaPanel(panel, nil, "", i18n.Text("when the Tech Level"), i18n.Text("When Tech Level"),
-		&def.WhenTL, 0, fxp.Twelve, 4, true, true)
+	rebuildDynamicRows()
 
 	panel.SetLayoutData(&unison.FlexLayoutData{
 		HAlign: align.Fill,

--- a/ux/skill_editor.go
+++ b/ux/skill_editor.go
@@ -68,7 +68,18 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 			if !lastWasSkillBased {
 				skillDefNameField.RemoveFromParent()
 			}
-			addDecimalField(wrapper, nil, "", i18n.Text("Technique Default Adjustment"),
+			var specPanel *unison.Panel
+			addSpecPanel := func() {
+				prefix := i18n.Text("whose specialization")
+				addStringCriteriaPanel(wrapper, prefix, prefix, i18n.Text("Specialization Qualifier"),
+					&e.editorData.TechniqueDefault.Specialization, 1, false)
+				children := wrapper.Children()
+				specPanel = children[len(children)-1]
+			}
+			if lastWasSkillBased {
+				addSpecPanel()
+			}
+			modifierField := addDecimalField(wrapper, nil, "", i18n.Text("Technique Default Adjustment"),
 				i18n.Text("Default Adjustment"), &e.editorData.TechniqueDefault.Modifier, -fxp.NinetyNine,
 				fxp.NinetyNine)
 			attrChoicePopup.SelectionChangedCallback = func(popup *unison.PopupMenu[*gurps.AttributeChoice]) {
@@ -77,10 +88,16 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 					if skillBased := gurps.DefaultTypeIsSkillBased(e.editorData.TechniqueDefault.DefaultType); skillBased != lastWasSkillBased {
 						lastWasSkillBased = skillBased
 						if skillBased {
-							wrapper.AddChildAtIndex(skillDefNameField, len(wrapper.Children())-1)
-							addSpecializationCriteriaPanel(wrapper, &e.editorData.TechniqueDefault.Specialization, 1, false)
+							modifierField.RemoveFromParent()
+							wrapper.AddChild(skillDefNameField)
+							addSpecPanel()
+							wrapper.AddChild(modifierField)
 						} else {
 							skillDefNameField.RemoveFromParent()
+							if specPanel != nil {
+								specPanel.RemoveFromParent()
+								specPanel = nil
+							}
 						}
 					}
 					MarkModified(content)

--- a/ux/skill_editor.go
+++ b/ux/skill_editor.go
@@ -141,7 +141,7 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 			adjustedDiffField := NewNonEditableField(func(field *NonEditableField) {
 				localOptSpec := nameable.Apply(e.editorData.OptionalSpecialization, e.target.Replacements)
 				diff := e.editorData.Difficulty
-				if localOptSpec != "" && diff.Difficulty > difficulty.Easy {
+				if localOptSpec != "" && diff.Difficulty != difficulty.Wildcard && diff.Difficulty > difficulty.Easy {
 					diff.Difficulty--
 				}
 				field.SetTitle(diff.Description(entity))
@@ -173,7 +173,7 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 						true, e.editorData.TechniqueLimitModifier, nil)
 				} else {
 					adjDiff := e.editorData.Difficulty
-					if localOptionalSpec != "" && adjDiff.Difficulty > difficulty.Easy {
+					if localOptionalSpec != "" && adjDiff.Difficulty != difficulty.Wildcard && adjDiff.Difficulty > difficulty.Easy {
 						adjDiff.Difficulty--
 					}
 					level = gurps.CalculateSkillLevel(entity, localName, localSpec, localOptionalSpec, e.editorData.Tags,

--- a/ux/skill_editor.go
+++ b/ux/skill_editor.go
@@ -10,6 +10,7 @@
 package ux
 
 import (
+	"github.com/richardwilkes/gcs/v5/model/criteria"
 	"github.com/richardwilkes/gcs/v5/model/fxp"
 	"github.com/richardwilkes/gcs/v5/model/gurps"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/difficulty"
@@ -35,6 +36,7 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 	addNameLabelAndField(content, &e.editorData.Name)
 	if !e.target.Container() && !e.target.IsTechnique() {
 		addSpecializationLabelAndField(content, &e.editorData.Specialization)
+		addOptionalSpecializationLabelAndField(content, &e.editorData.OptionalSpecialization)
 		addTechLevelRequired(content, &e.editorData.TechLevel, ownerIsSheet)
 	}
 	addNotesLabelAndField(content, &e.editorData.LocalNotes)
@@ -54,24 +56,17 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 				gurps.TenFlag|gurps.SkillFlag|gurps.ParryFlag|gurps.BlockFlag|gurps.DodgeFlag,
 				e.editorData.TechniqueDefault.DefaultType)
 			attrChoicePopup := addPopup(wrapper, choices, &attrChoice)
+			e.editorData.TechniqueDefault.Name.Compare = criteria.IsText
 			skillDefNameField := addStringField(wrapper, i18n.Text("Technique Default Skill Name"),
-				i18n.Text("Skill Name"), &e.editorData.TechniqueDefault.Name)
+				i18n.Text("Skill Name"), &e.editorData.TechniqueDefault.Name.Qualifier)
 			skillDefNameField.Watermark = i18n.Text("Skill")
 			skillDefNameField.SetLayoutData(&unison.FlexLayoutData{
-				HAlign: align.Fill,
-				HGrab:  true,
-			})
-			skillDefSpecialtyField := addStringField(wrapper, i18n.Text("Technique Default Skill Specialization"),
-				i18n.Text("Skill Specialization"), &e.editorData.TechniqueDefault.Specialization)
-			skillDefSpecialtyField.Watermark = i18n.Text("Specialization")
-			skillDefSpecialtyField.SetLayoutData(&unison.FlexLayoutData{
 				HAlign: align.Fill,
 				HGrab:  true,
 			})
 			lastWasSkillBased := gurps.DefaultTypeIsSkillBased(e.editorData.TechniqueDefault.DefaultType)
 			if !lastWasSkillBased {
 				skillDefNameField.RemoveFromParent()
-				skillDefSpecialtyField.RemoveFromParent()
 			}
 			addDecimalField(wrapper, nil, "", i18n.Text("Technique Default Adjustment"),
 				i18n.Text("Default Adjustment"), &e.editorData.TechniqueDefault.Modifier, -fxp.NinetyNine,
@@ -83,10 +78,9 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 						lastWasSkillBased = skillBased
 						if skillBased {
 							wrapper.AddChildAtIndex(skillDefNameField, len(wrapper.Children())-1)
-							wrapper.AddChildAtIndex(skillDefSpecialtyField, len(wrapper.Children())-1)
+							addSpecializationCriteriaPanel(wrapper, &e.editorData.TechniqueDefault.Specialization, 1, false)
 						} else {
 							skillDefNameField.RemoveFromParent()
-							skillDefSpecialtyField.RemoveFromParent()
 						}
 					}
 					MarkModified(content)
@@ -139,7 +133,22 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 				}
 			}
 		} else {
-			addDifficultyLabelAndFields(content, entity, &e.editorData.Difficulty)
+			diffWrapper := addFlowWrapper(content, i18n.Text("Difficulty"), 5)
+			addAttributeChoicePopup(diffWrapper, entity, "", &e.editorData.Difficulty.Attribute, gurps.TenFlag)
+			diffWrapper.AddChild(NewFieldTrailingLabel("/", false))
+			addPopup(diffWrapper, difficulty.Levels, &e.editorData.Difficulty.Difficulty)
+			diffWrapper.AddChild(NewFieldInteriorLeadingLabel(i18n.Text("Adjusted Difficulty"), false))
+			adjustedDiffField := NewNonEditableField(func(field *NonEditableField) {
+				localOptSpec := nameable.Apply(e.editorData.OptionalSpecialization, e.target.Replacements)
+				diff := e.editorData.Difficulty
+				if localOptSpec != "" && diff.Difficulty > difficulty.Easy {
+					diff.Difficulty--
+				}
+				field.SetTitle(diff.Description(entity))
+				field.MarkForLayoutAndRedraw()
+			})
+			diffWrapper.AddChild(adjustedDiffField)
+
 			encLabel := i18n.Text("Encumbrance Penalty")
 			wrapper := addFlowWrapper(content, encLabel, 2)
 			addDecimalField(wrapper, nil, "", encLabel, "", &e.editorData.EncumbrancePenaltyMultiplier, 0, fxp.Nine)
@@ -154,16 +163,21 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 			levelField := NewNonEditableField(func(field *NonEditableField) {
 				localName := nameable.Apply(e.editorData.Name, e.target.Replacements)
 				localSpec := nameable.Apply(e.editorData.Specialization, e.target.Replacements)
+				localOptionalSpec := nameable.Apply(e.editorData.OptionalSpecialization, e.target.Replacements)
 				points := gurps.AdjustedPointsForNonContainerSkillOrTechnique(entity, e.editorData.Points, localName,
-					localSpec, e.editorData.Tags, nil)
+					localSpec, localOptionalSpec, e.editorData.Tags, nil)
 				var level gurps.Level
 				if e.target.IsTechnique() {
 					level = gurps.CalculateTechniqueLevel(entity, e.target.NameableReplacements(), localName, localSpec,
 						e.editorData.Tags, e.editorData.TechniqueDefault, e.editorData.Difficulty.Difficulty, points,
 						true, e.editorData.TechniqueLimitModifier, nil)
 				} else {
-					level = gurps.CalculateSkillLevel(entity, localName, localSpec, e.editorData.Tags,
-						e.editorData.DefaultedFrom, e.editorData.Difficulty, points,
+					adjDiff := e.editorData.Difficulty
+					if localOptionalSpec != "" && adjDiff.Difficulty > difficulty.Easy {
+						adjDiff.Difficulty--
+					}
+					level = gurps.CalculateSkillLevel(entity, localName, localSpec, localOptionalSpec, e.editorData.Tags,
+						e.editorData.DefaultedFrom, adjDiff, points,
 						e.editorData.EncumbrancePenaltyMultiplier)
 				}
 				lvl := level.Level.Floor()

--- a/ux/widgets.go
+++ b/ux/widgets.go
@@ -94,7 +94,7 @@ func addNameLabelAndField(parent *unison.Panel, fieldData *string) {
 }
 
 func addSpecializationLabelAndField(parent *unison.Panel, fieldData *string) {
-	addLabelAndStringField(parent, i18n.Text("Specialization"), "", fieldData)
+	addLabelAndStringField(parent, i18n.Text("Required Specialization"), "", fieldData)
 }
 
 func addOptionalSpecializationLabelAndField(parent *unison.Panel, fieldData *string) {

--- a/ux/widgets.go
+++ b/ux/widgets.go
@@ -97,6 +97,10 @@ func addSpecializationLabelAndField(parent *unison.Panel, fieldData *string) {
 	addLabelAndStringField(parent, i18n.Text("Specialization"), "", fieldData)
 }
 
+func addOptionalSpecializationLabelAndField(parent *unison.Panel, fieldData *string) {
+	addLabelAndStringField(parent, i18n.Text("Optional Specialization"), "", fieldData)
+}
+
 func addPageRefLabelAndField(parent *unison.Panel, fieldData *string) {
 	addLabelAndStringField(parent, i18n.Text("Page Reference"), gurps.PageRefTooltip(), fieldData)
 }


### PR DESCRIPTION
After writing the Issue for this (#1038 ) I decided I've probably thought it through enough to just implement this myself.

## Rule Definition

Optional specialties are described in Basic Set pp. 169-170 and are functionally distinct from required specialties.

Optional specialties represent sub-fields of an IQ-based skill which a character may specialize in but are not required to. They have the following effects on a skill:
- Including an optional specialty in a skill decreases the difficulty level for said skill by one level (e.g. Hard -> Average). As such, they are only compatible with skills of an original difficulty of Average or harder.
- The general skill defaults to the optionally specialized version at -2.
- Skills which default to a general skill default to the optionally specialized skill at their specified default modifier, plus an additional -2.

Importantly, a skill can have _both_ a required and optional specialty. Examples in Basic Set include:
- Biology, which must be specialized by planet type, may also be specialized by class of animal
- Artist, which must be specialized by art form, may also be specialized by medium or technique.

## The Problem 

GCS currently does not fully support some of the above features. It can support some of these features partially, but said implementation on the data side of things is clunky at best.
- Multiple replacement strings _can_ be placed within a skill, but these are not recognized as distinct specialties by the Skill Default field, which supports only an exact case-insensitive match.
- A skill defaulting to an optionally specialized version of itself at -2 is achievable by adding a Skill Default entry to the skill with the specialization left blank (for skills with only an optional specialty) but the inexact match for skills with both a required and optional specialty means that this is not possible for such skills. (This is, again, caused by the exact case-insensitive match of the specialization field for Skill Defaults).
- The difficulty level of a skill _can_ be manually adjusted if it includes an optional specialty, but this requires duplication of any skills which fall under this rule, which at least somewhat negatively affects maintainability.

## Change Overview

### `Skill` struct (`model/gurps/skill.go`)

- Added `OptionalSpecialization` string field with full nameable-replacement support (displayed after any required specialization, separated by a comma, e.g. `Artist (Painting, Oil)`).
- Added `AdjustedDifficulty()` returning the effective `AttributeDifficulty` — one step lower than the declared difficulty when an optional specialization is present, capped at Easy.
- `CellData()` and level display in the editor now use the adjusted difficulty rather than the raw declared difficulty.
- `resolveToSpecificDefaults()` now implements the two automatic defaulting rules:
  - **Rule 1** — if skill `Foo` has no optional specialization and `Foo (Bar)` (with optional spec `Bar`) exists on the character with points, `Foo` automatically defaults to `Foo (Bar)` at −2, without requiring an explicit Skill Default entry.
  - **Rule 2** — if skill `A` explicitly defaults to `C` at penalty `−X`, and `C (E)` (with optional spec `E`) exists on the character, `A` also defaults to `C (E)` at `−(X+2)`.
- Fixed `bestDefault()` incorrectly bailing out when a skill has no explicit defaults, which prevented Rule 1 from firing.
- Fixed `inDefaultChain()` passing a nil excludes set to the skill lookup, causing false-positive cycle detection that suppressed all same-name optional-spec defaults.

### `SkillDefault` struct (`model/gurps/skill_default.go`)

- `Name` and `Specialization` fields changed from plain `string` to `criteria.Text`, enabling all string-comparison modes (is, is not, contains, starts with, ends with, …) rather than only exact case-insensitive matching.
- Added `migrateStringToCriteriaText()` for backwards-compatible JSON loading: existing files that store these fields as plain strings are automatically migrated to `{compare: "is", qualifier: "…"}` on load.
- `best()` and `bestFast()` now call `Entity.SkillMatching()` with the full `criteria.Text` objects, so user-configured comparison modes are honoured when resolving default levels.

**Possible Issue:** The `TechniqueDefault` object uses the `SkillDefault` structure but the UI does not expose the `Compare` value for editing, the value is always `criteria.IsText`. This is intentional, as I don't think the changes made to these fields in `SkillDefault` are necessary to carry over to the Technique data, but it could potentially cause issues if the value is manually edited. This may be worth revising.

### `Entity` (`model/gurps/entity.go`)

- Added `SkillMatching(nameCriteria, specializationCriteria criteria.Text, replacements, …)` — a criteria-aware counterpart to `SkillNamed` that applies the `Compare` field rather than always using case-insensitive equality.
- Added `BestSkillMatching(…)` returning the highest-level skill among those matching.
- `SkillBonusFor()` signature updated to accept and match on `optionalSpecialization`.
- Internal skill-level resolution exclusion keys now incorporate the optional specialization to avoid false cache hits between skills that share a name and required specialization but differ in optional specialization.

### Skill editor (`ux/skill_editor.go`)

- Added **Optional Specialization** input field for non-container, non-technique skills.
- Added an **Adjusted Difficulty** read-only display next to the difficulty selector; it updates live as the optional specialization field is filled in or cleared.
- Level preview now computes using the adjusted difficulty.

### Defaults panel (`ux/defaults_panel.go`)

- `Name` and `Specialization` entries replaced with full criteria UI panels (`addNameCriteriaPanel` / `addSpecializationCriteriaPanel`), exposing the comparison-mode selector alongside the qualifier field.
- Name and specialization rows are now hidden when the default type is not skill-based, and shown when skill-based is selected.
- Modifier field now displays with a side label instead of placeholder text.

### Other call-site fixes

- `model/gurps/spell.go` — updated calls to `BestSkillNamed`, `SkillNamed`, and `AdjustedPointsForNonContainerSkillOrTechnique` to match revised signatures.
- `model/gurps/natural_attacks.go` — weapon `Defaults` entries migrated from bare string fields to `criteria.Text` via a local `skillName()` helper.
