### PR TITLE
Add 'preconfigured' flag for template items

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,7 +12,6 @@
   don't apply.
 - Spells can now have features, just like traits, skills and equipment. As a side effect, weapons attached to a spell
   now receive any "this weapon" bonuses defined by the spell's own features.
-- Template items (non-container) now have a "Preconfigured" flag used to indicate that modifier and substitution configuration can be skipped when adding thie item to a character. (#1102)
 - Adding items to a template now triggers modifier selections and nameable replacements (#1101)
 - Template items (non-container) now have a "Preconfigured" flag used to indicate that modifier and substitution configuration can be skipped when adding thie item to a character. (#1102)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
   now receive any "this weapon" bonuses defined by the spell's own features.
 - Template items (non-container) now have a "Preconfigured" flag used to indicate that modifier and substitution configuration can be skipped when adding thie item to a character. (#1102)
 - Adding items to a template now triggers modifier selections and nameable replacements (#1101)
+- Template items (non-container) now have a "Preconfigured" flag used to indicate that modifier and substitution configuration can be skipped when adding thie item to a character. (#1102)
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
   don't apply.
 - Spells can now have features, just like traits, skills and equipment. As a side effect, weapons attached to a spell
   now receive any "this weapon" bonuses defined by the spell's own features.
+- Template items (non-container) now have a "Preconfigured" flag used to indicate that modifier and substitution configuration can be skipped when adding thie item to a character. (#1102)
 
 ## Bug Fixes
 

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -1204,3 +1204,8 @@ func (e *EquipmentEditData) copyFrom(equipment *Equipment, other *EquipmentEditD
 	e.Weapons = CloneWeapons(other.Weapons, equipment, isApply)
 	e.Features = other.Features.Clone()
 }
+
+// CanPreconfigureContainer implements Preconfigurable.
+func (e *EquipmentEditData) CanPreconfigureContainer() bool {
+	return true
+}

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -98,6 +98,7 @@ type EquipmentEditData struct {
 	Uses         int                  `json:"uses,omitzero"`
 	Equipped     bool                 `json:"equipped,omitzero"`
 	ItemSwitch
+	preconfigurable
 }
 
 // EquipmentSyncData holds the equipment sync data that is common to both containers and non-containers.

--- a/model/gurps/note.go
+++ b/model/gurps/note.go
@@ -63,6 +63,7 @@ type NoteData struct {
 type NoteEditData struct {
 	NoteSyncData
 	Replacements map[string]string `json:"replacements,omitzero"`
+	preconfigurable
 }
 
 // NoteSyncData holds the note sync data that is common to both containers and non-containers.

--- a/model/gurps/preconfigured.go
+++ b/model/gurps/preconfigured.go
@@ -1,0 +1,48 @@
+// Copyright (c) 1998-2026 by Richard A. Wilkes. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, version 2.0. If a copy of the MPL was not distributed with
+// this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, version 2.0.
+
+package gurps
+
+import "github.com/richardwilkes/toolbox/v2/xreflect"
+
+// Preconfigurable interface for objects that can have their selections and substitutions marked as preconfigured.
+type Preconfigurable interface {
+	IsPreconfigured() bool
+	PreconfiguredRef() *bool
+	SetPreconfigured(bool)
+}
+
+// preconfigurable self contained Preconfigurable implementation that can be embedded in another struct in this package
+type preconfigurable struct {
+	Preconfigured bool `json:"preconfigured,omitzero"`
+}
+
+// IsPreconfigured implements Preconfigurable.
+func (tl *preconfigurable) IsPreconfigured() bool {
+	return tl.Preconfigured
+}
+
+// PreconfiguredRef implements Preconfigurable.
+func (tl *preconfigurable) PreconfiguredRef() *bool {
+	return &tl.Preconfigured
+}
+
+// SetPreconfigured implements Preconfigurable.
+func (tl *preconfigurable) SetPreconfigured(preconfigured bool) {
+	tl.Preconfigured = preconfigured
+}
+
+// IsNodePreconfigured reports whether the given node has been marked as preconfigured, meaning its modifiers and nameable
+// replacements are considered already finalized and shouldn't be prompted for again (e.g. when applying a template).
+func IsNodePreconfigured[T Node[T]](node T) bool {
+	if tl, ok := any(node).(Preconfigurable); ok && !xreflect.IsNil(tl) {
+		return tl.IsPreconfigured()
+	}
+	return false
+}

--- a/model/gurps/preconfigured.go
+++ b/model/gurps/preconfigured.go
@@ -13,6 +13,8 @@ import "github.com/richardwilkes/toolbox/v2/xreflect"
 
 // Preconfigurable interface for objects that can have their selections and substitutions marked as preconfigured.
 type Preconfigurable interface {
+	CanPreconfigureItem() bool
+	CanPreconfigureContainer() bool
 	IsPreconfigured() bool
 	PreconfiguredRef() *bool
 	SetPreconfigured(bool)
@@ -21,6 +23,16 @@ type Preconfigurable interface {
 // preconfigurable self contained Preconfigurable implementation that can be embedded in another struct in this package
 type preconfigurable struct {
 	Preconfigured bool `json:"preconfigured,omitzero"`
+}
+
+// CanPreconfigureItem implements Preconfigurable.
+func (tl *preconfigurable) CanPreconfigureItem() bool {
+	return true
+}
+
+// CanPreconfigureContainer implements Preconfigurable.
+func (tl *preconfigurable) CanPreconfigureContainer() bool {
+	return false
 }
 
 // IsPreconfigured implements Preconfigurable.
@@ -36,6 +48,18 @@ func (tl *preconfigurable) PreconfiguredRef() *bool {
 // SetPreconfigured implements Preconfigurable.
 func (tl *preconfigurable) SetPreconfigured(preconfigured bool) {
 	tl.Preconfigured = preconfigured
+}
+
+// IsNodePreconfigurable reports whether the given node can be marked preconfigured.
+func IsNodePreconfigurable[T Node[T]](node T) bool {
+	if tl, ok := any(node).(Preconfigurable); ok && !xreflect.IsNil(tl) {
+		if node.Container() {
+			return tl.CanPreconfigureContainer()
+		} else {
+			return tl.CanPreconfigureItem()
+		}
+	}
+	return false
 }
 
 // IsNodePreconfigured reports whether the given node has been marked as preconfigured, meaning its modifiers and nameable

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -88,6 +88,7 @@ type SkillEditData struct {
 	ItemSwitch
 	SkillNonContainerOnlyEditData
 	SkillContainerOnlySyncData
+	preconfigurable
 }
 
 // SkillNonContainerOnlyEditData holds the Skill data that is only applicable to skills that aren't containers.

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -86,9 +86,9 @@ type SkillEditData struct {
 	VTTNotes     string            `json:"vtt_notes,omitzero"`
 	Replacements map[string]string `json:"replacements,omitzero"`
 	ItemSwitch
+	preconfigurable
 	SkillNonContainerOnlyEditData
 	SkillContainerOnlySyncData
-	preconfigurable
 }
 
 // SkillNonContainerOnlyEditData holds the Skill data that is only applicable to skills that aren't containers.

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -97,6 +97,7 @@ type SpellEditData struct {
 	ItemSwitch
 	SpellNonContainerOnlyEditData
 	SkillContainerOnlySyncData
+	preconfigurable
 }
 
 // SpellNonContainerOnlyEditData holds the Spell data that is only applicable to spells that aren't containers.

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -95,9 +95,9 @@ type SpellEditData struct {
 	VTTNotes     string            `json:"vtt_notes,omitzero"`
 	Replacements map[string]string `json:"replacements,omitzero"`
 	ItemSwitch
+	preconfigurable
 	SpellNonContainerOnlyEditData
 	SkillContainerOnlySyncData
-	preconfigurable
 }
 
 // SpellNonContainerOnlyEditData holds the Spell data that is only applicable to spells that aren't containers.

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -92,9 +92,9 @@ type TraitEditData struct {
 	Frequency    frequency.Roll    `json:"frequency,omitzero"`
 	Disabled     bool              `json:"disabled,omitzero"`
 	ItemSwitch
+	preconfigurable
 	TraitNonContainerOnlyEditData
 	TraitContainerSyncData
-	preconfigurable
 }
 
 // TraitNonContainerOnlyEditData holds the Trait data that is only applicable to traits that aren't containers.

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -94,6 +94,7 @@ type TraitEditData struct {
 	ItemSwitch
 	TraitNonContainerOnlyEditData
 	TraitContainerSyncData
+	preconfigurable
 }
 
 // TraitNonContainerOnlyEditData holds the Trait data that is only applicable to traits that aren't containers.

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -1195,3 +1195,8 @@ func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply boo
 	}
 	t.TemplatePicker = t.TemplatePicker.Clone()
 }
+
+// CanPreconfigureContainer implements Preconfigurable.
+func (t *TraitEditData) CanPreconfigureContainer() bool {
+	return true
+}

--- a/ux/editor.go
+++ b/ux/editor.go
@@ -218,7 +218,7 @@ func (e *editor[N, D]) createToolbar(helpMD string, initToolbar func(*editor[N, 
 				e.nameablesButton.Tooltip = newWrappedTooltip(i18n.Text("Set Substitutions"))
 				e.nameablesButton.ClickCallback = func() {
 					if tmp, m := e.prepareForSubstitutions(); len(m) > 0 {
-						ShowNameablesDialog([]string{tmp.String()}, []map[string]string{m})
+						ShowNameablesDialog([]string{tmp.String()}, []map[string]string{m}, [][]string{nil})
 						tmp.ApplyNameableKeys(m)
 						// Applying nameable keys only alters the replacements map, so copy just that back into the
 						// editor data. Using CopyFrom here would replace the entire object graph with fresh

--- a/ux/equipment_editor.go
+++ b/ux/equipment_editor.go
@@ -80,6 +80,7 @@ func initEquipmentEditor(carried bool) func(e *editor[*gurps.Equipment, *gurps.E
 		content.AddChild(unison.NewPanel())
 		addCheckBox(content, i18n.Text("Ignore weight for skills"), &e.editorData.WeightIgnoredForSkills)
 		addSwitchedOnCheckBox(content, &e.editorData.SwitchedOn)
+		addPreconfigurable(e, content)
 		resolvedMaxUses := func() int { return cloneEquipmentWithOverlay(e.target, e.editorData).ResolvedMaxUses() }
 		usesLabel := i18n.Text("Uses Left")
 		wrapper := addFlowWrapper(content, usesLabel, 5)

--- a/ux/modifier_processing.go
+++ b/ux/modifier_processing.go
@@ -54,6 +54,10 @@ func ProcessModifiers[T gurps.Node[T]](owner unison.Paneler, rows []T) {
 	}
 	for _, row := range rows {
 		gurps.Traverse(func(row T) bool {
+			// If the row is preconfigured, bypass processing
+			if gurps.IsNodePreconfigured(row) {
+				return false
+			}
 			switch t := any(row).(type) {
 			case *gurps.Trait:
 				if promptForTraitModifiers(xstrings.Truncate(row.String(), 40, true), t.Modifiers) {

--- a/ux/nameables_processing.go
+++ b/ux/nameables_processing.go
@@ -107,7 +107,10 @@ func ShowNameablesDialog(titles []string, nameables []map[string]string, visible
 		VSpacing: unison.StdVSpacing,
 	})
 	for i, one := range titles {
-		keys := visibleKeys[i]
+		var keys []string
+		if visibleKeys != nil {
+			keys = visibleKeys[i]
+		}
 		if keys == nil {
 			keys = make([]string, 0, len(nameables[i]))
 			for k := range nameables[i] {

--- a/ux/nameables_processing.go
+++ b/ux/nameables_processing.go
@@ -11,8 +11,10 @@ package ux
 
 import (
 	"github.com/richardwilkes/gcs/v5/model/gurps"
+	"github.com/richardwilkes/gcs/v5/model/nameable"
 	"github.com/richardwilkes/toolbox/v2/geom"
 	"github.com/richardwilkes/toolbox/v2/i18n"
+	"github.com/richardwilkes/toolbox/v2/xreflect"
 	"github.com/richardwilkes/toolbox/v2/xstrings"
 	"github.com/richardwilkes/unison"
 	"github.com/richardwilkes/unison/enums/align"
@@ -37,20 +39,31 @@ func ProcessNameables[T gurps.Node[T]](owner unison.Paneler, rows []T) {
 	var data []T
 	var titles []string
 	var nameables []map[string]string
+	var visibleKeys [][]string
 	for _, row := range rows {
 		gurps.Traverse(func(row T) bool {
 			m := make(map[string]string)
 			row.FillWithNameableKeys(m, nil)
-			if len(m) > 0 {
-				data = append(data, row)
-				titles = append(titles, row.String())
-				nameables = append(nameables, m)
+			if len(m) == 0 {
+				return false
 			}
+			var keys []string
+			if gurps.IsNodePreconfigured(row) {
+				// Only prompt for keys that don't already have a replacement recorded; the rest were already
+				// resolved and shouldn't be asked about again.
+				if keys = missingNameableKeys(row, m); len(keys) == 0 {
+					return false
+				}
+			}
+			data = append(data, row)
+			titles = append(titles, row.String())
+			nameables = append(nameables, m)
+			visibleKeys = append(visibleKeys, keys) // nil means "show all keys"
 			return false
 		}, false, false, row)
 	}
 	if len(data) > 0 {
-		if promptForNameables(titles, nameables) {
+		if promptForNameables(titles, nameables, visibleKeys) {
 			for i, row := range data {
 				row.ApplyNameableKeys(nameables[i])
 			}
@@ -68,8 +81,24 @@ func ProcessNameables[T gurps.Node[T]](owner unison.Paneler, rows []T) {
 	}
 }
 
-// ShowNameablesDialog shows a dialog for editing nameables.
-func ShowNameablesDialog(titles []string, nameables []map[string]string) bool {
+// missingNameableKeys returns the keys in m that don't already have an explicit replacement recorded on row.
+func missingNameableKeys[T gurps.Node[T]](row T, m map[string]string) []string {
+	var existing map[string]string
+	if accessor, ok := any(row).(nameable.Accesser); ok && !xreflect.IsNil(accessor) {
+		existing = accessor.NameableReplacements()
+	}
+	missing := make([]string, 0, len(m))
+	for key := range m {
+		if _, has := existing[key]; !has {
+			missing = append(missing, key)
+		}
+	}
+	return missing
+}
+
+// ShowNameablesDialog shows a dialog for editing nameables. For each row, visibleKeys restricts which keys of the
+// corresponding nameables map are shown/editable; a nil entry shows all of that row's keys.
+func ShowNameablesDialog(titles []string, nameables []map[string]string, visibleKeys [][]string) bool {
 	list := unison.NewPanel()
 	list.SetBorder(unison.NewEmptyBorder(geom.NewUniformInsets(unison.StdHSpacing)))
 	list.SetLayout(&unison.FlexLayout{
@@ -78,9 +107,12 @@ func ShowNameablesDialog(titles []string, nameables []map[string]string) bool {
 		VSpacing: unison.StdVSpacing,
 	})
 	for i, one := range titles {
-		keys := make([]string, 0, len(nameables[i]))
-		for k := range nameables[i] {
-			keys = append(keys, k)
+		keys := visibleKeys[i]
+		if keys == nil {
+			keys = make([]string, 0, len(nameables[i]))
+			for k := range nameables[i] {
+				keys = append(keys, k)
+			}
 		}
 		xstrings.SortStringsNaturalAscending(keys)
 		if i != 0 {

--- a/ux/nameables_processing_test.go
+++ b/ux/nameables_processing_test.go
@@ -26,7 +26,7 @@ func stubNameablesPrompt(t *testing.T, respond func(nameables []map[string]strin
 	original := promptForNameables
 	t.Cleanup(func() { promptForNameables = original })
 	shown := 0
-	promptForNameables = func(_ []string, nameables []map[string]string) bool {
+	promptForNameables = func(_ []string, nameables []map[string]string, visibleKeys [][]string) bool {
 		shown++
 		return respond(nameables)
 	}

--- a/ux/nameables_processing_test.go
+++ b/ux/nameables_processing_test.go
@@ -26,7 +26,7 @@ func stubNameablesPrompt(t *testing.T, respond func(nameables []map[string]strin
 	original := promptForNameables
 	t.Cleanup(func() { promptForNameables = original })
 	shown := 0
-	promptForNameables = func(_ []string, nameables []map[string]string, visibleKeys [][]string) bool {
+	promptForNameables = func(_ []string, nameables []map[string]string, _ [][]string) bool {
 		shown++
 		return respond(nameables)
 	}

--- a/ux/note_editor.go
+++ b/ux/note_editor.go
@@ -100,6 +100,7 @@ func initNoteEditor(e *editor[*gurps.Note, *gurps.NoteEditData], content *unison
 	}
 
 	addTagsLabelAndField(content, &e.editorData.Tags)
+	addPreconfigurable(e, content)
 	addPageRefLabelAndField(content, &e.editorData.PageRef)
 	addPageRefHighlightLabelAndField(content, &e.editorData.PageRefHighlight)
 	addSourceFields(content, &e.target.SourcedID)

--- a/ux/preconfigurable.go
+++ b/ux/preconfigurable.go
@@ -36,3 +36,31 @@ func addPreconfigurable[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D],
 		addCheckBox(parent, i18n.Text("Preconfigured"), p.PreconfiguredRef())
 	}
 }
+
+func shouldClearPreconfiguredFlag(panel unison.Paneler) bool {
+	if xreflect.IsNil(panel) {
+		return false
+	}
+	if _, ok := unison.AncestorOrSelf[unison.Dockable](panel).(*Template); ok {
+		return false
+	}
+	return true
+}
+
+func clearPreconfiguredFlag[T gurps.Node[T]](table *unison.Table[*Node[T]], rows []*Node[T]) bool {
+	if !shouldClearPreconfiguredFlag(table) {
+		return false
+	}
+	if rows == nil {
+		rows = table.SelectedRows(true)
+	}
+	var changes bool
+	for _, row := range rows {
+		node := row.Data()
+		if tl, ok := any(node).(gurps.Preconfigurable); ok && !xreflect.IsNil(node) && tl.IsPreconfigured() {
+			changes = true
+			tl.SetPreconfigured(false)
+		}
+	}
+	return changes
+}

--- a/ux/preconfigurable.go
+++ b/ux/preconfigurable.go
@@ -20,10 +20,17 @@ func addPreconfigurable[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D],
 	if _, ownerIsTemplate := owner.(*Template); !ownerIsTemplate {
 		return
 	}
-	if e.target.Container() {
-		return
-	}
 	if p, ok := any(e.editorData).(gurps.Preconfigurable); ok && !xreflect.IsNil(p) {
+		if e.target.Container() {
+			if !p.CanPreconfigureContainer() {
+				return
+			}
+		} else {
+			if !p.CanPreconfigureItem() {
+				return
+			}
+		}
+
 		// This panel serves only to fill the space where a label would normally be located
 		parent.AddChild(unison.NewPanel())
 		addCheckBox(parent, i18n.Text("Preconfigured"), p.PreconfiguredRef())

--- a/ux/preconfigurable.go
+++ b/ux/preconfigurable.go
@@ -1,0 +1,31 @@
+// Copyright (c) 1998-2026 by Richard A. Wilkes. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, version 2.0. If a copy of the MPL was not distributed with
+// this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, version 2.0.package ux
+package ux
+
+import (
+	"github.com/richardwilkes/gcs/v5/model/gurps"
+	"github.com/richardwilkes/toolbox/v2/i18n"
+	"github.com/richardwilkes/toolbox/v2/xreflect"
+	"github.com/richardwilkes/unison"
+)
+
+func addPreconfigurable[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent *unison.Panel) {
+	owner := e.owner.AsPanel().Self
+	if _, ownerIsTemplate := owner.(*Template); !ownerIsTemplate {
+		return
+	}
+	if e.target.Container() {
+		return
+	}
+	if p, ok := any(e.editorData).(gurps.Preconfigurable); ok && !xreflect.IsNil(p) {
+		// This panel serves only to fill the space where a label would normally be located
+		parent.AddChild(unison.NewPanel())
+		addCheckBox(parent, i18n.Text("Preconfigured"), p.PreconfiguredRef())
+	}
+}

--- a/ux/preconfigurable.go
+++ b/ux/preconfigurable.go
@@ -5,7 +5,7 @@
 // this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // This Source Code Form is "Incompatible With Secondary Licenses", as
-// defined by the Mozilla Public License, version 2.0.package ux
+// defined by the Mozilla Public License, version 2.0.
 package ux
 
 import (

--- a/ux/skill_editor.go
+++ b/ux/skill_editor.go
@@ -45,6 +45,7 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 	if !e.target.Container() {
 		addSwitchedOnCheckBox(content, &e.editorData.SwitchedOn)
 	}
+	addPreconfigurable(e, content)
 	entity := gurps.EntityFromNode(e.target)
 	if e.target.Container() {
 		addTemplateChoices(content, nil, "", &e.editorData.TemplatePicker)

--- a/ux/spell_editor.go
+++ b/ux/spell_editor.go
@@ -95,6 +95,7 @@ func initSpellEditor(e *editor[*gurps.Spell, *gurps.SpellEditData], content *uni
 		addLabelAndMultiLineStringField(content, i18n.Text("Item"), "", &e.editorData.Item)
 	}
 	addTagsLabelAndField(content, &e.editorData.Tags)
+	addPreconfigurable(e, content)
 	if e.target.Container() {
 		addTemplateChoices(content, nil, "", &e.editorData.TemplatePicker)
 	} else {

--- a/ux/table.go
+++ b/ux/table.go
@@ -341,41 +341,15 @@ func copySelectionToSheet[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 					// All processing must happen inside the postProcessor so it is captured by the undo edit's
 					// after-state (CopyRowsTo records that after the postProcessor runs); otherwise redo would not
 					// restore the resolved tech levels, nameables, or the merged points.
-					CopyRowsTo(targetTable, sel, func(_ []*Node[T]) {
+					CopyRowsTo(targetTable, sel, func(rows []*Node[T]) {
 						processDropData()
-						processCopiedRowsForSheet(table, targetTable)
+						processCopiedRows(table, targetTable)
+						clearPreconfiguredFlag(targetTable, rows)
 					}, true)
 				}
 			}
 		}
 	}
-}
-
-// processCopiedRowsForSheet resolves the just-copied, currently-selected rows of a sheet's table the same way a drop
-// onto a sheet does: prompting for the modifiers and nameables of rows that arrived from somewhere other than a sheet,
-// then folding the points of rows that duplicate ones already present into those rows. Does nothing when the
-// destination isn't a character or loot sheet.
-func processCopiedRowsForSheet[T gurps.Node[T]](source, target *unison.Table[*Node[T]]) {
-	if !shouldProcessModifiersAndNameables(target) {
-		return
-	}
-	// Only process modifiers and nameables when copying from something besides a character or loot sheet; rows already
-	// on a sheet have had these resolved.
-	if !shouldProcessModifiersAndNameables(source) {
-		// Answering the modifier prompt rebuilds the owner, and that rebuild can replace the table underneath us: only
-		// the modifiers that are enabled count toward a row having switchable features, so turning one on or off can
-		// add or take away the switch column, and a list can only change its columns by building a new table. An
-		// orphaned table has no Rebuildable above it, so a rebuild asked for through it never happens, and the rows it
-		// reports as selected are its own rather than the ones the user is now looking at -- both of which the steps
-		// below depend upon. Applying nameable substitutions rebuilds as well, so look it up again afterwards too.
-		ProcessModifiersForSelection(target)
-		target = liveTable(target)
-		ProcessNameablesForSelection(target)
-		target = liveTable(target)
-	}
-	// The copy always adds rows to a different sheet, so always merge points into identical existing rows, including
-	// when copying from another sheet.
-	MergeAddedRows(target)
 }
 
 func copySelectionToTemplate[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
@@ -408,13 +382,40 @@ func copySelectionToTemplate[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 					// All processing must happen inside the postProcessor so it is captured by the undo edit's
 					// after-state (CopyRowsTo records that after the postProcessor runs); otherwise redo would not
 					// restore the resolved tech levels, nameables, or the merged points.
-					CopyRowsTo(targetTable, sel, func(_ []*Node[T]) {
+					CopyRowsTo(targetTable, sel, func(rows []*Node[T]) {
 						processDropData()
-						processCopiedRowsForSheet(table, targetTable)
+						processCopiedRows(table, targetTable)
+						clearPreconfiguredFlag(targetTable, rows)
 					}, true)
 				}
 			}
 		}
+	}
+}
+
+// processCopiedRows resolves the just-copied, currently-selected rows of a sheet's table the same way a drop
+// onto a sheet does: prompting for the modifiers and nameables of rows that arrived from somewhere other than a sheet,
+// then folding the points of rows that duplicate ones already present into those rows. Does nothing when the
+// destination isn't a character or loot sheet.
+func processCopiedRows[T gurps.Node[T]](source, target *unison.Table[*Node[T]]) {
+	if shouldProcessModifiersAndNameables(target) {
+		// Only process modifiers and nameables when copying from something besides a character or loot sheet; rows already
+		// on a sheet have had these resolved.
+		if !shouldProcessModifiersAndNameables(source) {
+			// Answering the modifier prompt rebuilds the owner, and that rebuild can replace the table underneath us: only
+			// the modifiers that are enabled count toward a row having switchable features, so turning one on or off can
+			// add or take away the switch column, and a list can only change its columns by building a new table. An
+			// orphaned table has no Rebuildable above it, so a rebuild asked for through it never happens, and the rows it
+			// reports as selected are its own rather than the ones the user is now looking at -- both of which the steps
+			// below depend upon. Applying nameable substitutions rebuilds as well, so look it up again afterwards too.
+			ProcessModifiersForSelection(target)
+			target = liveTable(target)
+			ProcessNameablesForSelection(target)
+			target = liveTable(target)
+		}
+		// The copy always adds rows to a different sheet, so always merge points into identical existing rows, including
+		// when copying from another sheet.
+		MergeAddedRows(target)
 	}
 }
 

--- a/ux/table_drop.go
+++ b/ux/table_drop.go
@@ -192,6 +192,9 @@ func didDropCallback[T gurps.Node[T]](undo *unison.UndoEdit[*TableDragUndoEditDa
 			MergeAddedRows(to)
 		}
 	}
+	if clearPreconfiguredFlag(to, nil) {
+		to = liveTable(to)
+	}
 	finishDidDrop(undo, from, to, move)
 }
 

--- a/ux/table_drop_test.go
+++ b/ux/table_drop_test.go
@@ -447,7 +447,7 @@ func TestCopyToSheetPostProcessingSurvivesTheTargetTableBeingReplaced(t *testing
 	shown := stubTraitModifierPrompt(t, enableAllModifiers)
 
 	CopyRowsTo(target, source.RootRows(), func(_ []*Node[*gurps.Trait]) {
-		processCopiedRowsForSheet(source, target)
+		processCopiedRows(source, target)
 	}, true)
 
 	c.Equal(1, *shown, "a copy from a library must prompt for the copied row's modifiers")

--- a/ux/template.go
+++ b/ux/template.go
@@ -458,6 +458,12 @@ Disable your character's existing Ancestry (%s)?`),
 	ProcessNameablesForSelection(sheet.Traits.Table)
 	ProcessNameablesForSelection(sheet.CarriedEquipment.Table)
 	ProcessNameablesForSelection(sheet.Notes.Table)
+	clearPreconfiguredFlag(sheet.Traits.Table, sheet.Traits.Table.RootRows())
+	clearPreconfiguredFlag(sheet.Skills.Table, sheet.Skills.Table.RootRows())
+	clearPreconfiguredFlag(sheet.Spells.Table, sheet.Spells.Table.RootRows())
+	clearPreconfiguredFlag(sheet.CarriedEquipment.Table, sheet.CarriedEquipment.Table.RootRows())
+	clearPreconfiguredFlag(sheet.Notes.Table, sheet.Notes.Table.RootRows())
+
 	if len(templateAncestries) != 0 && gurps.GlobalSettings().General.AutoFillProfile {
 		randomize := true
 		if !suppressRandomizePrompt {

--- a/ux/trait_editor.go
+++ b/ux/trait_editor.go
@@ -34,6 +34,7 @@ func initTraitEditor(e *editor[*gurps.Trait, *gurps.TraitEditData], content *uni
 	addVTTNotesLabelAndField(content, &e.editorData.VTTNotes)
 	addUserDescLabelAndField(content, &e.editorData.UserDesc)
 	addTagsLabelAndField(content, &e.editorData.Tags)
+	addPreconfigurable(e, content)
 	content.AddChild(unison.NewPanel())
 	addInvertedCheckBox(content, i18n.Text("Enabled"), &e.editorData.Disabled)
 	addSwitchedOnCheckBox(content, &e.editorData.SwitchedOn)


### PR DESCRIPTION
Current template behavior is that when applying a template to a character, all modifier and substition config is done for each template item as it's applied. In most cases the template creator has already made modifier and substitution selections when creating the template. This causes a poor UX when applying a template. It opens the user up to confusion about "should I select modifiers" and "what's this subtitution meant to cover?"

This commit adds a new, optional, flag to template traits, skills, spells, and notes. When this flag is off or missing a template acts exactly the same as it has until now. When a template designer is creating a template they can choose to flag some or all items as "preconfigured" to signal that the modifier and substitution processing during template application can be skipped. If a template item has the flag set but some substitutions are *not* set, then the ones that are not set will be prompted during processing while the already-set ones are skipped.