### PR TITLE
Add Fantasy Folk: The Reptilian Races page reference mapping

### DIFF
--- a/ux/pageref_name_mappings.go
+++ b/ux/pageref_name_mappings.go
@@ -129,6 +129,7 @@ var PageRefKeyNameMappings = map[string]string{
 	"FFE":     "Fantasy Folk: Elves",
 	"FFGH":    "Fantasy Folk: Goblins and Hobgoblins",
 	"FFK":     "Fantasy Folk: Kobolds",
+	"FFRR":    "Fantasy Folk: The Reptilian Races",
 	"FFWF":    "Fantasy Folk: Winged Folk",
 	"FH":      "Future History",
 	"FPR":     "Fantasy: Portal Realms",


### PR DESCRIPTION
I'm putting together a pull request for the templates from Fantasy Folk: The Reptilian Races, so I've added a page reference mapping for it.

I omitted a letter for "The" as the convention seems to be to ignore connecting words like "of" and "the", e.g. The Broken Clockwork World is BCW.