### PR TITLE
Trigger modifier selections and substitutions for templates

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
   don't apply.
 - Spells can now have features, just like traits, skills and equipment. As a side effect, weapons attached to a spell
   now receive any "this weapon" bonuses defined by the spell's own features.
+- Adding items to a template now triggers modifier selections and nameable replacements (#1101)
 
 ## Bug Fixes
 

--- a/ux/table.go
+++ b/ux/table.go
@@ -356,12 +356,12 @@ func copySelectionToSheet[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 // then folding the points of rows that duplicate ones already present into those rows. Does nothing when the
 // destination isn't a character or loot sheet.
 func processCopiedRowsForSheet[T gurps.Node[T]](source, target *unison.Table[*Node[T]]) {
-	if !isForCharacterOrLootSheet(target) {
+	if !(isForCharacterOrLootSheet(target) || isForTemplate(target)) {
 		return
 	}
 	// Only process modifiers and nameables when copying from something besides a character or loot sheet; rows already
 	// on a sheet have had these resolved.
-	if !isForCharacterOrLootSheet(source) {
+	if !(isForCharacterOrLootSheet(source) || isForTemplate(source)) {
 		ProcessModifiersForSelection(target)
 		// Answering the modifier prompt rebuilds the owner, and that rebuild can replace the table underneath us: only
 		// the modifiers that are enabled count toward a row having switchable features, so turning one on or off can
@@ -383,17 +383,35 @@ func copySelectionToTemplate[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 		if templates := PromptForDestination(OpenTemplates(unison.Ancestor[*Template](table))); len(templates) > 0 {
 			sel := table.SelectedRows(true)
 			for _, t := range templates {
+				var targetTable *unison.Table[*Node[T]]
+				var processDropData func()
 				switch any(sel[0].Data()).(type) {
 				case *gurps.Trait:
-					CopyRowsTo(convertTable[T](t.Traits.Table), sel, nil, true)
+					targetTable = convertTable[T](t.Traits.Table)
+					processDropData = func() { t.Traits.provider.ProcessDropData(nil, t.Traits.Table) }
 				case *gurps.Skill:
-					CopyRowsTo(convertTable[T](t.Skills.Table), sel, nil, true)
+					targetTable = convertTable[T](t.Skills.Table)
+					processDropData = func() { t.Skills.provider.ProcessDropData(nil, t.Skills.Table) }
 				case *gurps.Spell:
-					CopyRowsTo(convertTable[T](t.Spells.Table), sel, nil, true)
+					targetTable = convertTable[T](t.Spells.Table)
+					processDropData = func() { t.Spells.provider.ProcessDropData(nil, t.Spells.Table) }
 				case *gurps.Equipment:
-					CopyRowsTo(convertTable[T](t.Equipment.Table), sel, nil, true)
+					targetTable = convertTable[T](t.Equipment.Table)
+					processDropData = func() { t.Equipment.provider.ProcessDropData(nil, t.Equipment.Table) }
 				case *gurps.Note:
-					CopyRowsTo(convertTable[T](t.Notes.Table), sel, nil, true)
+					targetTable = convertTable[T](t.Notes.Table)
+					processDropData = func() { t.Notes.provider.ProcessDropData(nil, t.Notes.Table) }
+				default:
+					continue
+				}
+				if targetTable != nil {
+					// All processing must happen inside the postProcessor so it is captured by the undo edit's
+					// after-state (CopyRowsTo records that after the postProcessor runs); otherwise redo would not
+					// restore the resolved tech levels, nameables, or the merged points.
+					CopyRowsTo(targetTable, sel, func(_ []*Node[T]) {
+						processDropData()
+						processCopiedRowsForSheet(table, targetTable)
+					}, true)
 				}
 			}
 		}

--- a/ux/table.go
+++ b/ux/table.go
@@ -356,19 +356,19 @@ func copySelectionToSheet[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 // then folding the points of rows that duplicate ones already present into those rows. Does nothing when the
 // destination isn't a character or loot sheet.
 func processCopiedRowsForSheet[T gurps.Node[T]](source, target *unison.Table[*Node[T]]) {
-	if !isForCharacterOrLootSheet(target) && !isForTemplate(target) {
+	if !shouldProcessModifiersAndNameables(target) {
 		return
 	}
 	// Only process modifiers and nameables when copying from something besides a character or loot sheet; rows already
 	// on a sheet have had these resolved.
-	if !isForCharacterOrLootSheet(source) && !isForTemplate(source) {
-		ProcessModifiersForSelection(target)
+	if !shouldProcessModifiersAndNameables(source) {
 		// Answering the modifier prompt rebuilds the owner, and that rebuild can replace the table underneath us: only
 		// the modifiers that are enabled count toward a row having switchable features, so turning one on or off can
 		// add or take away the switch column, and a list can only change its columns by building a new table. An
 		// orphaned table has no Rebuildable above it, so a rebuild asked for through it never happens, and the rows it
 		// reports as selected are its own rather than the ones the user is now looking at -- both of which the steps
 		// below depend upon. Applying nameable substitutions rebuilds as well, so look it up again afterwards too.
+		ProcessModifiersForSelection(target)
 		target = liveTable(target)
 		ProcessNameablesForSelection(target)
 		target = liveTable(target)

--- a/ux/table.go
+++ b/ux/table.go
@@ -356,12 +356,12 @@ func copySelectionToSheet[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 // then folding the points of rows that duplicate ones already present into those rows. Does nothing when the
 // destination isn't a character or loot sheet.
 func processCopiedRowsForSheet[T gurps.Node[T]](source, target *unison.Table[*Node[T]]) {
-	if !(isForCharacterOrLootSheet(target) || isForTemplate(target)) {
+	if !isForCharacterOrLootSheet(target) && !isForTemplate(target) {
 		return
 	}
 	// Only process modifiers and nameables when copying from something besides a character or loot sheet; rows already
 	// on a sheet have had these resolved.
-	if !(isForCharacterOrLootSheet(source) || isForTemplate(source)) {
+	if !isForCharacterOrLootSheet(source) && !isForTemplate(source) {
 		ProcessModifiersForSelection(target)
 		// Answering the modifier prompt rebuilds the owner, and that rebuild can replace the table underneath us: only
 		// the modifiers that are enabled count toward a row having switchable features, so turning one on or off can

--- a/ux/table_drop.go
+++ b/ux/table_drop.go
@@ -167,10 +167,10 @@ func didDropCallback[T gurps.Node[T]](undo *unison.UndoEdit[*TableDragUndoEditDa
 		from = liveTable(from)
 		to = liveTable(to)
 	}
-	if isForCharacterOrLootSheet(to) {
-		// Only process modifiers and nameables when the drop comes from something besides a character or loot sheet;
-		// rows already on a sheet have had these resolved.
-		if !isForCharacterOrLootSheet(from) {
+	if isForCharacterOrLootSheet(to) || isForTemplate(to) {
+		// Only process modifiers and nameables when the drop comes from something besides a character, loot sheet
+		// or template; rows already on one of those have had these resolved.
+		if !(isForCharacterOrLootSheet(from) || isForTemplate(from)) {
 			ProcessModifiersForSelection(to)
 			// Answering the modifier prompt rebuilds the owner all over again, and that rebuild can replace the tables
 			// just as the one above did: only the modifiers that are enabled count toward a row having switchable
@@ -231,6 +231,15 @@ func isForCharacterOrLootSheet(panel unison.Paneler) bool {
 	default:
 		return false
 	}
+}
+
+func isForTemplate(panel unison.Paneler) bool {
+	if xreflect.IsNil(panel) {
+		return false
+	}
+
+	_, ok := unison.AncestorOrSelf[unison.Dockable](panel).(*Template)
+	return ok
 }
 
 func finishDidDrop[T gurps.Node[T]](undo *unison.UndoEdit[*TableDragUndoEditData[T]], from, to *unison.Table[*Node[T]], move bool) {

--- a/ux/table_drop.go
+++ b/ux/table_drop.go
@@ -167,11 +167,10 @@ func didDropCallback[T gurps.Node[T]](undo *unison.UndoEdit[*TableDragUndoEditDa
 		from = liveTable(from)
 		to = liveTable(to)
 	}
-	if isForCharacterOrLootSheet(to) || isForTemplate(to) {
+	if shouldProcessModifiersAndNameables(to) {
 		// Only process modifiers and nameables when the drop comes from something besides a character, loot sheet
 		// or template; rows already on one of those have had these resolved.
-		if !isForCharacterOrLootSheet(from) && !isForTemplate(from) {
-			ProcessModifiersForSelection(to)
+		if !shouldProcessModifiersAndNameables(from) {
 			// Answering the modifier prompt rebuilds the owner all over again, and that rebuild can replace the tables
 			// just as the one above did: only the modifiers that are enabled count toward a row having switchable
 			// features, so turning one on or off can add or take away the switch column, and a list can only change its
@@ -180,6 +179,7 @@ func didDropCallback[T gurps.Node[T]](undo *unison.UndoEdit[*TableDragUndoEditDa
 			// is now looking at -- both of which the steps below depend upon. Applying nameable substitutions rebuilds
 			// as well, so refresh again afterwards. Refreshing both tables each time keeps them comparable, for the
 			// same reason the rebuild above does.
+			ProcessModifiersForSelection(to)
 			from = liveTable(from)
 			to = liveTable(to)
 			ProcessNameablesForSelection(to)
@@ -221,25 +221,16 @@ func dropRebuilder(table unison.Paneler) Rebuildable {
 	return unison.Ancestor[Rebuildable](table)
 }
 
-func isForCharacterOrLootSheet(panel unison.Paneler) bool {
+func shouldProcessModifiersAndNameables(panel unison.Paneler) bool {
 	if xreflect.IsNil(panel) {
 		return false
 	}
 	switch unison.AncestorOrSelf[unison.Dockable](panel).(type) {
-	case *Sheet, *LootSheet:
+	case *Sheet, *LootSheet, *Template:
 		return true
 	default:
 		return false
 	}
-}
-
-func isForTemplate(panel unison.Paneler) bool {
-	if xreflect.IsNil(panel) {
-		return false
-	}
-
-	_, ok := unison.AncestorOrSelf[unison.Dockable](panel).(*Template)
-	return ok
 }
 
 func finishDidDrop[T gurps.Node[T]](undo *unison.UndoEdit[*TableDragUndoEditData[T]], from, to *unison.Table[*Node[T]], move bool) {

--- a/ux/table_drop.go
+++ b/ux/table_drop.go
@@ -170,7 +170,7 @@ func didDropCallback[T gurps.Node[T]](undo *unison.UndoEdit[*TableDragUndoEditDa
 	if isForCharacterOrLootSheet(to) || isForTemplate(to) {
 		// Only process modifiers and nameables when the drop comes from something besides a character, loot sheet
 		// or template; rows already on one of those have had these resolved.
-		if !(isForCharacterOrLootSheet(from) || isForTemplate(from)) {
+		if !isForCharacterOrLootSheet(from) && !isForTemplate(from) {
 			ProcessModifiersForSelection(to)
 			// Answering the modifier prompt rebuilds the owner all over again, and that rebuild can replace the tables
 			// just as the one above did: only the modifiers that are enabled count toward a row having switchable


### PR DESCRIPTION
This changes the behavior of to "Copy To Template" and the drag to template operations. Previously they did not trigger the modifier config or the substitions config.