### PR TITLE
Auto-redirect `B` page refs for "Campaigns" to `BX`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## New & Improved
 
-- (none yet)
+- Page references for `B:338+` (Basic Set: Campaigns) are redirected to use `BX` automatically. This allows split PDF users to open `B338+` page references. (#1098)
 
 ## Bug Fixes
 

--- a/ux/pageref_mappings_dockable.go
+++ b/ux/pageref_mappings_dockable.go
@@ -136,6 +136,10 @@ func openPDFPageReference(ref, highlight string, promptContext map[string]bool) 
 			return false
 		}
 		key := ref[:i]
+		// Special-case handing for Basic Set page references that use `B` for pages in the Campaigns book
+		if key == "B" && page >= 338 {
+			key = "BX"
+		}
 		s := gurps.GlobalSettings()
 		pageRef := s.PageRefs.Lookup(key)
 		if pageRef == nil && !promptContext[key] {


### PR DESCRIPTION
For users that have split Basic Set PDFs, any `B` page ref that's pointing to pages in the second PDF (Campaigns) has no way to click those links without editing the library data. After researching and discovering apparently 16k+ references that trigger this (many clickable), I decided to add a remap from B338+ over to BX instead. This happens before the code to PDF lookup, so it properly triggers the page mapping UI for the `BX` code the first time.

This is currently the only case where a single "book" is split across multiple physical books but has a single page number space.