### PR TITLE
Refactor with self-referential generics

### DIFF
--- a/model/gurps/conditional_modifier.go
+++ b/model/gurps/conditional_modifier.go
@@ -26,7 +26,7 @@ import (
 	"github.com/richardwilkes/unison/enums/align"
 )
 
-var _ Node[*ConditionalModifier] = &ConditionalModifier{}
+var _ = assertNode[*ConditionalModifier]
 
 // Columns that can be used with the conditional modifier method .CellData()
 const (

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -38,11 +38,12 @@ import (
 )
 
 var (
-	_ WeaponOwner            = &Equipment{}
-	_ LeveledOwner           = &Equipment{}
-	_ Node[*Equipment]       = &Equipment{}
-	_ TechLevelProvider      = &Equipment{}
-	_ EditorData[*Equipment] = &EquipmentEditData{}
+	_ = assertNode[*Equipment]
+	_ = assertEditorData[*Equipment]
+
+	_ WeaponOwner       = &Equipment{}
+	_ LeveledOwner      = &Equipment{}
+	_ TechLevelProvider = &Equipment{}
 )
 
 // Columns that can be used with the equipment method .CellData()

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -39,7 +39,7 @@ import (
 
 var (
 	_ = assertNode[*Equipment]
-	_ = assertEditorData[*Equipment]
+	_ = assertEditorData[*EquipmentEditData]
 
 	_ WeaponOwner       = &Equipment{}
 	_ LeveledOwner      = &Equipment{}

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -38,11 +38,11 @@ import (
 )
 
 var (
-	_ WeaponOwner                   = &Equipment{}
-	_ LeveledOwner                  = &Equipment{}
-	_ Node[*Equipment]              = &Equipment{}
-	_ TechLevelProvider[*Equipment] = &Equipment{}
-	_ EditorData[*Equipment]        = &EquipmentEditData{}
+	_ WeaponOwner            = &Equipment{}
+	_ LeveledOwner           = &Equipment{}
+	_ Node[*Equipment]       = &Equipment{}
+	_ TechLevelProvider      = &Equipment{}
+	_ EditorData[*Equipment] = &EquipmentEditData{}
 )
 
 // Columns that can be used with the equipment method .CellData()

--- a/model/gurps/equipment_modifier.go
+++ b/model/gurps/equipment_modifier.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	_ = assertNode[*EquipmentModifier]
-	_ = assertEditorData[*EquipmentModifier]
+	_ = assertEditorData[*EquipmentModifierEditData]
 
 	_ GeneralModifier = &EquipmentModifier{}
 )

--- a/model/gurps/equipment_modifier.go
+++ b/model/gurps/equipment_modifier.go
@@ -36,9 +36,10 @@ import (
 )
 
 var (
-	_ Node[*EquipmentModifier]       = &EquipmentModifier{}
-	_ GeneralModifier                = &EquipmentModifier{}
-	_ EditorData[*EquipmentModifier] = &EquipmentModifierEditData{}
+	_ = assertNode[*EquipmentModifier]
+	_ = assertEditorData[*EquipmentModifier]
+
+	_ GeneralModifier = &EquipmentModifier{}
 )
 
 // Columns that can be used with the equipment modifier method .CellData()

--- a/model/gurps/hashable.go
+++ b/model/gurps/hashable.go
@@ -112,13 +112,12 @@ func MarshalWithoutCalc(in any) ([]byte, error) {
 }
 
 // NodesToHashesByID traverses the provided nodes and generates hashes.
-func NodesToHashesByID[T NodeTypes](result map[tid.TID]HashAndData, data ...T) {
+func NodesToHashesByID[T Node[T]](result map[tid.TID]HashAndData, data ...T) {
 	Traverse(func(one T) bool {
-		node := AsNode(one)
-		id := node.ID()
+		id := one.ID()
 		if _, exists := result[id]; !exists {
 			result[id] = HashAndData{
-				Hash: Hash64(node),
+				Hash: Hash64(one),
 				Data: one,
 			}
 		}

--- a/model/gurps/node.go
+++ b/model/gurps/node.go
@@ -61,15 +61,15 @@ type Node[T NodeTypes] interface {
 }
 
 // RawPointsAdjuster defines methods for nodes that can have their raw points adjusted must implement.
-type RawPointsAdjuster[T NodeTypes] interface {
-	Node[T]
+type RawPointsAdjuster interface {
+	Container() bool
 	RawPoints() fxp.Int
 	SetRawPoints(points fxp.Int) bool
 }
 
 // SkillAdjustmentProvider defines methods for nodes that can have their skill level adjusted must implement.
-type SkillAdjustmentProvider[T NodeTypes] interface {
-	RawPointsAdjuster[T]
+type SkillAdjustmentProvider interface {
+	RawPointsAdjuster
 	IncrementSkillLevel()
 	DecrementSkillLevel()
 }

--- a/model/gurps/node.go
+++ b/model/gurps/node.go
@@ -31,10 +31,9 @@ type DataOwnerProvider interface {
 	DataOwner() DataOwner
 }
 
-// Node defines the methods required of nodes in our tables.
-//
-// This interface is a "constraint" and cannot be used as a type param, just as a constraint.
-// In practice this just means that it can only be used inside the square brackets of generic methods/types.
+// The type union in the body makes this a constraint, not an ordinary interface: it may only be used as a type
+// parameter's constraint or embedded in another constraint, never as a type. Generic code takes a T Node[T] type
+// parameter and works with T directly.
 type Node[T Node[T]] interface {
 	// These are the limited set of types that can be nodes. New node types *must* be added here
 	*ConditionalModifier | *Equipment | *EquipmentModifier | *Note | *Skill | *Spell | *Trait | *TraitModifier | *Weapon
@@ -62,14 +61,14 @@ type Node[T Node[T]] interface {
 
 func assertNode[T Node[T]]() {}
 
-// RawPointsAdjuster defines methods for nodes that can have their raw points adjusted must implement.
+// RawPointsAdjuster interface for objects that can have their raw points adjusted.
 type RawPointsAdjuster interface {
 	Container() bool
 	RawPoints() fxp.Int
 	SetRawPoints(points fxp.Int) bool
 }
 
-// SkillAdjustmentProvider defines methods for nodes that can have their skill level adjusted must implement.
+// SkillAdjustmentProvider interface for objects that can have their skill level adjusted.
 type SkillAdjustmentProvider interface {
 	RawPointsAdjuster
 	IncrementSkillLevel()

--- a/model/gurps/node.go
+++ b/model/gurps/node.go
@@ -31,6 +31,8 @@ type DataOwnerProvider interface {
 	DataOwner() DataOwner
 }
 
+// Node defines the methods required of nodes in our tables.
+//
 // The type union in the body makes this a constraint, not an ordinary interface: it may only be used as a type
 // parameter's constraint or embedded in another constraint, never as a type. Generic code takes a T Node[T] type
 // parameter and works with T directly.

--- a/model/gurps/node.go
+++ b/model/gurps/node.go
@@ -39,7 +39,7 @@ type Node[T Node[T]] interface {
 	// These are the limited set of types that can be nodes. New node types *must* be added here
 	*ConditionalModifier | *Equipment | *EquipmentModifier | *Note | *Skill | *Spell | *Trait | *TraitModifier | *Weapon
 
-	// These are the interface mathods each of the above types must implement as a minimum
+	// These are the interface methods each of the above types must implement as a minimum
 	fmt.Stringer
 	Openable
 	Hashable

--- a/model/gurps/node.go
+++ b/model/gurps/node.go
@@ -31,15 +31,15 @@ type DataOwnerProvider interface {
 	DataOwner() DataOwner
 }
 
-// NodeTypes is a constraint that defines the types that may be nodes.
-type NodeTypes interface {
-	*ConditionalModifier | *Equipment | *EquipmentModifier | *Note | *Skill | *Spell | *Trait | *TraitModifier | *Weapon
-	nameable.Applier
-	fmt.Stringer
-}
-
 // Node defines the methods required of nodes in our tables.
-type Node[T NodeTypes] interface {
+//
+// This interface is a "constraint" and cannot be used as a type param, just as a constraint.
+// In practice this just means that it can only be used inside the square brackets of generic methods/types.
+type Node[T Node[T]] interface {
+	// These are the limited set of types that can be nodes. New node types *must* be added here
+	*ConditionalModifier | *Equipment | *EquipmentModifier | *Note | *Skill | *Spell | *Trait | *TraitModifier | *Weapon
+
+	// These are the interface mathods each of the above types must implement as a minimum
 	fmt.Stringer
 	Openable
 	Hashable
@@ -60,6 +60,8 @@ type Node[T NodeTypes] interface {
 	CellData(columnID int, data *CellData)
 }
 
+func assertNode[T Node[T]]() {}
+
 // RawPointsAdjuster defines methods for nodes that can have their raw points adjusted must implement.
 type RawPointsAdjuster interface {
 	Container() bool
@@ -75,24 +77,17 @@ type SkillAdjustmentProvider interface {
 }
 
 // EditorData defines the methods required of editor data.
-type EditorData[T NodeTypes] interface {
+type EditorData[T Node[T]] interface {
 	// CopyFrom copies the corresponding data from the node into this editor data.
 	CopyFrom(T)
 	// ApplyTo copies the editor data into the provided node.
 	ApplyTo(T)
 }
 
-// AsNode converts a T to a Node[T]. This shouldn't require these hoops, but Go generics (as of 1.19) fails to compile
-// otherwise.
-func AsNode[T NodeTypes](in T) Node[T] {
-	if node, ok := any(in).(Node[T]); ok {
-		return node
-	}
-	return nil
-}
+func assertEditorData[T EditorData[N], N Node[N]]() {}
 
 // EntityFromNode returns the owning entity of the node, or nil.
-func EntityFromNode[T NodeTypes](node Node[T]) *Entity {
+func EntityFromNode[T Node[T]](node T) *Entity {
 	if xreflect.IsNil(node) {
 		return nil
 	}
@@ -121,6 +116,6 @@ func convertOldCategoriesToTags(tags, categories []string) []string {
 }
 
 // PropagateNodeNoteClosedState propagates the note closed state from one node to another.
-func PropagateNodeNoteClosedState[T NodeTypes](from, to Node[T]) {
+func PropagateNodeNoteClosedState[T Node[T]](from, to T) {
 	SetClosedState("N:"+string(to.ID()), IsClosed("N:"+string(from.ID())))
 }

--- a/model/gurps/note.go
+++ b/model/gurps/note.go
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	_ Node[*Note]       = &Note{}
-	_ EditorData[*Note] = &NoteEditData{}
+	_ = assertNode[*Note]
+	_ = assertEditorData[*NoteEditData]
 )
 
 // Columns that can be used with the note method .CellData()

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -40,11 +40,12 @@ import (
 )
 
 var (
-	_ Node[*Skill]            = &Skill{}
+	_ = assertNode[*Skill]
+	_ = assertEditorData[*SkillEditData]
+
 	_ TechLevelProvider       = &Skill{}
 	_ SkillAdjustmentProvider = &Skill{}
 	_ TemplatePickerProvider  = &Skill{}
-	_ EditorData[*Skill]      = &SkillEditData{}
 )
 
 // Columns that can be used with the skill method .CellData()

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -40,11 +40,11 @@ import (
 )
 
 var (
-	_ Node[*Skill]                    = &Skill{}
-	_ TechLevelProvider[*Skill]       = &Skill{}
-	_ SkillAdjustmentProvider[*Skill] = &Skill{}
-	_ TemplatePickerProvider          = &Skill{}
-	_ EditorData[*Skill]              = &SkillEditData{}
+	_ Node[*Skill]            = &Skill{}
+	_ TechLevelProvider       = &Skill{}
+	_ SkillAdjustmentProvider = &Skill{}
+	_ TemplatePickerProvider  = &Skill{}
+	_ EditorData[*Skill]      = &SkillEditData{}
 )
 
 // Columns that can be used with the skill method .CellData()

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -41,7 +41,7 @@ import (
 
 var (
 	_ = assertNode[*Spell]
-	_ = assertEditorData[*Spell]
+	_ = assertEditorData[*SpellEditData]
 
 	_ TechLevelProvider       = &Spell{}
 	_ SkillAdjustmentProvider = &Spell{}

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -40,11 +40,11 @@ import (
 )
 
 var (
-	_ Node[*Spell]                    = &Spell{}
-	_ TechLevelProvider[*Spell]       = &Spell{}
-	_ SkillAdjustmentProvider[*Spell] = &Spell{}
-	_ TemplatePickerProvider          = &Spell{}
-	_ EditorData[*Spell]              = &SpellEditData{}
+	_ Node[*Spell]            = &Spell{}
+	_ TechLevelProvider       = &Spell{}
+	_ SkillAdjustmentProvider = &Spell{}
+	_ TemplatePickerProvider  = &Spell{}
+	_ EditorData[*Spell]      = &SpellEditData{}
 )
 
 // Columns that can be used with the spell method .CellData()

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -40,11 +40,12 @@ import (
 )
 
 var (
-	_ Node[*Spell]            = &Spell{}
+	_ = assertNode[*Spell]
+	_ = assertEditorData[*Spell]
+
 	_ TechLevelProvider       = &Spell{}
 	_ SkillAdjustmentProvider = &Spell{}
 	_ TemplatePickerProvider  = &Spell{}
-	_ EditorData[*Spell]      = &SpellEditData{}
 )
 
 // Columns that can be used with the spell method .CellData()

--- a/model/gurps/tech_level.go
+++ b/model/gurps/tech_level.go
@@ -17,8 +17,7 @@ import (
 )
 
 // TechLevelProvider defines methods that a TechLevel provider must implement.
-type TechLevelProvider[T NodeTypes] interface {
-	Node[T]
+type TechLevelProvider interface {
 	RequiresTL() bool
 	TL() string
 	SetTL(tl string)

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -46,7 +46,7 @@ import (
 
 var (
 	_ = assertNode[*Trait]
-	_ = assertEditorData[*Trait]
+	_ = assertEditorData[*TraitEditData]
 
 	_ WeaponOwner            = &Trait{}
 	_ TemplatePickerProvider = &Trait{}

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -45,11 +45,12 @@ import (
 )
 
 var (
+	_ = assertNode[*Trait]
+	_ = assertEditorData[*Trait]
+
 	_ WeaponOwner            = &Trait{}
-	_ Node[*Trait]           = &Trait{}
 	_ TemplatePickerProvider = &Trait{}
 	_ LeveledOwner           = &Trait{}
-	_ EditorData[*Trait]     = &TraitEditData{}
 )
 
 // Columns that can be used with the trait method .CellData()

--- a/model/gurps/trait_modifier.go
+++ b/model/gurps/trait_modifier.go
@@ -36,10 +36,11 @@ import (
 )
 
 var (
-	_ Node[*TraitModifier]       = &TraitModifier{}
-	_ GeneralModifier            = &TraitModifier{}
-	_ LeveledOwner               = &TraitModifier{}
-	_ EditorData[*TraitModifier] = &TraitModifierEditData{}
+	_ = assertNode[*TraitModifier]
+	_ = assertEditorData[*TraitModifier]
+
+	_ GeneralModifier = &TraitModifier{}
+	_ LeveledOwner    = &TraitModifier{}
 )
 
 // Columns that can be used with the trait modifier method .CellData()

--- a/model/gurps/trait_modifier.go
+++ b/model/gurps/trait_modifier.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	_ = assertNode[*TraitModifier]
-	_ = assertEditorData[*TraitModifier]
+	_ = assertEditorData[*TraitModifierEditData]
 
 	_ GeneralModifier = &TraitModifier{}
 	_ LeveledOwner    = &TraitModifier{}

--- a/model/gurps/traverse.go
+++ b/model/gurps/traverse.go
@@ -11,7 +11,7 @@ package gurps
 
 import "slices"
 
-type traversalData[T NodeTypes] struct {
+type traversalData[T Node[T]] struct {
 	list  []T
 	index int
 }
@@ -19,7 +19,7 @@ type traversalData[T NodeTypes] struct {
 // Traverse calls the function 'f' for each node and its children in the input list, recursively. Return true from the
 // function to abort early. If excludeContainers is true, then nodes that are containers will not be passed to 'f',
 // although their children will still be processed as usual.
-func Traverse[T NodeTypes](f func(T) bool, onlyEnabled, excludeContainers bool, in ...T) {
+func Traverse[T Node[T]](f func(T) bool, onlyEnabled, excludeContainers bool, in ...T) {
 	tracking := []*traversalData[T]{
 		{
 			list:  in,
@@ -32,11 +32,10 @@ func Traverse[T NodeTypes](f func(T) bool, onlyEnabled, excludeContainers bool, 
 			tracking = tracking[:len(tracking)-1]
 			continue
 		}
-		one := current.list[current.index]
-		node := AsNode(one)
+		node := current.list[current.index]
 		current.index++
 		if !onlyEnabled || node.Enabled() {
-			if (!excludeContainers || !node.Container()) && f(one) {
+			if (!excludeContainers || !node.Container()) && f(node) {
 				return
 			}
 			if node.HasChildren() {

--- a/model/gurps/weapon.go
+++ b/model/gurps/weapon.go
@@ -42,7 +42,7 @@ import (
 	"github.com/zeebo/xxh3"
 )
 
-var _ Node[*Weapon] = &Weapon{}
+var _ = assertNode[*Weapon]
 
 const currentWeaponSubVersion = 1
 

--- a/ux/adjust_points.go
+++ b/ux/adjust_points.go
@@ -16,9 +16,9 @@ import (
 	"github.com/richardwilkes/unison"
 )
 
-func rawPointsExtractor[T gurps.NodeTypes](increment bool) func(T) (gurps.RawPointsAdjuster[T], bool) {
-	return func(data T) (gurps.RawPointsAdjuster[T], bool) {
-		if provider, ok := any(data).(gurps.RawPointsAdjuster[T]); ok && !provider.Container() &&
+func rawPointsExtractor[T gurps.NodeTypes](increment bool) func(T) (gurps.RawPointsAdjuster, bool) {
+	return func(data T) (gurps.RawPointsAdjuster, bool) {
+		if provider, ok := any(data).(gurps.RawPointsAdjuster); ok && !provider.Container() &&
 			(increment || provider.RawPoints() > 0) {
 			return provider, true
 		}
@@ -36,9 +36,9 @@ func adjustRawPoints[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[*
 		title = i18n.Text("Increment Points")
 	}
 	adjustSelection(title, owner, table, rawPointsExtractor[T](increment),
-		func(p gurps.RawPointsAdjuster[T]) fxp.Int { return p.RawPoints() },
-		func(p gurps.RawPointsAdjuster[T], v fxp.Int) { p.SetRawPoints(v) },
-		func(p gurps.RawPointsAdjuster[T]) {
+		func(p gurps.RawPointsAdjuster) fxp.Int { return p.RawPoints() },
+		func(p gurps.RawPointsAdjuster, v fxp.Int) { p.SetRawPoints(v) },
+		func(p gurps.RawPointsAdjuster) {
 			rawPts := p.RawPoints()
 			pts := rawPts.Floor()
 			if increment {

--- a/ux/adjust_points.go
+++ b/ux/adjust_points.go
@@ -16,7 +16,7 @@ import (
 	"github.com/richardwilkes/unison"
 )
 
-func rawPointsExtractor[T gurps.NodeTypes](increment bool) func(T) (gurps.RawPointsAdjuster, bool) {
+func rawPointsExtractor[T gurps.Node[T]](increment bool) func(T) (gurps.RawPointsAdjuster, bool) {
 	return func(data T) (gurps.RawPointsAdjuster, bool) {
 		if provider, ok := any(data).(gurps.RawPointsAdjuster); ok && !provider.Container() &&
 			(increment || provider.RawPoints() > 0) {
@@ -26,11 +26,11 @@ func rawPointsExtractor[T gurps.NodeTypes](increment bool) func(T) (gurps.RawPoi
 	}
 }
 
-func canAdjustRawPoints[T gurps.NodeTypes](table *unison.Table[*Node[T]], increment bool) bool {
+func canAdjustRawPoints[T gurps.Node[T]](table *unison.Table[*Node[T]], increment bool) bool {
 	return canAdjustSelection(table, rawPointsExtractor[T](increment))
 }
 
-func adjustRawPoints[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[*Node[T]], increment bool) {
+func adjustRawPoints[T gurps.Node[T]](owner Rebuildable, table *unison.Table[*Node[T]], increment bool) {
 	title := i18n.Text("Decrement Points")
 	if increment {
 		title = i18n.Text("Increment Points")

--- a/ux/adjust_skill_level.go
+++ b/ux/adjust_skill_level.go
@@ -15,7 +15,7 @@ import (
 	"github.com/richardwilkes/unison"
 )
 
-func skillLevelExtractor[T gurps.NodeTypes](increment bool) func(T) (gurps.SkillAdjustmentProvider, bool) {
+func skillLevelExtractor[T gurps.Node[T]](increment bool) func(T) (gurps.SkillAdjustmentProvider, bool) {
 	return func(data T) (gurps.SkillAdjustmentProvider, bool) {
 		if provider, ok := any(data).(gurps.SkillAdjustmentProvider); ok && !provider.Container() &&
 			(increment || provider.RawPoints() > 0) {
@@ -25,11 +25,11 @@ func skillLevelExtractor[T gurps.NodeTypes](increment bool) func(T) (gurps.Skill
 	}
 }
 
-func canAdjustSkillLevel[T gurps.NodeTypes](table *unison.Table[*Node[T]], increment bool) bool {
+func canAdjustSkillLevel[T gurps.Node[T]](table *unison.Table[*Node[T]], increment bool) bool {
 	return canAdjustSelection(table, skillLevelExtractor[T](increment))
 }
 
-func adjustSkillLevel[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[*Node[T]], increment bool) {
+func adjustSkillLevel[T gurps.Node[T]](owner Rebuildable, table *unison.Table[*Node[T]], increment bool) {
 	title := increaseSkillLevelAction.Title
 	if !increment {
 		title = decreaseSkillLevelAction.Title

--- a/ux/adjust_skill_level.go
+++ b/ux/adjust_skill_level.go
@@ -15,9 +15,9 @@ import (
 	"github.com/richardwilkes/unison"
 )
 
-func skillLevelExtractor[T gurps.NodeTypes](increment bool) func(T) (gurps.SkillAdjustmentProvider[T], bool) {
-	return func(data T) (gurps.SkillAdjustmentProvider[T], bool) {
-		if provider, ok := any(data).(gurps.SkillAdjustmentProvider[T]); ok && !provider.Container() &&
+func skillLevelExtractor[T gurps.NodeTypes](increment bool) func(T) (gurps.SkillAdjustmentProvider, bool) {
+	return func(data T) (gurps.SkillAdjustmentProvider, bool) {
+		if provider, ok := any(data).(gurps.SkillAdjustmentProvider); ok && !provider.Container() &&
 			(increment || provider.RawPoints() > 0) {
 			return provider, true
 		}
@@ -35,9 +35,9 @@ func adjustSkillLevel[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[
 		title = decreaseSkillLevelAction.Title
 	}
 	adjustSelection(title, owner, table, skillLevelExtractor[T](increment),
-		func(p gurps.SkillAdjustmentProvider[T]) fxp.Int { return p.RawPoints() },
-		func(p gurps.SkillAdjustmentProvider[T], v fxp.Int) { p.SetRawPoints(v) },
-		func(p gurps.SkillAdjustmentProvider[T]) {
+		func(p gurps.SkillAdjustmentProvider) fxp.Int { return p.RawPoints() },
+		func(p gurps.SkillAdjustmentProvider, v fxp.Int) { p.SetRawPoints(v) },
+		func(p gurps.SkillAdjustmentProvider) {
 			if increment {
 				p.IncrementSkillLevel()
 			} else {

--- a/ux/adjust_tech_level.go
+++ b/ux/adjust_tech_level.go
@@ -15,9 +15,9 @@ import (
 	"github.com/richardwilkes/unison"
 )
 
-func techLevelExtractor[T gurps.NodeTypes](amount fxp.Int) func(T) (gurps.TechLevelProvider[T], bool) {
-	return func(data T) (gurps.TechLevelProvider[T], bool) {
-		if provider, ok := any(data).(gurps.TechLevelProvider[T]); ok && provider.RequiresTL() {
+func techLevelExtractor[T gurps.NodeTypes](amount fxp.Int) func(T) (gurps.TechLevelProvider, bool) {
+	return func(data T) (gurps.TechLevelProvider, bool) {
+		if provider, ok := any(data).(gurps.TechLevelProvider); ok && provider.RequiresTL() {
 			if _, changed := gurps.AdjustTechLevel(provider.TL(), amount); changed {
 				return provider, true
 			}
@@ -36,9 +36,9 @@ func adjustTechLevel[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[*
 		title = decreaseTechLevelAction.Title
 	}
 	adjustSelection(title, owner, table, techLevelExtractor[T](amount),
-		func(p gurps.TechLevelProvider[T]) string { return p.TL() },
-		func(p gurps.TechLevelProvider[T], v string) { p.SetTL(v) },
-		func(p gurps.TechLevelProvider[T]) {
+		func(p gurps.TechLevelProvider) string { return p.TL() },
+		func(p gurps.TechLevelProvider, v string) { p.SetTL(v) },
+		func(p gurps.TechLevelProvider) {
 			tl, _ := gurps.AdjustTechLevel(p.TL(), amount)
 			p.SetTL(tl)
 		},

--- a/ux/adjust_tech_level.go
+++ b/ux/adjust_tech_level.go
@@ -15,7 +15,7 @@ import (
 	"github.com/richardwilkes/unison"
 )
 
-func techLevelExtractor[T gurps.NodeTypes](amount fxp.Int) func(T) (gurps.TechLevelProvider, bool) {
+func techLevelExtractor[T gurps.Node[T]](amount fxp.Int) func(T) (gurps.TechLevelProvider, bool) {
 	return func(data T) (gurps.TechLevelProvider, bool) {
 		if provider, ok := any(data).(gurps.TechLevelProvider); ok && provider.RequiresTL() {
 			if _, changed := gurps.AdjustTechLevel(provider.TL(), amount); changed {
@@ -26,11 +26,11 @@ func techLevelExtractor[T gurps.NodeTypes](amount fxp.Int) func(T) (gurps.TechLe
 	}
 }
 
-func canAdjustTechLevel[T gurps.NodeTypes](table *unison.Table[*Node[T]], amount fxp.Int) bool {
+func canAdjustTechLevel[T gurps.Node[T]](table *unison.Table[*Node[T]], amount fxp.Int) bool {
 	return canAdjustSelection(table, techLevelExtractor[T](amount))
 }
 
-func adjustTechLevel[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[*Node[T]], amount fxp.Int) {
+func adjustTechLevel[T gurps.Node[T]](owner Rebuildable, table *unison.Table[*Node[T]], amount fxp.Int) {
 	title := increaseTechLevelAction.Title
 	if amount < 0 {
 		title = decreaseTechLevelAction.Title

--- a/ux/container_conversion.go
+++ b/ux/container_conversion.go
@@ -11,6 +11,7 @@ package ux
 
 import (
 	"github.com/richardwilkes/gcs/v5/model/gurps"
+	"github.com/richardwilkes/toolbox/v2/xreflect"
 	"github.com/richardwilkes/unison"
 )
 
@@ -68,7 +69,7 @@ func InstallContainerConversionHandlers[T gurps.Node[T]](paneler unison.Paneler,
 // CanConvertToContainer returns true if the table's current selection has a row that can be converted to a container.
 func CanConvertToContainer[T gurps.Node[T]](table *unison.Table[*Node[T]]) bool {
 	for _, row := range table.SelectedRows(false) {
-		if data, ok := any(row.Data()).(ConvertableContainer); ok && data.CanConvertToFromContainer() && !data.Container() {
+		if data, ok := any(row.Data()).(ConvertableContainer); ok && !xreflect.IsNil(data) && data.CanConvertToFromContainer() && !data.Container() {
 			return true
 		}
 	}
@@ -79,7 +80,7 @@ func CanConvertToContainer[T gurps.Node[T]](table *unison.Table[*Node[T]]) bool 
 // non-container.
 func CanConvertToNonContainer[T gurps.Node[T]](table *unison.Table[*Node[T]]) bool {
 	for _, row := range table.SelectedRows(false) {
-		if data, ok := any(row.Data()).(ConvertableContainer); ok && data.CanConvertToFromContainer() && data.Container() {
+		if data, ok := any(row.Data()).(ConvertableContainer); ok && !xreflect.IsNil(data) && data.CanConvertToFromContainer() && data.Container() {
 			return true
 		}
 	}
@@ -91,7 +92,7 @@ func ConvertToContainer[T gurps.Node[T]](owner Rebuildable, table *unison.Table[
 	before := &containerConversionList{Owner: owner}
 	after := &containerConversionList{Owner: owner}
 	for _, row := range table.SelectedRows(false) {
-		if data, ok := any(row.Data()).(ConvertableContainer); ok && data.CanConvertToFromContainer() && !data.Container() {
+		if data, ok := any(row.Data()).(ConvertableContainer); ok && !xreflect.IsNil(data) && data.CanConvertToFromContainer() && !data.Container() {
 			before.List = append(before.List, newContainerConversion(data, false))
 			after.List = append(after.List, newContainerConversion(data, true))
 			data.ConvertToContainer()
@@ -117,7 +118,7 @@ func ConvertToNonContainer[T gurps.Node[T]](owner Rebuildable, table *unison.Tab
 	before := &containerConversionList{Owner: owner}
 	after := &containerConversionList{Owner: owner}
 	for _, row := range table.SelectedRows(false) {
-		if data, ok := any(row.Data()).(ConvertableContainer); ok && data.CanConvertToFromContainer() && data.Container() {
+		if data, ok := any(row.Data()).(ConvertableContainer); ok && !xreflect.IsNil(data) && data.CanConvertToFromContainer() && data.Container() {
 			before.List = append(before.List, newContainerConversion(data, true))
 			after.List = append(after.List, newContainerConversion(data, false))
 			data.ConvertToNonContainer()

--- a/ux/container_conversion.go
+++ b/ux/container_conversion.go
@@ -10,49 +10,43 @@
 package ux
 
 import (
-	"fmt"
-
 	"github.com/richardwilkes/gcs/v5/model/gurps"
-	"github.com/richardwilkes/gcs/v5/model/nameable"
 	"github.com/richardwilkes/unison"
 )
 
-// ConvertableNodeTypes defines the types that the container conversion can work on.
-type ConvertableNodeTypes interface {
-	*gurps.Equipment | *gurps.Note
-	fmt.Stringer
-	nameable.Applier
+// ConvertableContainer defines the types that the container conversion can work on.
+type ConvertableContainer interface {
 	Container() bool
 	CanConvertToFromContainer() bool
 	ConvertToContainer()
 	ConvertToNonContainer()
 }
 
-type containerConversionList[T ConvertableNodeTypes] struct {
+type containerConversionList struct {
 	Owner Rebuildable
-	List  []*containerConversion[T]
+	List  []*containerConversion
 }
 
-func (c *containerConversionList[T]) Apply() {
+func (c *containerConversionList) Apply() {
 	for _, one := range c.List {
 		one.Apply()
 	}
 	c.Owner.Rebuild(true)
 }
 
-type containerConversion[T ConvertableNodeTypes] struct {
-	Target      T
+type containerConversion struct {
+	Target      ConvertableContainer
 	ToContainer bool
 }
 
-func newContainerConversion[T ConvertableNodeTypes](target T, toContainer bool) *containerConversion[T] {
-	return &containerConversion[T]{
+func newContainerConversion(target ConvertableContainer, toContainer bool) *containerConversion {
+	return &containerConversion{
 		Target:      target,
 		ToContainer: toContainer,
 	}
 }
 
-func (c *containerConversion[T]) Apply() {
+func (c *containerConversion) Apply() {
 	if c.ToContainer {
 		c.Target.ConvertToContainer()
 	} else {
@@ -61,7 +55,7 @@ func (c *containerConversion[T]) Apply() {
 }
 
 // InstallContainerConversionHandlers installs the to & from container conversion handlers.
-func InstallContainerConversionHandlers[T ConvertableNodeTypes](paneler unison.Paneler, owner Rebuildable, table *unison.Table[*Node[T]]) {
+func InstallContainerConversionHandlers[T gurps.Node[T]](paneler unison.Paneler, owner Rebuildable, table *unison.Table[*Node[T]]) {
 	p := paneler.AsPanel()
 	p.InstallCmdHandlers(ConvertToContainerItemID,
 		func(_ any) bool { return CanConvertToContainer(table) },
@@ -72,9 +66,9 @@ func InstallContainerConversionHandlers[T ConvertableNodeTypes](paneler unison.P
 }
 
 // CanConvertToContainer returns true if the table's current selection has a row that can be converted to a container.
-func CanConvertToContainer[T ConvertableNodeTypes](table *unison.Table[*Node[T]]) bool {
+func CanConvertToContainer[T gurps.Node[T]](table *unison.Table[*Node[T]]) bool {
 	for _, row := range table.SelectedRows(false) {
-		if data := row.Data(); data != nil && data.CanConvertToFromContainer() && !data.Container() {
+		if data, ok := any(row.Data()).(ConvertableContainer); ok && data.CanConvertToFromContainer() && !data.Container() {
 			return true
 		}
 	}
@@ -83,9 +77,9 @@ func CanConvertToContainer[T ConvertableNodeTypes](table *unison.Table[*Node[T]]
 
 // CanConvertToNonContainer returns true if the table's current selection has a row that can be converted to a
 // non-container.
-func CanConvertToNonContainer[T ConvertableNodeTypes](table *unison.Table[*Node[T]]) bool {
+func CanConvertToNonContainer[T gurps.Node[T]](table *unison.Table[*Node[T]]) bool {
 	for _, row := range table.SelectedRows(false) {
-		if data := row.Data(); data != nil && data.CanConvertToFromContainer() && data.Container() {
+		if data, ok := any(row.Data()).(ConvertableContainer); ok && data.CanConvertToFromContainer() && data.Container() {
 			return true
 		}
 	}
@@ -93,11 +87,11 @@ func CanConvertToNonContainer[T ConvertableNodeTypes](table *unison.Table[*Node[
 }
 
 // ConvertToContainer converts any selected rows to containers, if possible.
-func ConvertToContainer[T ConvertableNodeTypes](owner Rebuildable, table *unison.Table[*Node[T]]) {
-	before := &containerConversionList[T]{Owner: owner}
-	after := &containerConversionList[T]{Owner: owner}
+func ConvertToContainer[T gurps.Node[T]](owner Rebuildable, table *unison.Table[*Node[T]]) {
+	before := &containerConversionList{Owner: owner}
+	after := &containerConversionList{Owner: owner}
 	for _, row := range table.SelectedRows(false) {
-		if data := row.Data(); data != nil && data.CanConvertToFromContainer() && !data.Container() {
+		if data, ok := any(row.Data()).(ConvertableContainer); ok && data.CanConvertToFromContainer() && !data.Container() {
 			before.List = append(before.List, newContainerConversion(data, false))
 			after.List = append(after.List, newContainerConversion(data, true))
 			data.ConvertToContainer()
@@ -105,11 +99,11 @@ func ConvertToContainer[T ConvertableNodeTypes](owner Rebuildable, table *unison
 	}
 	if len(before.List) > 0 {
 		if mgr := unison.UndoManagerFor(table); mgr != nil {
-			mgr.Add(&unison.UndoEdit[*containerConversionList[T]]{
+			mgr.Add(&unison.UndoEdit[*containerConversionList]{
 				ID:         unison.NextUndoID(),
 				EditName:   convertToContainerAction.Title,
-				UndoFunc:   func(edit *unison.UndoEdit[*containerConversionList[T]]) { edit.BeforeData.Apply() },
-				RedoFunc:   func(edit *unison.UndoEdit[*containerConversionList[T]]) { edit.AfterData.Apply() },
+				UndoFunc:   func(edit *unison.UndoEdit[*containerConversionList]) { edit.BeforeData.Apply() },
+				RedoFunc:   func(edit *unison.UndoEdit[*containerConversionList]) { edit.AfterData.Apply() },
 				BeforeData: before,
 				AfterData:  after,
 			})
@@ -119,11 +113,11 @@ func ConvertToContainer[T ConvertableNodeTypes](owner Rebuildable, table *unison
 }
 
 // ConvertToNonContainer converts any selected rows to non-containers, if possible.
-func ConvertToNonContainer[T ConvertableNodeTypes](owner Rebuildable, table *unison.Table[*Node[T]]) {
-	before := &containerConversionList[T]{Owner: owner}
-	after := &containerConversionList[T]{Owner: owner}
+func ConvertToNonContainer[T gurps.Node[T]](owner Rebuildable, table *unison.Table[*Node[T]]) {
+	before := &containerConversionList{Owner: owner}
+	after := &containerConversionList{Owner: owner}
 	for _, row := range table.SelectedRows(false) {
-		if data := row.Data(); data != nil && data.CanConvertToFromContainer() && data.Container() {
+		if data, ok := any(row.Data()).(ConvertableContainer); ok && data.CanConvertToFromContainer() && data.Container() {
 			before.List = append(before.List, newContainerConversion(data, true))
 			after.List = append(after.List, newContainerConversion(data, false))
 			data.ConvertToNonContainer()
@@ -131,11 +125,11 @@ func ConvertToNonContainer[T ConvertableNodeTypes](owner Rebuildable, table *uni
 	}
 	if len(before.List) > 0 {
 		if mgr := unison.UndoManagerFor(table); mgr != nil {
-			mgr.Add(&unison.UndoEdit[*containerConversionList[T]]{
+			mgr.Add(&unison.UndoEdit[*containerConversionList]{
 				ID:         unison.NextUndoID(),
 				EditName:   convertToNonContainerAction.Title,
-				UndoFunc:   func(edit *unison.UndoEdit[*containerConversionList[T]]) { edit.BeforeData.Apply() },
-				RedoFunc:   func(edit *unison.UndoEdit[*containerConversionList[T]]) { edit.AfterData.Apply() },
+				UndoFunc:   func(edit *unison.UndoEdit[*containerConversionList]) { edit.BeforeData.Apply() },
+				RedoFunc:   func(edit *unison.UndoEdit[*containerConversionList]) { edit.AfterData.Apply() },
 				BeforeData: before,
 				AfterData:  after,
 			})

--- a/ux/container_conversion.go
+++ b/ux/container_conversion.go
@@ -15,7 +15,8 @@ import (
 	"github.com/richardwilkes/unison"
 )
 
-// ConvertableContainer defines the types that the container conversion can work on.
+// ConvertableContainer defines the methods a node must implement to be convertible to and from a container. Rows are
+// matched against it at runtime, so nodes that do not implement it are simply skipped.
 type ConvertableContainer interface {
 	Container() bool
 	CanConvertToFromContainer() bool

--- a/ux/container_conversion.go
+++ b/ux/container_conversion.go
@@ -58,13 +58,16 @@ func (c *containerConversion) Apply() {
 
 // InstallContainerConversionHandlers installs the to & from container conversion handlers.
 func InstallContainerConversionHandlers[T gurps.Node[T]](paneler unison.Paneler, owner Rebuildable, table *unison.Table[*Node[T]]) {
-	p := paneler.AsPanel()
-	p.InstallCmdHandlers(ConvertToContainerItemID,
-		func(_ any) bool { return CanConvertToContainer(table) },
-		func(_ any) { ConvertToContainer(owner, table) })
-	p.InstallCmdHandlers(ConvertToNonContainerItemID,
-		func(_ any) bool { return CanConvertToNonContainer(table) },
-		func(_ any) { ConvertToNonContainer(owner, table) })
+	var zero T
+	if _, ok := any(zero).(ConvertableContainer); ok {
+		p := paneler.AsPanel()
+		p.InstallCmdHandlers(ConvertToContainerItemID,
+			func(_ any) bool { return CanConvertToContainer(table) },
+			func(_ any) { ConvertToContainer(owner, table) })
+		p.InstallCmdHandlers(ConvertToNonContainerItemID,
+			func(_ any) bool { return CanConvertToNonContainer(table) },
+			func(_ any) { ConvertToNonContainer(owner, table) })
+	}
 }
 
 // CanConvertToContainer returns true if the table's current selection has a row that can be converted to a container.

--- a/ux/editor.go
+++ b/ux/editor.go
@@ -42,7 +42,7 @@ type nameableReplacementsSetter interface {
 	SetNameableReplacements(replacements map[string]string)
 }
 
-type editor[N gurps.NodeTypes, D gurps.EditorData[N]] struct {
+type editor[N gurps.Node[N], D gurps.EditorData[N]] struct {
 	unison.Panel
 	owner                Rebuildable
 	target               N
@@ -66,12 +66,12 @@ type editor[N gurps.NodeTypes, D gurps.EditorData[N]] struct {
 	promptForSave        bool
 }
 
-func displayEditor[N gurps.NodeTypes, D gurps.EditorData[N]](owner Rebuildable, target N, icon *unison.SVG, helpMD string, initToolbar func(*editor[N, D], *unison.Panel), initContent func(*editor[N, D], *unison.Panel) func(), preApplyCallback func(D)) *editor[N, D] {
+func displayEditor[N gurps.Node[N], D gurps.EditorData[N]](owner Rebuildable, target N, icon *unison.SVG, helpMD string, initToolbar func(*editor[N, D], *unison.Panel), initContent func(*editor[N, D], *unison.Panel) func(), preApplyCallback func(D)) *editor[N, D] {
 	var found *editor[N, D]
-	lookFor := gurps.AsNode(target).ID()
+	lookFor := target.ID()
 	if Activate(func(d unison.Dockable) bool {
 		if e, ok := d.AsPanel().Self.(*editor[N, D]); ok {
-			if e.owner == owner && gurps.AsNode(e.target).ID() == lookFor {
+			if e.owner == owner && e.target.ID() == lookFor {
 				found = e
 				return true
 			}
@@ -144,7 +144,7 @@ func displayEditor[N gurps.NodeTypes, D gurps.EditorData[N]](owner Rebuildable, 
 	e.AddChild(e.createToolbar(helpMD, initToolbar))
 	e.modificationCallback = initContent(e, content)
 	e.AddChild(e.scroll)
-	e.ClientData()[AssociatedIDKey] = gurps.AsNode(target).ID()
+	e.ClientData()[AssociatedIDKey] = target.ID()
 	e.promptForSave = true
 	e.scroll.Content().AsPanel().ValidateScrollRoot()
 	group := dgroup.Editors
@@ -253,8 +253,7 @@ func (e *editor[N, D]) createToolbar(helpMD string, initToolbar func(*editor[N, 
 }
 
 func (e *editor[N, D]) prepareForSubstitutions() (tmpNode N, m map[string]string) {
-	node := gurps.AsNode(e.target)
-	tmpNode = node.Clone(node.GetSource().LibraryFile, node.DataOwner(), nil, true)
+	tmpNode = e.target.Clone(e.target.GetSource().LibraryFile, e.target.DataOwner(), nil, true)
 	e.editorData.ApplyTo(tmpNode)
 	m = make(map[string]string)
 	tmpNode.FillWithNameableKeys(m, nil)
@@ -269,7 +268,7 @@ func (e *editor[N, D]) TitleIcon(suggestedSize geom.Size) unison.Drawable {
 }
 
 func (e *editor[N, D]) Title() string {
-	return fmt.Sprintf(i18n.Text("%s Editor for %s"), gurps.AsNode(e.target).Kind(), e.owner.String())
+	return fmt.Sprintf(i18n.Text("%s Editor for %s"), e.target.Kind(), e.owner.String())
 }
 
 func (e *editor[N, D]) String() string {
@@ -314,14 +313,13 @@ func (e *editor[N, D]) Modified() bool {
 // to avoid cloning the target on every call, since Modified is invoked frequently during layout and redraw.
 func (e *editor[N, D]) hasNameableKeys() bool {
 	if xreflect.IsNil(e.nameablesScratch) {
-		node := gurps.AsNode(e.target)
-		e.nameablesScratch = node.Clone(node.GetSource().LibraryFile, node.DataOwner(), nil, true)
+		e.nameablesScratch = e.target.Clone(e.target.GetSource().LibraryFile, e.target.DataOwner(), nil, true)
 		e.nameablesKeys = make(map[string]string)
 	} else {
 		clear(e.nameablesKeys)
 	}
 	e.editorData.ApplyTo(e.nameablesScratch)
-	gurps.AsNode(e.nameablesScratch).FillWithNameableKeys(e.nameablesKeys, nil)
+	e.nameablesScratch.FillWithNameableKeys(e.nameablesKeys, nil)
 	return len(e.nameablesKeys) > 0
 }
 
@@ -339,7 +337,7 @@ func (e *editor[N, D]) MarkModified(_ unison.Paneler) {
 }
 
 func (e *editor[N, D]) Rebuild(_ bool) {
-	if entity := gurps.EntityFromNode(gurps.AsNode(e.target)); entity != nil {
+	if entity := gurps.EntityFromNode(e.target); entity != nil {
 		entity.DiscardCaches()
 	} else {
 		gurps.DiscardGlobalResolveCache()
@@ -397,7 +395,7 @@ func (e *editor[N, D]) apply() {
 		target := e.target
 		mgr.Add(&unison.UndoEdit[D]{
 			ID:       unison.NextUndoID(),
-			EditName: fmt.Sprintf(i18n.Text("%s Changes"), gurps.AsNode(target).Kind()),
+			EditName: fmt.Sprintf(i18n.Text("%s Changes"), target.Kind()),
 			UndoFunc: func(edit *unison.UndoEdit[D]) {
 				edit.BeforeData.ApplyTo(target)
 				owner.Rebuild(true)

--- a/ux/editor_header.go
+++ b/ux/editor_header.go
@@ -23,7 +23,7 @@ import (
 )
 
 // NewEditorListHeader creates a new list header for an editor.
-func NewEditorListHeader[T gurps.NodeTypes](title, tooltip string, less func(a, b string) bool, forPage bool) unison.TableColumnHeader[*Node[T]] {
+func NewEditorListHeader[T gurps.Node[T]](title, tooltip string, less func(a, b string) bool, forPage bool) unison.TableColumnHeader[*Node[T]] {
 	if forPage {
 		return NewPageTableColumnHeader[T](title, tooltip, less)
 	}
@@ -31,7 +31,7 @@ func NewEditorListHeader[T gurps.NodeTypes](title, tooltip string, less func(a, 
 }
 
 // NewEditorListSVGHeader creates a new list header with an SVG image as its content rather than text.
-func NewEditorListSVGHeader[T gurps.NodeTypes](icon *unison.SVG, tooltip string, less func(a, b string) bool, forPage bool) unison.TableColumnHeader[*Node[T]] {
+func NewEditorListSVGHeader[T gurps.Node[T]](icon *unison.SVG, tooltip string, less func(a, b string) bool, forPage bool) unison.TableColumnHeader[*Node[T]] {
 	if forPage {
 		header := NewPageTableColumnHeader[T]("", tooltip, less)
 		baseline := header.Font.Baseline()
@@ -51,7 +51,7 @@ func NewEditorListSVGHeader[T gurps.NodeTypes](icon *unison.SVG, tooltip string,
 }
 
 // NewEditorListSVGPairHeader creates a new list header with a pair of SVG images as its content rather than text.
-func NewEditorListSVGPairHeader[T gurps.NodeTypes](leftSVG, rightSVG *unison.SVG, tooltip string, less func(a, b string) bool, forPage bool) unison.TableColumnHeader[*Node[T]] {
+func NewEditorListSVGPairHeader[T gurps.Node[T]](leftSVG, rightSVG *unison.SVG, tooltip string, less func(a, b string) bool, forPage bool) unison.TableColumnHeader[*Node[T]] {
 	if forPage {
 		header := NewPageTableColumnHeader[T]("", tooltip, less)
 		baseline := header.Font.Baseline()
@@ -72,7 +72,7 @@ func NewEditorListSVGPairHeader[T gurps.NodeTypes](leftSVG, rightSVG *unison.SVG
 	return header
 }
 
-func headerFromData[T gurps.NodeTypes](data gurps.HeaderData, forPage bool) unison.TableColumnHeader[*Node[T]] {
+func headerFromData[T gurps.Node[T]](data gurps.HeaderData, forPage bool) unison.TableColumnHeader[*Node[T]] {
 	if data.TitleIsImageKey {
 		var img1, img2 *unison.SVG
 		switch data.Title {
@@ -104,7 +104,7 @@ func headerFromData[T gurps.NodeTypes](data gurps.HeaderData, forPage bool) unis
 }
 
 // NewTableColumnHeader creates a new table column header panel with the given title in small caps.
-func NewTableColumnHeader[T gurps.NodeTypes](title, tooltip string, less func(a, b string) bool) *unison.DefaultTableColumnHeader[*Node[T]] {
+func NewTableColumnHeader[T gurps.Node[T]](title, tooltip string, less func(a, b string) bool) *unison.DefaultTableColumnHeader[*Node[T]] {
 	header := unison.NewTableColumnHeader[*Node[T]](title, tooltip, less)
 	header.Text = unison.NewSmallCapsText(title, &header.TextDecoration)
 	return header
@@ -126,14 +126,14 @@ var PageTableColumnHeaderTheme = unison.LabelTheme{
 var _ unison.TableColumnHeader[*Node[*gurps.Trait]] = &PageTableColumnHeader[*gurps.Trait]{}
 
 // PageTableColumnHeader provides a default page table column header panel.
-type PageTableColumnHeader[T gurps.NodeTypes] struct {
+type PageTableColumnHeader[T gurps.Node[T]] struct {
 	*unison.Label
 	less      func(a, b string) bool
 	sortState unison.SortState
 }
 
 // NewPageTableColumnHeader creates a new page table column header panel with the given title.
-func NewPageTableColumnHeader[T gurps.NodeTypes](title, tooltip string, less func(a, b string) bool) *PageTableColumnHeader[T] {
+func NewPageTableColumnHeader[T gurps.Node[T]](title, tooltip string, less func(a, b string) bool) *PageTableColumnHeader[T] {
 	h := &PageTableColumnHeader[T]{
 		Label: unison.NewLabel(),
 		less:  less,

--- a/ux/editor_table.go
+++ b/ux/editor_table.go
@@ -14,7 +14,7 @@ import (
 	"github.com/richardwilkes/unison"
 )
 
-func newEditorTable[T gurps.NodeTypes](parent *unison.Panel, provider TableProvider[T]) *unison.Table[*Node[T]] {
+func newEditorTable[T gurps.Node[T]](parent *unison.Panel, provider TableProvider[T]) *unison.Table[*Node[T]] {
 	header, table := NewNodeTable(provider, unison.FieldFont)
 	table.InstallCmdHandlers(OpenEditorItemID, func(_ any) bool { return table.HasSelection() },
 		func(_ any) { provider.OpenEditor(unison.AncestorOrSelf[Rebuildable](table), table) })

--- a/ux/modifier_processing.go
+++ b/ux/modifier_processing.go
@@ -10,10 +10,7 @@
 package ux
 
 import (
-	"fmt"
-
 	"github.com/richardwilkes/gcs/v5/model/gurps"
-	"github.com/richardwilkes/gcs/v5/model/nameable"
 	"github.com/richardwilkes/toolbox/v2/geom"
 	"github.com/richardwilkes/toolbox/v2/i18n"
 	"github.com/richardwilkes/toolbox/v2/xmath"
@@ -25,14 +22,8 @@ import (
 	"github.com/richardwilkes/unison/enums/mod"
 )
 
-type modifiersOnly interface {
-	*gurps.TraitModifier | *gurps.EquipmentModifier
-	fmt.Stringer
-	nameable.Applier
-}
-
 // ProcessModifiersForSelection processes the selected rows for modifiers that can be toggled on or off.
-func ProcessModifiersForSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
+func ProcessModifiersForSelection[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 	rows := table.SelectedRows(true)
 	data := make([]T, 0, len(rows))
 	for _, row := range rows {
@@ -49,7 +40,7 @@ var (
 
 // ProcessModifiers processes the rows for modifiers that can be toggled on or off. Note that only rows that can hold
 // modifiers (traits and equipment) are considered -- passing in the modifiers themselves does nothing.
-func ProcessModifiers[T gurps.NodeTypes](owner unison.Paneler, rows []T) {
+func ProcessModifiers[T gurps.Node[T]](owner unison.Paneler, rows []T) {
 	rebuild := func() {
 		if builder := unison.AncestorOrSelf[Rebuildable](owner); builder != nil {
 			builder.Rebuild(true)
@@ -59,11 +50,11 @@ func ProcessModifiers[T gurps.NodeTypes](owner unison.Paneler, rows []T) {
 		gurps.Traverse(func(row T) bool {
 			switch t := any(row).(type) {
 			case *gurps.Trait:
-				if promptForTraitModifiers(xstrings.Truncate(gurps.AsNode(row).String(), 40, true), t.Modifiers) {
+				if promptForTraitModifiers(xstrings.Truncate(row.String(), 40, true), t.Modifiers) {
 					rebuild()
 				}
 			case *gurps.Equipment:
-				if promptForEquipmentModifiers(xstrings.Truncate(gurps.AsNode(row).String(), 40, true), t.Modifiers) {
+				if promptForEquipmentModifiers(xstrings.Truncate(row.String(), 40, true), t.Modifiers) {
 					rebuild()
 				}
 			}
@@ -72,7 +63,7 @@ func ProcessModifiers[T gurps.NodeTypes](owner unison.Paneler, rows []T) {
 	}
 }
 
-func processModifiers[T modifiersOnly](title string, modifiers []T) bool {
+func processModifiers[T gurps.Node[T]](title string, modifiers []T) bool {
 	if len(modifiers) == 0 {
 		return false
 	}

--- a/ux/nameables_processing.go
+++ b/ux/nameables_processing.go
@@ -20,7 +20,7 @@ import (
 )
 
 // ProcessNameablesForSelection processes the selected rows and their children for any nameables.
-func ProcessNameablesForSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
+func ProcessNameablesForSelection[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 	rows := table.SelectedRows(true)
 	data := make([]T, 0, len(rows))
 	for _, row := range rows {
@@ -30,17 +30,17 @@ func ProcessNameablesForSelection[T gurps.NodeTypes](table *unison.Table[*Node[T
 }
 
 // ProcessNameables processes the rows and their children for any nameables.
-func ProcessNameables[T gurps.NodeTypes](owner unison.Paneler, rows []T) {
+func ProcessNameables[T gurps.Node[T]](owner unison.Paneler, rows []T) {
 	var data []T
 	var titles []string
 	var nameables []map[string]string
 	for _, row := range rows {
 		gurps.Traverse(func(row T) bool {
 			m := make(map[string]string)
-			gurps.AsNode(row).FillWithNameableKeys(m, nil)
+			row.FillWithNameableKeys(m, nil)
 			if len(m) > 0 {
 				data = append(data, row)
-				titles = append(titles, gurps.AsNode(row).String())
+				titles = append(titles, row.String())
 				nameables = append(nameables, m)
 			}
 			return false
@@ -49,7 +49,7 @@ func ProcessNameables[T gurps.NodeTypes](owner unison.Paneler, rows []T) {
 	if len(data) > 0 {
 		if ShowNameablesDialog(titles, nameables) {
 			for i, row := range data {
-				gurps.AsNode(row).ApplyNameableKeys(nameables[i])
+				row.ApplyNameableKeys(nameables[i])
 			}
 			if rebuildable := unison.Ancestor[Rebuildable](owner); rebuildable != nil {
 				rebuildable.Rebuild(true)

--- a/ux/navigator.go
+++ b/ux/navigator.go
@@ -1078,7 +1078,7 @@ func prepareProfileForContentCache(profile *gurps.Profile) string {
 	}, "\n"))
 }
 
-func prepareForContentCache[T gurps.NodeTypes](data []T) string {
+func prepareForContentCache[T gurps.Node[T]](data []T) string {
 	var buffer strings.Builder
 	gurps.Traverse(func(one T) bool {
 		buffer.WriteString(strings.ToLower(one.String()))

--- a/ux/page_exporter.go
+++ b/ux/page_exporter.go
@@ -321,7 +321,7 @@ func (s *pageState) key() string {
 	return ""
 }
 
-func addRowPanel[T gurps.NodeTypes](rowPanel *unison.Panel, list *PageList[T], key string, startAtMap map[string]int) {
+func addRowPanel[T gurps.Node[T]](rowPanel *unison.Panel, list *PageList[T], key string, startAtMap map[string]int) {
 	list.ClientData()[pageKey] = key
 	count := list.RowCount()
 	startAt := startAtMap[key]

--- a/ux/page_list.go
+++ b/ux/page_list.go
@@ -320,13 +320,7 @@ func installEquipmentLevelHandlers(p *PageList[*gurps.Equipment], owner Rebuilda
 }
 
 func (p *PageList[T]) installContainerConversionHandlers(owner Rebuildable) {
-	if t, ok := any(p.Table).(*unison.Table[*Node[*gurps.Equipment]]); ok {
-		InstallContainerConversionHandlers(p, owner, t)
-		return
-	}
-	if t, ok := any(p.Table).(*unison.Table[*Node[*gurps.Note]]); ok {
-		InstallContainerConversionHandlers(p, owner, t)
-	}
+	InstallContainerConversionHandlers(p, owner, p.Table)
 }
 
 // SelectedNodes returns the set of selected nodes. If 'minimal' is true, then children of selected rows that may also

--- a/ux/page_list.go
+++ b/ux/page_list.go
@@ -27,7 +27,7 @@ var (
 )
 
 // PageList holds a list for a sheet page.
-type PageList[T gurps.NodeTypes] struct {
+type PageList[T gurps.Node[T]] struct {
 	unison.Panel
 	tableHeader *unison.TableHeader[*Node[T]]
 	Table       *unison.Table[*Node[T]]
@@ -129,7 +129,7 @@ func NewRangedWeaponsPageList(entity *gurps.Entity) *PageList[*gurps.Weapon] {
 	return p
 }
 
-func newPageList[T gurps.NodeTypes](owner Rebuildable, provider TableProvider[T]) *PageList[T] {
+func newPageList[T gurps.Node[T]](owner Rebuildable, provider TableProvider[T]) *PageList[T] {
 	header, table := NewNodeTable(provider, fonts.PageFieldPrimary)
 	table.ClientData()[WorkingDirKey] = WorkingDirProvider(owner)
 	table.RefKey = provider.RefKey()

--- a/ux/page_ref.go
+++ b/ux/page_ref.go
@@ -15,10 +15,10 @@ import (
 )
 
 // CanOpenPageRef returns true if the current selection on the table has a page reference.
-func CanOpenPageRef[T gurps.NodeTypes](table *unison.Table[*Node[T]]) bool {
+func CanOpenPageRef[T gurps.Node[T]](table *unison.Table[*Node[T]]) bool {
 	for _, row := range table.SelectedRows(false) {
 		var data gurps.CellData
-		gurps.AsNode(row.Data()).CellData(gurps.PageRefCellAlias, &data)
+		row.Data().CellData(gurps.PageRefCellAlias, &data)
 		if len(ExtractPageReferences(data.Primary)) != 0 {
 			return true
 		}
@@ -27,11 +27,11 @@ func CanOpenPageRef[T gurps.NodeTypes](table *unison.Table[*Node[T]]) bool {
 }
 
 // OpenPageRef opens the first page reference on each selected item in the table.
-func OpenPageRef[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
+func OpenPageRef[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 	promptCtx := make(map[string]bool)
 	for _, row := range table.SelectedRows(false) {
 		var data gurps.CellData
-		gurps.AsNode(row.Data()).CellData(gurps.PageRefCellAlias, &data)
+		row.Data().CellData(gurps.PageRefCellAlias, &data)
 		for _, one := range ExtractPageReferences(data.Primary) {
 			OpenPageReference(one, data.Secondary, promptCtx)
 			break
@@ -40,11 +40,11 @@ func OpenPageRef[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
 }
 
 // OpenEachPageRef opens the all page references on each selected item in the table.
-func OpenEachPageRef[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
+func OpenEachPageRef[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 	promptCtx := make(map[string]bool)
 	for _, row := range table.SelectedRows(false) {
 		var data gurps.CellData
-		gurps.AsNode(row.Data()).CellData(gurps.PageRefCellAlias, &data)
+		row.Data().CellData(gurps.PageRefCellAlias, &data)
 		for _, one := range ExtractPageReferences(data.Primary) {
 			if OpenPageReference(one, data.Secondary, promptCtx) {
 				return

--- a/ux/preserved_table_data.go
+++ b/ux/preserved_table_data.go
@@ -17,7 +17,7 @@ import (
 )
 
 // PreservedTableData holds the data and selection state of a table in a serialized form.
-type PreservedTableData[T gurps.NodeTypes] struct {
+type PreservedTableData[T gurps.Node[T]] struct {
 	data   []byte
 	selMap map[tid.TID]bool
 }

--- a/ux/search_tracker.go
+++ b/ux/search_tracker.go
@@ -109,16 +109,16 @@ func (s *SearchTracker) doSearch(text string) {
 	s.adjustForMatch()
 }
 
-func searchSheetTable[T gurps.NodeTypes](refList *[]*searchRef, text string, namesOnly bool, pageList *PageList[T]) {
+func searchSheetTable[T gurps.Node[T]](refList *[]*searchRef, text string, namesOnly bool, pageList *PageList[T]) {
 	for _, row := range pageList.Table.RootRows() {
 		searchSheetTableRows(refList, text, namesOnly, pageList.Table, row)
 	}
 }
 
-func searchSheetTableRows[T gurps.NodeTypes](refList *[]*searchRef, text string, namesOnly bool, table *unison.Table[*Node[T]], row *Node[T]) {
+func searchSheetTableRows[T gurps.Node[T]](refList *[]*searchRef, text string, namesOnly bool, table *unison.Table[*Node[T]], row *Node[T]) {
 	if text != "" {
 		if namesOnly {
-			if strings.Contains(strings.ToLower(row.dataAsNode.String()), text) {
+			if strings.Contains(strings.ToLower(row.data.String()), text) {
 				*refList = append(*refList, &searchRef{
 					table: table,
 					row:   row,
@@ -206,7 +206,7 @@ func showSearchRef(ref *searchRef) {
 	}
 }
 
-func showSearchResolvedRef[T gurps.NodeTypes](table *unison.Table[*Node[T]], row *Node[T]) {
+func showSearchResolvedRef[T gurps.Node[T]](table *unison.Table[*Node[T]], row *Node[T]) {
 	table.DiscloseRow(row, false)
 	table.ClearSelection()
 	rowIndex := table.RowToIndex(row)

--- a/ux/table.go
+++ b/ux/table.go
@@ -41,7 +41,7 @@ const (
 )
 
 // TableProvider defines the methods a table provider must contain.
-type TableProvider[T gurps.NodeTypes] interface {
+type TableProvider[T gurps.Node[T]] interface {
 	unison.TableModel[*Node[T]]
 	gurps.DataOwnerProvider
 	SetTable(table *unison.Table[*Node[T]])
@@ -69,7 +69,7 @@ type TableProvider[T gurps.NodeTypes] interface {
 
 // NewNodeTable creates a new node table of the specified type, returning the header and table. Pass nil for 'font' if
 // this should be a standalone top-level table for a dockable. Otherwise, pass in the typical font used for a cell.
-func NewNodeTable[T gurps.NodeTypes](provider TableProvider[T], font unison.Font) (header *unison.TableHeader[*Node[T]], table *unison.Table[*Node[T]]) {
+func NewNodeTable[T gurps.Node[T]](provider TableProvider[T], font unison.Font) (header *unison.TableHeader[*Node[T]], table *unison.Table[*Node[T]]) {
 	table = unison.NewTable(provider)
 	table.ShowFirstColumnDivider = false
 	provider.SetTable(table)
@@ -199,7 +199,7 @@ func NewNodeTable[T gurps.NodeTypes](provider TableProvider[T], font unison.Font
 // and the setting is enabled, lets any page reference columns claim leftover space so they can show more than one
 // reference before the rest goes to the excess column. This is run both when the table's frame changes and when it is
 // synced, since a settings change won't necessarily alter the frame.
-func sizePageTableColumns[T gurps.NodeTypes](table *unison.Table[*Node[T]], excessColumnID int) {
+func sizePageTableColumns[T gurps.Node[T]](table *unison.Table[*Node[T]], excessColumnID int) {
 	table.SizeColumnsToFitWithExcessIn(excessColumnID)
 	if table.PreventUserColumnResize && gurps.GlobalSettings().General.ExpandPageReferences &&
 		expandPageRefColumns(table, excessColumnID) {
@@ -212,7 +212,7 @@ func sizePageTableColumns[T gurps.NodeTypes](table *unison.Table[*Node[T]], exce
 // its primary content with notes collapsed; only the space beyond that is offered to the page reference columns, and
 // each grows only up to the width needed to show all of its references (capped by its AutoMaximum). Whatever isn't
 // claimed stays with the excess column. Returns true if any column width was changed.
-func expandPageRefColumns[T gurps.NodeTypes](table *unison.Table[*Node[T]], excessColumnID int) bool {
+func expandPageRefColumns[T gurps.Node[T]](table *unison.Table[*Node[T]], excessColumnID int) bool {
 	excess := table.ColumnIndexForID(excessColumnID)
 	if excess < 0 || excess >= len(table.Columns) {
 		return false
@@ -280,17 +280,17 @@ func isAcceptableTypeForSheetOrTemplate(data any) bool {
 	}
 }
 
-func canCopySelectionToSheet[T gurps.NodeTypes](table *unison.Table[*Node[T]]) bool {
+func canCopySelectionToSheet[T gurps.Node[T]](table *unison.Table[*Node[T]]) bool {
 	var t T
 	return table.HasSelection() && len(OpenSheets(unison.Ancestor[*Sheet](table))) > 0 && isAcceptableTypeForSheetOrTemplate(t)
 }
 
-func canCopySelectionToTemplate[T gurps.NodeTypes](table *unison.Table[*Node[T]]) bool {
+func canCopySelectionToTemplate[T gurps.Node[T]](table *unison.Table[*Node[T]]) bool {
 	var t T
 	return table.HasSelection() && len(OpenTemplates(unison.Ancestor[*Template](table))) > 0 && isAcceptableTypeForSheetOrTemplate(t)
 }
 
-func libraryFileFromTable[T gurps.NodeTypes](table *unison.Table[*Node[T]]) gurps.LibraryFile {
+func libraryFileFromTable[T gurps.Node[T]](table *unison.Table[*Node[T]]) gurps.LibraryFile {
 	if d := unison.Ancestor[*TableDockable[T]](table); d != nil {
 		for _, lib := range gurps.GlobalSettings().Libraries() {
 			libPathOnDisk := lib.Data().PathOnDisk + string(filepath.Separator)
@@ -306,7 +306,7 @@ func libraryFileFromTable[T gurps.NodeTypes](table *unison.Table[*Node[T]]) gurp
 	return gurps.LibraryFile{}
 }
 
-func copySelectionToSheet[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
+func copySelectionToSheet[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 	if table.HasSelection() {
 		if sheets := PromptForDestination(OpenSheets(unison.Ancestor[*Sheet](table))); len(sheets) > 0 {
 			sel := table.SelectedRows(true)
@@ -356,7 +356,7 @@ func copySelectionToSheet[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
 	}
 }
 
-func copySelectionToTemplate[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
+func copySelectionToTemplate[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 	if table.HasSelection() {
 		if templates := PromptForDestination(OpenTemplates(unison.Ancestor[*Template](table))); len(templates) > 0 {
 			sel := table.SelectedRows(true)
@@ -378,7 +378,7 @@ func copySelectionToTemplate[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
 	}
 }
 
-func convertTable[T gurps.NodeTypes](table any) *unison.Table[*Node[T]] {
+func convertTable[T gurps.Node[T]](table any) *unison.Table[*Node[T]] {
 	// This is here just to get around limitations in the way Go generics behave
 	if t, ok := table.(*unison.Table[*Node[T]]); ok {
 		return t
@@ -387,7 +387,7 @@ func convertTable[T gurps.NodeTypes](table any) *unison.Table[*Node[T]] {
 }
 
 // InsertCmdContextMenuItem inserts a context menu item for the given command.
-func InsertCmdContextMenuItem[T gurps.NodeTypes](table *unison.Table[*Node[T]], title string, cmdID int, id *int, cm unison.Menu) {
+func InsertCmdContextMenuItem[T gurps.Node[T]](table *unison.Table[*Node[T]], title string, cmdID int, id *int, cm unison.Menu) {
 	if table.CanPerformCmd(table, cmdID) {
 		useID := *id
 		*id++
@@ -414,7 +414,7 @@ func flexibleLess(s1, s2 string) bool {
 }
 
 // OpenEditor opens an editor for each selected row in the table.
-func OpenEditor[T gurps.NodeTypes](table *unison.Table[*Node[T]], edit func(item T)) {
+func OpenEditor[T gurps.Node[T]](table *unison.Table[*Node[T]], edit func(item T)) {
 	var zero T
 	selection := table.SelectedRows(false)
 	if len(selection) > 4 {
@@ -431,7 +431,7 @@ func OpenEditor[T gurps.NodeTypes](table *unison.Table[*Node[T]], edit func(item
 }
 
 // DeleteSelection removes the selected nodes from the table.
-func DeleteSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]], recordUndo bool) {
+func DeleteSelection[T gurps.Node[T]](table *unison.Table[*Node[T]], recordUndo bool) {
 	if provider, ok := any(table.Model).(TableProvider[T]); ok && HasSelectionAndNotFiltered(table) {
 		sel := table.SelectedRows(true)
 		ids := make(map[tid.TID]bool, len(sel))
@@ -462,7 +462,7 @@ func DeleteSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]], recordUnd
 		}
 		topLevelData := provider.RootData()
 		for _, target := range list {
-			parent := gurps.AsNode(target).Parent()
+			parent := target.Parent()
 			if parent == zero {
 				for i, one := range topLevelData {
 					if one == target {
@@ -471,11 +471,10 @@ func DeleteSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]], recordUnd
 					}
 				}
 			} else {
-				pNode := gurps.AsNode(parent)
-				children := pNode.NodeChildren()
+				children := parent.NodeChildren()
 				for i, one := range children {
 					if one == target {
-						pNode.SetChildren(slices.Delete(children, i, i+1))
+						parent.SetChildren(slices.Delete(children, i, i+1))
 						break
 					}
 				}
@@ -493,7 +492,7 @@ func DeleteSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]], recordUnd
 }
 
 // DuplicateSelection duplicates the selected nodes in the table.
-func DuplicateSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
+func DuplicateSelection[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 	if provider, ok := any(table.Model).(TableProvider[T]); ok && HasSelectionAndNotFiltered(table) {
 		var undo *unison.UndoEdit[*TableUndoEditData[T]]
 		mgr := unison.UndoManagerFor(table)
@@ -517,10 +516,9 @@ func DuplicateSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
 			if target == zero {
 				continue
 			}
-			tData := gurps.AsNode(target)
-			parent := tData.Parent()
-			clone := tData.Clone(gurps.LibraryFile{}, gurps.EntityFromNode(tData), parent, false)
-			selMap[gurps.AsNode(clone).ID()] = true
+			parent := target.Parent()
+			clone := target.Clone(gurps.LibraryFile{}, gurps.EntityFromNode(target), parent, false)
+			selMap[clone.ID()] = true
 			if parent == zero {
 				for i, child := range topLevelData {
 					if child == target {
@@ -530,11 +528,10 @@ func DuplicateSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
 					}
 				}
 			} else {
-				pNode := gurps.AsNode(parent)
-				children := pNode.NodeChildren()
+				children := parent.NodeChildren()
 				for i, child := range children {
 					if child == target {
-						pNode.SetChildren(slices.Insert(children, i+1, clone))
+						parent.SetChildren(slices.Insert(children, i+1, clone))
 						break
 					}
 				}
@@ -556,12 +553,12 @@ func DuplicateSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
 }
 
 // HasSelectionAndNotFiltered returns true if the table has a selection and is not filtered.
-func HasSelectionAndNotFiltered[T gurps.NodeTypes](table *unison.Table[*Node[T]]) bool {
+func HasSelectionAndNotFiltered[T gurps.Node[T]](table *unison.Table[*Node[T]]) bool {
 	return !table.IsFiltered() && table.HasSelection()
 }
 
 // ClearSourceFromSelection clears the source from the selected nodes.
-func ClearSourceFromSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
+func ClearSourceFromSelection[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 	if HasSelectionAndNotFiltered(table) {
 		var undo *unison.UndoEdit[*TableUndoEditData[T]]
 		mgr := unison.UndoManagerFor(table)
@@ -579,7 +576,7 @@ func ClearSourceFromSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]) 
 		sel := table.SelectedRows(false)
 		for _, row := range sel {
 			if target := row.Data(); target != zero {
-				gurps.AsNode(target).ClearSource()
+				target.ClearSource()
 			}
 		}
 		table.SyncToModel()
@@ -594,7 +591,7 @@ func ClearSourceFromSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]) 
 }
 
 // SyncWithSourceForSelection synchronizes the selected nodes with their source.
-func SyncWithSourceForSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
+func SyncWithSourceForSelection[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 	if HasSelectionAndNotFiltered(table) {
 		var undo *unison.UndoEdit[*TableUndoEditData[T]]
 		mgr := unison.UndoManagerFor(table)
@@ -612,7 +609,7 @@ func SyncWithSourceForSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]
 		sel := table.SelectedRows(false)
 		for _, row := range sel {
 			if target := row.Data(); target != zero {
-				gurps.AsNode(target).SyncWithSource()
+				target.SyncWithSource()
 			}
 		}
 		table.SyncToModel()
@@ -627,7 +624,7 @@ func SyncWithSourceForSelection[T gurps.NodeTypes](table *unison.Table[*Node[T]]
 }
 
 // CopyRowsTo copies the provided rows to the target table.
-func CopyRowsTo[T gurps.NodeTypes](table *unison.Table[*Node[T]], rows []*Node[T], postProcessor func(rows []*Node[T]), recordUndo bool) {
+func CopyRowsTo[T gurps.Node[T]](table *unison.Table[*Node[T]], rows []*Node[T], postProcessor func(rows []*Node[T]), recordUndo bool) {
 	if table == nil || table.IsFiltered() {
 		return
 	}
@@ -641,7 +638,7 @@ func CopyRowsTo[T gurps.NodeTypes](table *unison.Table[*Node[T]], rows []*Node[T
 		if mgr = unison.UndoManagerFor(table); mgr != nil {
 			undo = &unison.UndoEdit[*TableUndoEditData[T]]{
 				ID:         unison.NextUndoID(),
-				EditName:   fmt.Sprintf(i18n.Text("Insert %s"), gurps.AsNode(rows[0].Data()).Kind()),
+				EditName:   fmt.Sprintf(i18n.Text("Insert %s"), rows[0].Data().Kind()),
 				UndoFunc:   func(e *unison.UndoEdit[*TableUndoEditData[T]]) { e.BeforeData.Apply() },
 				RedoFunc:   func(e *unison.UndoEdit[*TableUndoEditData[T]]) { e.AfterData.Apply() },
 				AbsorbFunc: func(_ *unison.UndoEdit[*TableUndoEditData[T]], _ unison.Undoable) bool { return false },

--- a/ux/table_dockable.go
+++ b/ux/table_dockable.go
@@ -39,7 +39,7 @@ var (
 )
 
 // TableDockable holds the view for a file that contains a (potentially hierarchical) list of data.
-type TableDockable[T gurps.NodeTypes] struct {
+type TableDockable[T gurps.Node[T]] struct {
 	unison.Panel
 	path              string
 	extension         string
@@ -58,7 +58,7 @@ type TableDockable[T gurps.NodeTypes] struct {
 }
 
 // NewTableDockable creates a new TableDockable for list data files.
-func NewTableDockable[T gurps.NodeTypes](filePath, extension string, provider TableProvider[T], saver func(path string) error, canCreateIDs ...int) *TableDockable[T] {
+func NewTableDockable[T gurps.Node[T]](filePath, extension string, provider TableProvider[T], saver func(path string) error, canCreateIDs ...int) *TableDockable[T] {
 	header, table := NewNodeTable(provider, nil)
 	d := &TableDockable[T]{
 		path:              filePath,
@@ -334,7 +334,7 @@ func (d *TableDockable[T]) toggleHierarchy() {
 	d.table.SyncToModel()
 }
 
-func setTableDockableRowOpen[T gurps.NodeTypes](row *Node[T], open bool) {
+func setTableDockableRowOpen[T gurps.Node[T]](row *Node[T], open bool) {
 	row.SetOpen(open)
 	for _, child := range row.Children() {
 		if child.CanHaveChildren() {
@@ -364,10 +364,10 @@ func (d *TableDockable[T]) toggleNotes() {
 	d.table.SyncToModel()
 }
 
-func discoverNoteState[T gurps.NodeTypes](n *Node[T], state *int) {
+func discoverNoteState[T gurps.Node[T]](n *Node[T], state *int) {
 	for i := range n.table.Columns {
 		var data gurps.CellData
-		n.dataAsNode.CellData(n.table.Columns[i].ID, &data)
+		n.data.CellData(n.table.Columns[i].ID, &data)
 		if data.Type == cell.Text && data.Secondary != "" {
 			if gurps.IsClosed("N:" + string(n.ID())) {
 				*state = -1
@@ -387,10 +387,10 @@ func discoverNoteState[T gurps.NodeTypes](n *Node[T], state *int) {
 	}
 }
 
-func applyNoteState[T gurps.NodeTypes](n *Node[T], closed bool) {
+func applyNoteState[T gurps.Node[T]](n *Node[T], closed bool) {
 	for i := range n.table.Columns {
 		var data gurps.CellData
-		n.dataAsNode.CellData(n.table.Columns[i].ID, &data)
+		n.data.CellData(n.table.Columns[i].ID, &data)
 		if data.Type == cell.Text && data.Secondary != "" {
 			id := "N:" + string(n.ID())
 			if gurps.IsClosed(id) != closed {
@@ -445,7 +445,7 @@ func (d *TableDockable[T]) ApplyFilter(tags []string) {
 			f = func(row *Node[T]) bool {
 				match := false
 				if d.namesOnlyCheckBox.State == check.On {
-					match = strings.Contains(strings.ToLower(row.dataAsNode.String()), text)
+					match = strings.Contains(strings.ToLower(row.data.String()), text)
 				} else {
 					match = row.PartialMatchExceptTag(text)
 				}

--- a/ux/table_drop.go
+++ b/ux/table_drop.go
@@ -32,7 +32,7 @@ type AltDropSupport struct {
 }
 
 // InstallTableDropSupport installs our standard drop support on a table.
-func InstallTableDropSupport[T gurps.NodeTypes](table *unison.Table[*Node[T]], provider TableProvider[T]) {
+func InstallTableDropSupport[T gurps.Node[T]](table *unison.Table[*Node[T]], provider TableProvider[T]) {
 	table.ClientData()[TableProviderClientKey] = provider
 	unison.InstallDropSupport(table, provider.DragKey(), provider.DropShouldMoveData, willDropCallback[T],
 		didDropCallback[T])
@@ -119,7 +119,7 @@ func InstallTableDropSupport[T gurps.NodeTypes](table *unison.Table[*Node[T]], p
 	}
 }
 
-func willDropCallback[T gurps.NodeTypes](from, to *unison.Table[*Node[T]], move bool) *unison.UndoEdit[*TableDragUndoEditData[T]] {
+func willDropCallback[T gurps.Node[T]](from, to *unison.Table[*Node[T]], move bool) *unison.UndoEdit[*TableDragUndoEditData[T]] {
 	mgr := unison.UndoManagerFor(to)
 	if mgr == nil {
 		return nil
@@ -137,7 +137,7 @@ func willDropCallback[T gurps.NodeTypes](from, to *unison.Table[*Node[T]], move 
 	}
 }
 
-func didDropCallback[T gurps.NodeTypes](undo *unison.UndoEdit[*TableDragUndoEditData[T]], from, to *unison.Table[*Node[T]], move bool) {
+func didDropCallback[T gurps.Node[T]](undo *unison.UndoEdit[*TableDragUndoEditData[T]], from, to *unison.Table[*Node[T]], move bool) {
 	if provider, ok := to.ClientData()[TableProviderClientKey]; ok {
 		var tableProvider TableProvider[T]
 		if tableProvider, ok = provider.(TableProvider[T]); ok {
@@ -179,7 +179,7 @@ func isForCharacterOrLootSheet(panel unison.Paneler) bool {
 	}
 }
 
-func finishDidDrop[T gurps.NodeTypes](undo *unison.UndoEdit[*TableDragUndoEditData[T]], from, to *unison.Table[*Node[T]], move bool) {
+func finishDidDrop[T gurps.Node[T]](undo *unison.UndoEdit[*TableDragUndoEditData[T]], from, to *unison.Table[*Node[T]], move bool) {
 	if undo == nil {
 		return
 	}

--- a/ux/table_node.go
+++ b/ux/table_node.go
@@ -45,37 +45,34 @@ func (c *CellCache) Matches(width float32, data *gurps.CellData) bool {
 }
 
 // Node represents a row in a table.
-type Node[T gurps.NodeTypes] struct {
-	table      *unison.Table[*Node[T]]
-	parent     *Node[T]
-	data       T
-	dataAsNode gurps.Node[T]
-	children   []*Node[T]
-	cellCache  []*CellCache
-	forPage    bool
+type Node[T gurps.Node[T]] struct {
+	table     *unison.Table[*Node[T]]
+	parent    *Node[T]
+	data      T
+	children  []*Node[T]
+	cellCache []*CellCache
+	forPage   bool
 }
 
 // NewNode creates a new node for a table.
-func NewNode[T gurps.NodeTypes](table *unison.Table[*Node[T]], parent *Node[T], data T, forPage bool) *Node[T] {
+func NewNode[T gurps.Node[T]](table *unison.Table[*Node[T]], parent *Node[T], data T, forPage bool) *Node[T] {
 	return &Node[T]{
-		table:      table,
-		parent:     parent,
-		data:       data,
-		dataAsNode: gurps.AsNode(data),
-		cellCache:  make([]*CellCache, len(table.Columns)),
-		forPage:    forPage,
+		table:     table,
+		parent:    parent,
+		data:      data,
+		cellCache: make([]*CellCache, len(table.Columns)),
+		forPage:   forPage,
 	}
 }
 
 // NewNodeLike creates a new node for a table based on the characteristics of an existing node in that table.
-func NewNodeLike[T gurps.NodeTypes](like *Node[T], data T) *Node[T] {
+func NewNodeLike[T gurps.Node[T]](like *Node[T], data T) *Node[T] {
 	return &Node[T]{
-		table:      like.table,
-		parent:     like.parent,
-		data:       data,
-		dataAsNode: gurps.AsNode(data),
-		cellCache:  make([]*CellCache, len(like.table.Columns)),
-		forPage:    like.forPage,
+		table:     like.table,
+		parent:    like.parent,
+		data:      data,
+		cellCache: make([]*CellCache, len(like.table.Columns)),
+		forPage:   like.forPage,
 	}
 }
 
@@ -90,12 +87,12 @@ func (n *Node[T]) CloneForTarget(target unison.Paneler, newParent *Node[T]) *Nod
 		owner = provider.DataOwner()
 	}
 	return NewNode(table, newParent,
-		n.dataAsNode.Clone(libraryFileFromTable(n.table), owner, newParent.Data(), false), false)
+		n.data.Clone(libraryFileFromTable(n.table), owner, newParent.Data(), false), false)
 }
 
 // ID implements unison.TableRowData.
 func (n *Node[T]) ID() tid.TID {
-	return n.dataAsNode.ID()
+	return n.data.ID()
 }
 
 // Parent implements unison.TableRowData.
@@ -105,18 +102,18 @@ func (n *Node[T]) Parent() *Node[T] {
 
 // SetParent implements unison.TableRowData.
 func (n *Node[T]) SetParent(parent *Node[T]) {
-	n.dataAsNode.SetParent(parent.Data())
+	n.data.SetParent(parent.Data())
 }
 
 // CanHaveChildren implements unison.TableRowData.
 func (n *Node[T]) CanHaveChildren() bool {
-	return n.dataAsNode.Container()
+	return n.data.Container()
 }
 
 // Children implements unison.TableRowData.
 func (n *Node[T]) Children() []*Node[T] {
-	if n.dataAsNode.Container() && n.children == nil {
-		children := n.dataAsNode.NodeChildren()
+	if n.data.Container() && n.children == nil {
+		children := n.data.NodeChildren()
 		n.children = make([]*Node[T], len(children))
 		for i, one := range children {
 			n.children[i] = NewNode(n.table, n, one, n.forPage)
@@ -127,8 +124,8 @@ func (n *Node[T]) Children() []*Node[T] {
 
 // SetChildren implements unison.TableRowData.
 func (n *Node[T]) SetChildren(children []*Node[T]) {
-	if n.dataAsNode.Container() {
-		n.dataAsNode.SetChildren(ExtractNodeDataFromList(children))
+	if n.data.Container() {
+		n.data.SetChildren(ExtractNodeDataFromList(children))
 		n.children = nil
 	}
 }
@@ -143,9 +140,9 @@ func (n *Node[T]) RefreshChildren() {
 // CellDataForSort implements unison.TableRowData.
 func (n *Node[T]) CellDataForSort(index int) string {
 	var data gurps.CellData
-	n.dataAsNode.CellData(n.table.Columns[index].ID, &data)
+	n.data.CellData(n.table.Columns[index].ID, &data)
 	s := data.ForSort()
-	if gurps.GlobalSettings().General.GroupContainersOnSort && n.dataAsNode.Container() {
+	if gurps.GlobalSettings().General.GroupContainersOnSort && n.data.Container() {
 		return containerMarker + s
 	}
 	return s
@@ -154,7 +151,7 @@ func (n *Node[T]) CellDataForSort(index int) string {
 // ColumnCell implements unison.TableRowData.
 func (n *Node[T]) ColumnCell(row, col int, foreground, background unison.Ink, selected, indirectlySelected, _ bool) unison.Paneler {
 	var cellData gurps.CellData
-	n.dataAsNode.CellData(n.table.Columns[col].ID, &cellData)
+	n.data.CellData(n.table.Columns[col].ID, &cellData)
 	width := n.table.CellWidth(row, col)
 	if n.cellCache[col].Matches(width, &cellData) {
 		applyInkRecursively(n.cellCache[col].Panel.AsPanel(), foreground, background, selected || indirectlySelected)
@@ -206,14 +203,14 @@ func applyInkRecursively(panel *unison.Panel, foreground, background unison.Ink,
 
 // IsOpen implements unison.TableRowData.
 func (n *Node[T]) IsOpen() bool {
-	return n.dataAsNode.IsOpen()
+	return n.data.IsOpen()
 }
 
 // SetOpen implements unison.TableRowData.
 func (n *Node[T]) SetOpen(open bool) {
-	wasOpen := n.dataAsNode.IsOpen()
-	n.dataAsNode.SetOpen(open)
-	if wasOpen != n.dataAsNode.IsOpen() {
+	wasOpen := n.data.IsOpen()
+	n.data.SetOpen(open)
+	if wasOpen != n.data.IsOpen() {
 		n.table.SyncToModel()
 	}
 }
@@ -251,7 +248,7 @@ func (n *Node[T]) PartialMatchExceptTag(text string) bool {
 	text = strings.ToLower(text)
 	for i := range n.table.Columns {
 		var data gurps.CellData
-		n.dataAsNode.CellData(n.table.Columns[i].ID, &data)
+		n.data.CellData(n.table.Columns[i].ID, &data)
 		if data.Type != cell.Tags {
 			if strings.Contains(strings.ToLower(data.ForSort()), text) {
 				return true
@@ -798,7 +795,7 @@ func pageRefSeparatorWidth(font unison.Font) float32 {
 // excess width (up to the point where all references are visible) before the remainder goes to the excess-width column.
 func (n *Node[T]) pageRefColumnFullWidth(col int) float32 {
 	var c gurps.CellData
-	n.dataAsNode.CellData(n.table.Columns[col].ID, &c)
+	n.data.CellData(n.table.Columns[col].ID, &c)
 	if c.Type != cell.PageRef {
 		return -1
 	}
@@ -825,7 +822,7 @@ func (n *Node[T]) pageRefColumnFullWidth(col int) float32 {
 // to page reference columns.
 func (n *Node[T]) excessColumnCollapsedWidth(col int) float32 {
 	var c gurps.CellData
-	n.dataAsNode.CellData(n.table.Columns[col].ID, &c)
+	n.data.CellData(n.table.Columns[col].ID, &c)
 	if c.Type != cell.Text {
 		return -1
 	}
@@ -864,14 +861,14 @@ func (n *Node[T]) secondaryFieldFont() unison.Font {
 }
 
 // FindRowIndexByID returns the row index of the row with the given ID in the given table.
-func FindRowIndexByID[T gurps.NodeTypes](table *unison.Table[*Node[T]], id tid.TID) int {
+func FindRowIndexByID[T gurps.Node[T]](table *unison.Table[*Node[T]], id tid.TID) int {
 	_, i := rowIndex(id, 0, table.RootRows())
 	return i
 }
 
-func rowIndex[T gurps.NodeTypes](id tid.TID, startIndex int, rows []*Node[T]) (updatedStartIndex, result int) {
+func rowIndex[T gurps.Node[T]](id tid.TID, startIndex int, rows []*Node[T]) (updatedStartIndex, result int) {
 	for _, row := range rows {
-		if id == row.dataAsNode.ID() {
+		if id == row.data.ID() {
 			return 0, startIndex
 		}
 		startIndex++
@@ -885,7 +882,7 @@ func rowIndex[T gurps.NodeTypes](id tid.TID, startIndex int, rows []*Node[T]) (u
 }
 
 // InsertItems into a table.
-func InsertItems[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[*Node[T]], topList func() []T, setTopList func([]T), rowData func(table *unison.Table[*Node[T]]) []*Node[T], items ...T) {
+func InsertItems[T gurps.Node[T]](owner Rebuildable, table *unison.Table[*Node[T]], topList func() []T, setTopList func([]T), rowData func(table *unison.Table[*Node[T]]) []*Node[T], items ...T) {
 	if len(items) == 0 {
 		return
 	}
@@ -894,7 +891,7 @@ func InsertItems[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[*Node
 	if mgr != nil {
 		undo = &unison.UndoEdit[*TableUndoEditData[T]]{
 			ID:         unison.NextUndoID(),
-			EditName:   fmt.Sprintf(i18n.Text("Insert %s"), gurps.AsNode(items[0]).Kind()),
+			EditName:   fmt.Sprintf(i18n.Text("Insert %s"), items[0].Kind()),
 			UndoFunc:   func(e *unison.UndoEdit[*TableUndoEditData[T]]) { e.BeforeData.Apply() },
 			RedoFunc:   func(e *unison.UndoEdit[*TableUndoEditData[T]]) { e.AfterData.Apply() },
 			AbsorbFunc: func(_ *unison.UndoEdit[*TableUndoEditData[T]], _ unison.Undoable) bool { return false },
@@ -909,14 +906,14 @@ func InsertItems[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[*Node
 			if row.CanHaveChildren() {
 				// Target is container, append to end of that container
 				SetParents(items, target)
-				row.dataAsNode.SetChildren(append(row.dataAsNode.NodeChildren(), items...))
+				row.data.SetChildren(append(row.data.NodeChildren(), items...))
 			} else {
 				// Target isn't a container. If it has a parent, insert after the target within that parent.
 				parent := row.Parent()
 				if parentData := parent.Data(); parentData != zero {
 					SetParents(items, parentData)
-					children := parent.dataAsNode.NodeChildren()
-					parent.dataAsNode.SetChildren(slices.Insert(children, slices.Index(children, target)+1, items...))
+					children := parent.data.NodeChildren()
+					parent.data.SetChildren(slices.Insert(children, slices.Index(children, target)+1, items...))
 				} else {
 					// Otherwise, insert after the target within the top-level list.
 					SetParents(items, zero)
@@ -937,7 +934,7 @@ func InsertItems[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[*Node
 	table.RequestFocus()
 	selMap := make(map[tid.TID]bool)
 	for _, item := range items {
-		selMap[gurps.AsNode(item).ID()] = true
+		selMap[item.ID()] = true
 	}
 	table.SetSelectionMap(selMap)
 	table.ScrollRowCellIntoView(table.LastSelectedRowIndex(), 0)
@@ -950,14 +947,14 @@ func InsertItems[T gurps.NodeTypes](owner Rebuildable, table *unison.Table[*Node
 }
 
 // SetParents of each item.
-func SetParents[T gurps.NodeTypes](items []T, parent T) {
+func SetParents[T gurps.Node[T]](items []T, parent T) {
 	for _, item := range items {
-		gurps.AsNode(item).SetParent(parent)
+		item.SetParent(parent)
 	}
 }
 
 // ExtractNodeDataFromList returns the underlying node data.
-func ExtractNodeDataFromList[T gurps.NodeTypes](list []*Node[T]) []T {
+func ExtractNodeDataFromList[T gurps.Node[T]](list []*Node[T]) []T {
 	dataList := make([]T, 0, len(list))
 	for _, child := range list {
 		dataList = append(dataList, child.data)

--- a/ux/table_undo.go
+++ b/ux/table_undo.go
@@ -16,13 +16,13 @@ import (
 )
 
 // TableUndoEditData holds the data necessary to provide undo for a table.
-type TableUndoEditData[T gurps.NodeTypes] struct {
+type TableUndoEditData[T gurps.Node[T]] struct {
 	Table *unison.Table[*Node[T]]
 	Data  PreservedTableData[T]
 }
 
 // NewTableUndoEditData collects the undo edit data for a table.
-func NewTableUndoEditData[T gurps.NodeTypes](table *unison.Table[*Node[T]]) *TableUndoEditData[T] {
+func NewTableUndoEditData[T gurps.Node[T]](table *unison.Table[*Node[T]]) *TableUndoEditData[T] {
 	if table == nil {
 		return nil
 	}
@@ -45,13 +45,13 @@ func (t *TableUndoEditData[T]) Apply() {
 }
 
 // TableDragUndoEditData holds the undo edit data for a table drag.
-type TableDragUndoEditData[T gurps.NodeTypes] struct {
+type TableDragUndoEditData[T gurps.Node[T]] struct {
 	From *TableUndoEditData[T]
 	To   *TableUndoEditData[T]
 }
 
 // NewTableDragUndoEditData collects the undo edit data for a table drag.
-func NewTableDragUndoEditData[T gurps.NodeTypes](from, to *unison.Table[*Node[T]]) *TableDragUndoEditData[T] {
+func NewTableDragUndoEditData[T gurps.Node[T]](from, to *unison.Table[*Node[T]]) *TableDragUndoEditData[T] {
 	return &TableDragUndoEditData[T]{
 		From: NewTableUndoEditData(from),
 		To:   NewTableUndoEditData(to),

--- a/ux/template.go
+++ b/ux/template.go
@@ -528,7 +528,7 @@ func updateWeightField(sheet *Sheet, refKey string, value fxp.Weight) {
 	}
 }
 
-func cloneRows[T gurps.NodeTypes](table *unison.Table[*Node[T]], rows []*Node[T]) []*Node[T] {
+func cloneRows[T gurps.Node[T]](table *unison.Table[*Node[T]], rows []*Node[T]) []*Node[T] {
 	rows = slices.Clone(rows)
 	for j, row := range rows {
 		rows[j] = row.CloneForTarget(table, nil)
@@ -536,7 +536,7 @@ func cloneRows[T gurps.NodeTypes](table *unison.Table[*Node[T]], rows []*Node[T]
 	return rows
 }
 
-func appendRows[T gurps.NodeTypes](table *unison.Table[*Node[T]], rows []*Node[T]) {
+func appendRows[T gurps.Node[T]](table *unison.Table[*Node[T]], rows []*Node[T]) {
 	selMap := make(map[tid.TID]bool)
 	orig := slices.Clone(table.RootRows())
 	switch t := any(table).(type) {
@@ -572,7 +572,7 @@ func appendRows[T gurps.NodeTypes](table *unison.Table[*Node[T]], rows []*Node[T
 
 // entityTechLevel returns the tech level of the entity that owns the table, or an empty string if there is none. This
 // is the value substituted for an empty tech level when merging rows, matching what the table providers do on drop.
-func entityTechLevel[T gurps.NodeTypes](table *unison.Table[*Node[T]]) string {
+func entityTechLevel[T gurps.Node[T]](table *unison.Table[*Node[T]]) string {
 	if dataOwnerProvider := unison.Ancestor[gurps.DataOwnerProvider](table); !xreflect.IsNil(dataOwnerProvider) {
 		if dataOwner := dataOwnerProvider.DataOwner(); !xreflect.IsNil(dataOwner) {
 			if entity := dataOwner.OwningEntity(); entity != nil {
@@ -729,7 +729,7 @@ func mergeSpellPoints(existing, incoming []*gurps.Spell, defaultTechLevel string
 // copying a skill or spell that already exists on the sheet adds to its points rather than creating a duplicate. It
 // must be called only after tech levels and nameables have been resolved on the new rows, since the match includes
 // both. Only skills and spells are affected; other row types are left untouched.
-func MergeAddedRows[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
+func MergeAddedRows[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 	switch t := any(table).(type) {
 	case *unison.Table[*Node[*gurps.Skill]]:
 		mergeNewlySelectedRows(t, mergeSkillPoints)
@@ -738,7 +738,7 @@ func MergeAddedRows[T gurps.NodeTypes](table *unison.Table[*Node[T]]) {
 	}
 }
 
-func mergeNewlySelectedRows[T gurps.NodeTypes](table *unison.Table[*Node[T]], merge func(existing, incoming []T, defaultTechLevel string, selMap map[tid.TID]bool) []T) {
+func mergeNewlySelectedRows[T gurps.Node[T]](table *unison.Table[*Node[T]], merge func(existing, incoming []T, defaultTechLevel string, selMap map[tid.TID]bool) []T) {
 	sel := table.CopySelectionMap()
 	if len(sel) == 0 {
 		return

--- a/ux/template_picker.go
+++ b/ux/template_picker.go
@@ -16,7 +16,6 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/fxp"
 	"github.com/richardwilkes/gcs/v5/model/gurps"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
-	"github.com/richardwilkes/gcs/v5/model/nameable"
 	"github.com/richardwilkes/gcs/v5/svg"
 	"github.com/richardwilkes/toolbox/v2/errs"
 	"github.com/richardwilkes/toolbox/v2/geom"
@@ -29,7 +28,7 @@ import (
 	"github.com/richardwilkes/unison/enums/side"
 )
 
-func processPickerRows[T gurps.NodeTypes](rows []*Node[T]) (revised []*Node[T], abort bool) {
+func processPickerRows[T gurps.Node[T]](rows []*Node[T]) (revised []*Node[T], abort bool) {
 	for _, one := range ExtractNodeDataFromList(rows) {
 		result, cancel := processPickerRow(one)
 		if cancel {
@@ -42,13 +41,12 @@ func processPickerRows[T gurps.NodeTypes](rows []*Node[T]) (revised []*Node[T], 
 	return revised, false
 }
 
-func processPickerRow[T gurps.NodeTypes](row T) (revised []T, abort bool) {
-	n := gurps.AsNode(row)
-	if !n.Container() {
+func processPickerRow[T gurps.Node[T]](row T) (revised []T, abort bool) {
+	if !row.Container() {
 		return []T{row}, false
 	}
-	children := n.NodeChildren()
-	tpp, ok := n.(gurps.TemplatePickerProvider)
+	children := row.NodeChildren()
+	tpp, ok := any(row).(gurps.TemplatePickerProvider)
 	if !ok || tpp.TemplatePickerData().IsZero() {
 		rowChildren := make([]T, 0, len(children))
 		for _, child := range children {
@@ -59,7 +57,7 @@ func processPickerRow[T gurps.NodeTypes](row T) (revised []T, abort bool) {
 			}
 			rowChildren = append(rowChildren, result...)
 		}
-		n.SetChildren(rowChildren)
+		row.SetChildren(rowChildren)
 		SetParents(rowChildren, row)
 		return []T{row}, false
 	}
@@ -210,7 +208,7 @@ func processPickerRow[T gurps.NodeTypes](row T) (revised []T, abort bool) {
 			rowChildren = append(rowChildren, result...)
 		}
 	}
-	SetParents(rowChildren, n.Parent())
+	SetParents(rowChildren, row.Parent())
 	return rowChildren, false
 }
 
@@ -221,7 +219,7 @@ func pickerMatchStateColor(matches bool) unison.Color {
 	return unison.ThemeError.GetColor()
 }
 
-func addPickerRow[T gurps.NodeTypes](parent *unison.Panel, row T, callback func(), boxes []*unison.CheckBox) []*unison.CheckBox {
+func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, callback func(), boxes []*unison.CheckBox) []*unison.CheckBox {
 	wrapper := unison.NewPanel()
 	wrapper.SetLayout(&unison.FlexLayout{
 		Columns:  2,
@@ -295,7 +293,7 @@ func addPickerRow[T gurps.NodeTypes](parent *unison.Panel, row T, callback func(
 	return boxes
 }
 
-func updatePickerCheckBoxTitle[T gurps.NodeTypes](checkBox *unison.CheckBox, row T) {
+func updatePickerCheckBoxTitle[T gurps.Node[T]](checkBox *unison.CheckBox, row T) {
 	title := row.String()
 	points := rawPoints(row)
 	if points != 0 {
@@ -351,16 +349,12 @@ func pickerRowLevelEditor(trait *gurps.Trait, checkBox *unison.CheckBox, callbac
 	checkBox.MarkForRedraw()
 }
 
-type pickerRowPointEditorTypes interface {
-	*gurps.Skill | *gurps.Spell
-	nameable.Applier
-	fmt.Stringer
-	Kind() string
-	RawPoints() fxp.Int
-	SetRawPoints(fxp.Int) bool
+type pickerRowPointEditorTypes[T gurps.Node[T]] interface {
+	gurps.Node[T]
+	gurps.RawPointsAdjuster
 }
 
-func pickerRowPointEditor[T pickerRowPointEditorTypes](node T, checkBox *unison.CheckBox, callback func()) {
+func pickerRowPointEditor[T pickerRowPointEditorTypes[T]](node T, checkBox *unison.CheckBox, callback func()) {
 	points := node.RawPoints()
 	panel := unison.NewPanel()
 	panel.SetLayout(&unison.FlexLayout{

--- a/ux/value_adjuster.go
+++ b/ux/value_adjuster.go
@@ -47,7 +47,7 @@ func (s *snapshotList[A, V]) finish() {
 }
 
 // canAdjustSelection returns true if any selected row yields an adjustable target via extract.
-func canAdjustSelection[T gurps.NodeTypes, A any](table *unison.Table[*Node[T]], extract func(T) (A, bool)) bool {
+func canAdjustSelection[T gurps.Node[T], A any](table *unison.Table[*Node[T]], extract func(T) (A, bool)) bool {
 	for _, row := range table.SelectedRows(false) {
 		if _, ok := extract(row.Data()); ok {
 			return true
@@ -60,7 +60,7 @@ func canAdjustSelection[T gurps.NodeTypes, A any](table *unison.Table[*Node[T]],
 // target via extract. When recalculate is true, the owning entity is recalculated after the change (and on undo/redo);
 // when rebuild is true, the owner is rebuilt as well. The same extract should be used by the corresponding
 // canAdjustSelection call so that the enable check and the action never diverge.
-func adjustSelection[T gurps.NodeTypes, A, V any](undoTitle string, owner Rebuildable, table *unison.Table[*Node[T]],
+func adjustSelection[T gurps.Node[T], A, V any](undoTitle string, owner Rebuildable, table *unison.Table[*Node[T]],
 	extract func(T) (A, bool), get func(A) V, set func(A, V), mutate func(A), recalculate, rebuild bool,
 ) {
 	rows := table.SelectedRows(false)
@@ -77,7 +77,7 @@ func adjustSelection[T gurps.NodeTypes, A, V any](undoTitle string, owner Rebuil
 		return
 	}
 	if recalculate {
-		entity := gurps.EntityFromNode(gurps.AsNode(rows[0].Data()))
+		entity := gurps.EntityFromNode(rows[0].Data())
 		before.entity = entity
 		after.entity = entity
 	}

--- a/ux/weapons_provider.go
+++ b/ux/weapons_provider.go
@@ -259,7 +259,7 @@ func (p *weaponsProvider) OpenEditor(owner Rebuildable, table *unison.Table[*Nod
 	}
 }
 
-func openWeaponEditor[T gurps.NodeTypes, D gurps.EditorData[T]](sheet *Sheet, pageList *PageList[T], item *gurps.Weapon, itemOwner T, editFunc func(Rebuildable, T) *editor[T, D]) bool {
+func openWeaponEditor[T gurps.Node[T], D gurps.EditorData[T]](sheet *Sheet, pageList *PageList[T], item *gurps.Weapon, itemOwner T, editFunc func(Rebuildable, T) *editor[T, D]) bool {
 	if node := searchSheetTableFor(pageList, itemOwner); node != nil {
 		pageList.Table.DiscloseRow(node, false)
 		pageList.Table.ClearSelection()
@@ -289,7 +289,7 @@ func openWeaponEditor[T gurps.NodeTypes, D gurps.EditorData[T]](sheet *Sheet, pa
 	return false
 }
 
-func searchSheetTableFor[T gurps.NodeTypes](pageList *PageList[T], what T) *Node[T] {
+func searchSheetTableFor[T gurps.Node[T]](pageList *PageList[T], what T) *Node[T] {
 	for _, row := range pageList.Table.RootRows() {
 		if result := searchSheetTableRowsFor(pageList.Table, row, what); result != nil {
 			return result
@@ -298,7 +298,7 @@ func searchSheetTableFor[T gurps.NodeTypes](pageList *PageList[T], what T) *Node
 	return nil
 }
 
-func searchSheetTableRowsFor[T gurps.NodeTypes](table *unison.Table[*Node[T]], row *Node[T], what T) *Node[T] {
+func searchSheetTableRowsFor[T gurps.Node[T]](table *unison.Table[*Node[T]], row *Node[T], what T) *Node[T] {
 	if what == row.data {
 		return row
 	}


### PR DESCRIPTION
The original NodeTypes and Node interfaces didn't use self-referential
constraints. I believe this is simply becasue it was written before that
was allowed fully in the 1.26 release. In any case, it's possible to
define a generic type constraint that references itself now. This solves
what seems to be an oddity driven by the previous limitations. With this
update, NodeTypes and Node merge into a single `Node[T Node[T]]`
*constraint*. I highlight "constraint" because with the merge containing
the list of allowed node types, it's limited to being just a constraint.
This does have limitations that need to be respected, but they are all
solvable. One of the larger ones was what to do with the existing type
assertion checks for the node implementations. After a little research I
found that we could have a zero-arg and zero-body generic function that
enforces the type constraint at compile time. Most of the changes in
this PR are mechanical to switch to the new `Node[T Node[T]]`
constraint. There are a few editorial changes made to make the
transition easier. In a few locations (TL, Points, Levels) there were
heavy interfaces for the node that were being augmented with extra
methods. Those were cleaned up to just use a simple interface that was
narrowed to just the methods required for the task. This ends up being
cleaner overall and removes some friction points with the new Node
constraint. With the merge the old `AsNode` method was removed as it's
no longer needed. The UX Node had two properties (`data` and
`dataAsNode`) that collapsed into the same type and value under two
names. I retired the `dataAsNode` in favor of `data` to remove the
redundancy.

A future change might be removing the constraint portions of `Node[T
Node[T]]`, but there are a few wrinkles to making that happen. The
biggest is the `comparable` constraint being needed to properly compare
values. The current constraint where all values are known to be pointers
makes the `comparable` constraint pointless. That being said, if we
removed the allowed nodes constraint, we'd have to solve the comparison
of nodes. I would suggest that the Node interface gets a comparison
method so we can side-step needing a constraint.