### PR TITLE
Trait/Equipment Modifiers lose Source on Clone

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,3 +46,4 @@
   focus was returned to the list in a way that scrolled the entire list into view, which on a sheet with a long list
   could move the row far from where it had been. Now only the edited row is brought into view, and only when it isn't
   already visible.
+- Modifiers contained by Traits and Equipment properly set their `source` when the trait/equippment is copied to a character sheet or template (#1100)

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -1169,7 +1169,7 @@ func (e *EquipmentEditData) copyFrom(equipment *Equipment, other *EquipmentEditD
 	if len(other.Modifiers) != 0 {
 		e.Modifiers = make([]*EquipmentModifier, 0, len(other.Modifiers))
 		for _, one := range other.Modifiers {
-			cloned := one.Clone(one.Source.LibraryFile, equipment.owner, nil, isApply)
+			cloned := one.Clone(equipment.Source.LibraryFile, equipment.owner, nil, isApply)
 			// Point the copy at the equipment it belongs to, so that its nameable placeholders can be resolved with
 			// that equipment's replacements. Without this, the copies held in an editor show their raw placeholders
 			// (e.g. "@Material@"), since the accessors fall back to the unsubstituted text when there is no equipment.

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -1169,6 +1169,17 @@ func (e *EquipmentEditData) copyFrom(equipment *Equipment, other *EquipmentEditD
 	if len(other.Modifiers) != 0 {
 		e.Modifiers = make([]*EquipmentModifier, 0, len(other.Modifiers))
 		for _, one := range other.Modifiers {
+			// The LibraryFile for this clone must come from the parent equipment rather than
+			// from `one`. This covers the case where the source data *is* the authoritative
+			// source and therefore carries no source information of its own. `one.Source.LibraryFile`
+			// is empty and `AdjustSource` won't set source data on the copy. `equipment.Source.LibraryFile`
+			// holds the already-adjusted source for the equipment copy, so it always has the
+			// correct library path.
+			//
+			// Background: when GCS clones an item from one library into another location (as
+			// opposed to duplicating in place), it passes the *source* library as the first
+			// argument to `Clone`. That path, combined with the IDs from the source nodes, is
+			// what builds the `source` values for the clone.
 			cloned := one.Clone(equipment.Source.LibraryFile, equipment.owner, nil, isApply)
 			// Point the copy at the equipment it belongs to, so that its nameable placeholders can be resolved with
 			// that equipment's replacements. Without this, the copies held in an editor show their raw placeholders

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -1164,7 +1164,7 @@ func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply boo
 	if len(other.Modifiers) != 0 {
 		t.Modifiers = make([]*TraitModifier, 0, len(other.Modifiers))
 		for _, one := range other.Modifiers {
-			cloned := one.Clone(one.Source.LibraryFile, trait.owner, nil, isApply)
+			cloned := one.Clone(trait.Source.LibraryFile, trait.owner, nil, isApply)
 			// Point the copy at the trait it belongs to, so that a "use level from owner" modifier can resolve its
 			// level. Prior to this, the copies held in an editor only acquired their trait as a side effect of a point
 			// cost computation.

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -1164,6 +1164,17 @@ func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply boo
 	if len(other.Modifiers) != 0 {
 		t.Modifiers = make([]*TraitModifier, 0, len(other.Modifiers))
 		for _, one := range other.Modifiers {
+			// The LibraryFile for this clone must come from the parent trait rather than
+			// from `one`. This covers the case where the source data *is* the authoritative
+			// source and therefore carries no source information of its own. `one.Source.LibraryFile`
+			// is empty and `AdjustSource` won't set source data on the copy. `trait.Source.LibraryFile`
+			// holds the already-adjusted source for the trait copy, so it always has the
+			// correct library path.
+			//
+			// Background: when GCS clones an item from one library into another location (as
+			// opposed to duplicating in place), it passes the *source* library as the first
+			// argument to `Clone`. That path, combined with the IDs from the source nodes, is
+			// what builds the `source` values for the clone.
 			cloned := one.Clone(trait.Source.LibraryFile, trait.owner, nil, isApply)
 			// Point the copy at the trait it belongs to, so that a "use level from owner" modifier can resolve its
 			// level. Prior to this, the copies held in an editor only acquired their trait as a side effect of a point


### PR DESCRIPTION
This fixes attached Trait/Equiment modifiers losing their source when the Trait or Equipment is cloned.

The previous behavior was selecting the wrong library path. By using `one` it was referencing the *origin* path, when clone is expecting the *destination* path. The passed in trait/equipment has already had it's source fixed by the time Clone is called on each modifier. This lets us use the source library path from the passed in trait/equipment to get the correct value.

The net effect of this change is that modifiers attached to traits and equipment get a proper source value when they are copied over to character sheets and templates.