### PR TITLE
Fix nodes silently churning nested IDs

### DIFF
--- a/model/gurps/clone_weapons_test.go
+++ b/model/gurps/clone_weapons_test.go
@@ -38,7 +38,7 @@ func TestCloneWeaponsBelongToTheirNewHolder(t *testing.T) {
 				n.Replacements = map[string]string{"kind": "Fire"}
 				n.Weapons = []*Weapon{NewWeapon(n, true)}
 				n.SetDataOwner(nil)
-				dup := n.Clone(LibraryFile{}, nil, nil, false)
+				dup := n.Clone(LibraryFile{}, nil, nil, Reference)
 				dup.Replacements["kind"] = "Ice"
 				return n, dup, n.Weapons[0], dup.Weapons[0]
 			},
@@ -51,7 +51,7 @@ func TestCloneWeaponsBelongToTheirNewHolder(t *testing.T) {
 				n.Replacements = map[string]string{"kind": "Fire"}
 				n.Weapons = []*Weapon{NewWeapon(n, true)}
 				n.SetDataOwner(nil)
-				dup := n.Clone(LibraryFile{}, nil, nil, false)
+				dup := n.Clone(LibraryFile{}, nil, nil, Reference)
 				dup.Replacements["kind"] = "Ice"
 				return n, dup, n.Weapons[0], dup.Weapons[0]
 			},
@@ -64,7 +64,7 @@ func TestCloneWeaponsBelongToTheirNewHolder(t *testing.T) {
 				n.Replacements = map[string]string{"kind": "Fire"}
 				n.Weapons = []*Weapon{NewWeapon(n, false)}
 				n.SetDataOwner(nil)
-				dup := n.Clone(LibraryFile{}, nil, nil, false)
+				dup := n.Clone(LibraryFile{}, nil, nil, Reference)
 				dup.Replacements["kind"] = "Ice"
 				return n, dup, n.Weapons[0], dup.Weapons[0]
 			},
@@ -77,7 +77,7 @@ func TestCloneWeaponsBelongToTheirNewHolder(t *testing.T) {
 				n.Replacements = map[string]string{"kind": "Fire"}
 				n.Weapons = []*Weapon{NewWeapon(n, true)}
 				n.SetDataOwner(nil)
-				dup := n.Clone(LibraryFile{}, nil, nil, false)
+				dup := n.Clone(LibraryFile{}, nil, nil, Reference)
 				dup.Replacements["kind"] = "Ice"
 				return n, dup, n.Weapons[0], dup.Weapons[0]
 			},

--- a/model/gurps/conditional_modifier.go
+++ b/model/gurps/conditional_modifier.go
@@ -109,13 +109,13 @@ func (c *ConditionalModifier) Hash(h hash.Hash) {
 }
 
 // Clone implements Node.
-func (c *ConditionalModifier) Clone(_ LibraryFile, _ DataOwner, _ *ConditionalModifier, preserveID bool) *ConditionalModifier {
+func (c *ConditionalModifier) Clone(_ LibraryFile, _ DataOwner, _ *ConditionalModifier, mode CloneMode) *ConditionalModifier {
 	clone := &ConditionalModifier{
 		From:    c.From,
 		Amounts: slices.Clone(c.Amounts),
 		Sources: slices.Clone(c.Sources),
 	}
-	if preserveID {
+	if mode == Copy {
 		clone.TID = c.TID
 	} else {
 		clone.TID = tid.MustNewTID(kinds.ConditionalModifier)

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -219,7 +219,7 @@ func (e *Equipment) SetOpen(open bool) {
 // Clone implements Node.
 func (e *Equipment) Clone(from LibraryFile, owner DataOwner, parent *Equipment, mode CloneMode) *Equipment {
 	other := NewEquipment(owner, parent, e.Container())
-	other.AdjustSource(from, e.SourcedID, mode == Copy, mode == Reference)
+	other.AdjustSource(from, e.SourcedID, mode)
 	other.SetOpen(e.IsOpen())
 	other.ThirdParty = e.ThirdParty
 	other.copyFrom(other, &e.EquipmentEditData, false, mode)

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -217,17 +217,17 @@ func (e *Equipment) SetOpen(open bool) {
 }
 
 // Clone implements Node.
-func (e *Equipment) Clone(from LibraryFile, owner DataOwner, parent *Equipment, preserveID bool) *Equipment {
+func (e *Equipment) Clone(from LibraryFile, owner DataOwner, parent *Equipment, mode CloneMode) *Equipment {
 	other := NewEquipment(owner, parent, e.Container())
-	other.AdjustSource(from, e.SourcedID, preserveID)
+	other.AdjustSource(from, e.SourcedID, mode == Copy, mode == Reference)
 	other.SetOpen(e.IsOpen())
 	other.ThirdParty = e.ThirdParty
-	other.copyFrom(other, &e.EquipmentEditData, false)
+	other.copyFrom(other, &e.EquipmentEditData, false, mode)
 	PropagateNodeNoteClosedState(e, other)
 	if e.HasChildren() {
 		other.Children = make([]*Equipment, 0, len(e.Children))
 		for _, child := range e.Children {
-			other.Children = append(other.Children, child.Clone(from, owner, other, preserveID))
+			other.Children = append(other.Children, child.Clone(from, owner, other, mode))
 		}
 	}
 	return other
@@ -1108,7 +1108,7 @@ func (e *Equipment) SyncWithSource() {
 				e.EquipmentSyncData = other.EquipmentSyncData
 				e.Tags = slices.Clone(other.Tags)
 				e.Prereq = other.Prereq.CloneResolvingEmpty(false, true)
-				e.Weapons = CloneWeapons(other.Weapons, e, false)
+				e.Weapons = CloneWeapons(other.Weapons, e, Reference)
 				e.Features = other.Features.Clone()
 			}
 		}
@@ -1149,7 +1149,7 @@ func (e *EquipmentSyncData) hash(h hash.Hash) {
 
 // CopyFrom implements node.EditorData.
 func (e *EquipmentEditData) CopyFrom(other *Equipment) {
-	e.copyFrom(other, &other.EquipmentEditData, false)
+	e.copyFrom(other, &other.EquipmentEditData, false, Copy)
 }
 
 // SetNameableReplacements sets the replacements to be used with Nameables.
@@ -1159,10 +1159,14 @@ func (e *EquipmentEditData) SetNameableReplacements(replacements map[string]stri
 
 // ApplyTo implements node.EditorData.
 func (e *EquipmentEditData) ApplyTo(other *Equipment) {
-	other.copyFrom(other, e, true)
+	other.copyFrom(other, e, true, Copy)
 }
 
-func (e *EquipmentEditData) copyFrom(equipment *Equipment, other *EquipmentEditData, isApply bool) {
+// copyFrom copies other into e. isApply distinguishes staging the editor's working copy from committing it
+// back, and only affects how an empty Prereq list is resolved. mode controls how nested modifiers and
+// weapons are cloned -- CopyFrom/ApplyTo above always use Copy, since that's staging or committing the same
+// equipment's own data, not producing a new one; Clone passes its own mode through.
+func (e *EquipmentEditData) copyFrom(equipment *Equipment, other *EquipmentEditData, isApply bool, mode CloneMode) {
 	*e = *other
 	e.Tags = slices.Clone(other.Tags)
 	e.Replacements = maps.Clone(other.Replacements)
@@ -1181,7 +1185,7 @@ func (e *EquipmentEditData) copyFrom(equipment *Equipment, other *EquipmentEditD
 			// opposed to duplicating in place), it passes the *source* library as the first
 			// argument to `Clone`. That path, combined with the IDs from the source nodes, is
 			// what builds the `source` values for the clone.
-			cloned := one.Clone(equipment.Source.LibraryFile, equipment.owner, nil, isApply)
+			cloned := one.Clone(equipment.Source.LibraryFile, equipment.owner, nil, mode)
 			// Point the copy at the equipment it belongs to, so that its nameable placeholders can be resolved with
 			// that equipment's replacements. Without this, the copies held in an editor show their raw placeholders
 			// (e.g. "@Material@"), since the accessors fall back to the unsubstituted text when there is no equipment.
@@ -1201,7 +1205,7 @@ func (e *EquipmentEditData) copyFrom(equipment *Equipment, other *EquipmentEditD
 		}
 	}
 	e.Prereq = e.Prereq.CloneResolvingEmpty(false, isApply)
-	e.Weapons = CloneWeapons(other.Weapons, equipment, isApply)
+	e.Weapons = CloneWeapons(other.Weapons, equipment, mode)
 	e.Features = other.Features.Clone()
 }
 

--- a/model/gurps/equipment_modifier.go
+++ b/model/gurps/equipment_modifier.go
@@ -200,7 +200,7 @@ func (e *EquipmentModifier) SetOpen(open bool) {
 // Clone implements Node.
 func (e *EquipmentModifier) Clone(from LibraryFile, owner DataOwner, parent *EquipmentModifier, mode CloneMode) *EquipmentModifier {
 	other := NewEquipmentModifier(owner, parent, e.Container())
-	other.AdjustSource(from, e.SourcedID, mode == Copy, mode == Reference)
+	other.AdjustSource(from, e.SourcedID, mode)
 	other.SetOpen(e.IsOpen())
 	other.ThirdParty = e.ThirdParty
 	other.CopyFrom(e)

--- a/model/gurps/equipment_modifier.go
+++ b/model/gurps/equipment_modifier.go
@@ -198,9 +198,9 @@ func (e *EquipmentModifier) SetOpen(open bool) {
 }
 
 // Clone implements Node.
-func (e *EquipmentModifier) Clone(from LibraryFile, owner DataOwner, parent *EquipmentModifier, preserveID bool) *EquipmentModifier {
+func (e *EquipmentModifier) Clone(from LibraryFile, owner DataOwner, parent *EquipmentModifier, mode CloneMode) *EquipmentModifier {
 	other := NewEquipmentModifier(owner, parent, e.Container())
-	other.AdjustSource(from, e.SourcedID, preserveID)
+	other.AdjustSource(from, e.SourcedID, mode == Copy, mode == Reference)
 	other.SetOpen(e.IsOpen())
 	other.ThirdParty = e.ThirdParty
 	other.CopyFrom(e)
@@ -208,7 +208,7 @@ func (e *EquipmentModifier) Clone(from LibraryFile, owner DataOwner, parent *Equ
 	if e.HasChildren() {
 		other.Children = make([]*EquipmentModifier, 0, len(e.Children))
 		for _, child := range e.Children {
-			other.Children = append(other.Children, child.Clone(from, owner, other, preserveID))
+			other.Children = append(other.Children, child.Clone(from, owner, other, mode))
 		}
 	}
 	return other

--- a/model/gurps/equipment_modifier_test.go
+++ b/model/gurps/equipment_modifier_test.go
@@ -60,7 +60,7 @@ func TestEquipmentModifierCloneDoesNotShareReplacements(t *testing.T) {
 	library.Replacements = map[string]string{"Material": "Steel"}
 
 	// Dropping it onto a sheet's equipment row clones it...
-	dup := library.Clone(LibraryFile{}, nil, nil, false)
+	dup := library.Clone(LibraryFile{}, nil, nil, Reference)
 	c.Equal(map[string]string{"Material": "Steel"}, dup.Replacements, "the copy carries the replacements")
 
 	// ...and the next attachment pass migrates the copy's map into the equipment, which has none of its own.

--- a/model/gurps/equipment_test.go
+++ b/model/gurps/equipment_test.go
@@ -120,7 +120,7 @@ func TestEquipmentCloneAttachesModifiersToTheClone(t *testing.T) {
 	eqp.Modifiers = []*EquipmentModifier{mod}
 	eqp.SetDataOwner(entity)
 
-	clone := eqp.Clone(LibraryFile{}, entity, nil, false)
+	clone := eqp.Clone(LibraryFile{}, entity, nil, Reference)
 	c.Equal(1, len(clone.Modifiers))
 	if len(clone.Modifiers) != 1 || len(clone.Modifiers[0].Children) != 1 {
 		return
@@ -149,7 +149,7 @@ func TestEquipmentCloneMigratesLegacyModifierReplacements(t *testing.T) {
 	mod.Replacements = map[string]string{"Material": "Steel"}
 	eqp.Modifiers = []*EquipmentModifier{mod}
 
-	clone := eqp.Clone(LibraryFile{}, entity, nil, false)
+	clone := eqp.Clone(LibraryFile{}, entity, nil, Reference)
 	c.Equal(0, len(eqp.Replacements), "the equipment being cloned isn't mutated")
 	c.Equal(1, len(clone.Modifiers))
 	if len(clone.Modifiers) != 1 {

--- a/model/gurps/node.go
+++ b/model/gurps/node.go
@@ -45,7 +45,7 @@ type Node[T Node[T]] interface {
 	Openable
 	Hashable
 	nameable.Applier
-	Clone(from LibraryFile, owner DataOwner, newParent T, preserveID bool) T
+	Clone(from LibraryFile, owner DataOwner, newParent T, mode CloneMode) T
 	GetSource() Source
 	ClearSource()
 	SyncWithSource()
@@ -119,3 +119,21 @@ func convertOldCategoriesToTags(tags, categories []string) []string {
 func PropagateNodeNoteClosedState[T Node[T]](from, to T) {
 	SetClosedState("N:"+string(to.ID()), IsClosed("N:"+string(from.ID())))
 }
+
+// CloneMode controls how Clone treats the resulting node's ID and Source relative to the node being cloned.
+type CloneMode int
+
+const (
+	// Reference creates a fresh ID and, if the node being cloned has no Source of its own, anchors the
+	// result's Source to reference it. Used when copying a node into a different list: "Copy to Character
+	// Sheet"/"Copy to Template", drag-and-drop from a library into a sheet or template, dropping a
+	// modifier onto a row.
+	Reference CloneMode = iota
+	// Duplicate create a fresh ID but copies the node being cloned's Source verbatim, even when empty. Used
+	// for "Duplicate": the result is a sibling within the same list, not a new reference to the original.
+	Duplicate
+	// Copy preserves the ID of the node being cloned and copies its Source verbatim, even when empty.
+	// Used for in-memory working copies never inserted into any list: the editor's CopyFrom/ApplyTo
+	// staging round trip, and scratch clones for live preview/calculation.
+	Copy
+)

--- a/model/gurps/note.go
+++ b/model/gurps/note.go
@@ -167,16 +167,16 @@ func (n *Note) SetOpen(open bool) {
 }
 
 // Clone implements Node.
-func (n *Note) Clone(from LibraryFile, owner DataOwner, parent *Note, preserveID bool) *Note {
+func (n *Note) Clone(from LibraryFile, owner DataOwner, parent *Note, mode CloneMode) *Note {
 	other := NewNote(owner, parent, n.Container())
-	other.AdjustSource(from, n.SourcedID, preserveID)
+	other.AdjustSource(from, n.SourcedID, mode == Copy, mode == Reference)
 	other.SetOpen(n.IsOpen())
 	other.ThirdParty = n.ThirdParty
 	other.CopyFrom(n)
 	if n.HasChildren() {
 		other.Children = make([]*Note, 0, len(n.Children))
 		for _, child := range n.Children {
-			other.Children = append(other.Children, child.Clone(from, owner, other, preserveID))
+			other.Children = append(other.Children, child.Clone(from, owner, other, mode))
 		}
 	}
 	return other

--- a/model/gurps/note.go
+++ b/model/gurps/note.go
@@ -169,7 +169,7 @@ func (n *Note) SetOpen(open bool) {
 // Clone implements Node.
 func (n *Note) Clone(from LibraryFile, owner DataOwner, parent *Note, mode CloneMode) *Note {
 	other := NewNote(owner, parent, n.Container())
-	other.AdjustSource(from, n.SourcedID, mode == Copy, mode == Reference)
+	other.AdjustSource(from, n.SourcedID, mode)
 	other.SetOpen(n.IsOpen())
 	other.ThirdParty = n.ThirdParty
 	other.CopyFrom(n)

--- a/model/gurps/scripting_equipment_test.go
+++ b/model/gurps/scripting_equipment_test.go
@@ -97,7 +97,7 @@ func TestScriptEquipmentEquippedOnEditorClone(t *testing.T) {
 
 	// This is how ux.cloneEquipmentWithOverlay builds the clone the editor previews with.
 	cloneForEditor := func(eqp *Equipment) *Equipment {
-		return eqp.Clone(eqp.Source.LibraryFile, eqp.DataOwner(), eqp.Parent(), true)
+		return eqp.Clone(eqp.Source.LibraryFile, eqp.DataOwner(), eqp.Parent(), Copy)
 	}
 
 	// The clone preserves the ID of the row it came from, and script results are cached per entity by (self ID, script

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -278,7 +278,7 @@ func (s *Skill) Clone(from LibraryFile, owner DataOwner, parent *Skill, mode Clo
 		other = NewSkill(owner, parent, s.Container())
 		other.SetOpen(s.IsOpen())
 	}
-	other.AdjustSource(from, s.SourcedID, mode == Copy, mode == Reference)
+	other.AdjustSource(from, s.SourcedID, mode)
 	other.ThirdParty = s.ThirdParty
 	other.copyFrom(other, &s.SkillEditData, s.Container(), false, mode, s.IsTechnique())
 	PropagateNodeNoteClosedState(s, other)

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -266,7 +266,7 @@ func (s *Skill) IsTechnique() bool {
 }
 
 // Clone implements Node.
-func (s *Skill) Clone(from LibraryFile, owner DataOwner, parent *Skill, preserveID bool) *Skill {
+func (s *Skill) Clone(from LibraryFile, owner DataOwner, parent *Skill, mode CloneMode) *Skill {
 	var other *Skill
 	if s.IsTechnique() {
 		var skillName string
@@ -278,14 +278,14 @@ func (s *Skill) Clone(from LibraryFile, owner DataOwner, parent *Skill, preserve
 		other = NewSkill(owner, parent, s.Container())
 		other.SetOpen(s.IsOpen())
 	}
-	other.AdjustSource(from, s.SourcedID, preserveID)
+	other.AdjustSource(from, s.SourcedID, mode == Copy, mode == Reference)
 	other.ThirdParty = s.ThirdParty
-	other.copyFrom(other, &s.SkillEditData, s.Container(), false, s.IsTechnique())
+	other.copyFrom(other, &s.SkillEditData, s.Container(), false, mode, s.IsTechnique())
 	PropagateNodeNoteClosedState(s, other)
 	if s.HasChildren() {
 		other.Children = make([]*Skill, 0, len(s.Children))
 		for _, child := range s.Children {
-			other.Children = append(other.Children, child.Clone(from, owner, other, preserveID))
+			other.Children = append(other.Children, child.Clone(from, owner, other, mode))
 		}
 	}
 	return other
@@ -1457,7 +1457,7 @@ func (s *Skill) SyncWithSource() {
 						s.TechniqueLimitModifier = &mod
 					}
 					s.Prereq = other.Prereq.CloneResolvingEmpty(false, true)
-					s.Weapons = CloneWeapons(other.Weapons, s, false)
+					s.Weapons = CloneWeapons(other.Weapons, s, Reference)
 					s.Features = other.Features.Clone()
 				}
 			}
@@ -1523,7 +1523,7 @@ func (s *SkillNonContainerOnlySyncData) hash(h hash.Hash) {
 
 // CopyFrom implements node.EditorData.
 func (s *SkillEditData) CopyFrom(other *Skill) {
-	s.copyFrom(other, &other.SkillEditData, other.Container(), false, other.IsTechnique())
+	s.copyFrom(other, &other.SkillEditData, other.Container(), false, Copy, other.IsTechnique())
 }
 
 // SetNameableReplacements sets the replacements to be used with Nameables.
@@ -1533,10 +1533,14 @@ func (s *SkillEditData) SetNameableReplacements(replacements map[string]string) 
 
 // ApplyTo implements node.EditorData.
 func (s *SkillEditData) ApplyTo(other *Skill) {
-	other.copyFrom(other, s, other.Container(), true, other.IsTechnique())
+	other.copyFrom(other, s, other.Container(), true, Copy, other.IsTechnique())
 }
 
-func (s *SkillEditData) copyFrom(skill *Skill, other *SkillEditData, isContainer, isApply, isTechnique bool) {
+// copyFrom copies other into s. isApply distinguishes staging the editor's working copy from committing it
+// back, and only affects how an empty Prereq list is resolved. mode controls how cloned weapons are
+// cloned -- CopyFrom/ApplyTo above always use Copy, since that's staging or committing the same skill's own
+// data, not producing a new one; Clone passes its own mode through.
+func (s *SkillEditData) copyFrom(skill *Skill, other *SkillEditData, isContainer, isApply bool, mode CloneMode, isTechnique bool) {
 	*s = *other
 	s.Tags = slices.Clone(other.Tags)
 	s.Replacements = maps.Clone(other.Replacements)
@@ -1572,7 +1576,7 @@ func (s *SkillEditData) copyFrom(skill *Skill, other *SkillEditData, isContainer
 		}
 	}
 	s.Prereq = s.Prereq.CloneResolvingEmpty(isContainer, isApply)
-	s.Weapons = CloneWeapons(other.Weapons, skill, isApply)
+	s.Weapons = CloneWeapons(other.Weapons, skill, mode)
 	s.Features = other.Features.Clone()
 	if len(other.Study) != 0 {
 		s.Study = make([]*Study, len(other.Study))

--- a/model/gurps/skill_test.go
+++ b/model/gurps/skill_test.go
@@ -128,7 +128,7 @@ func TestTechniqueWithoutDefaultDoesNotPanic(t *testing.T) {
 	c.NotPanics(func() { sk.AdjustedRelativeLevel() }, "AdjustedRelativeLevel must not panic")
 	c.NotPanics(func() { sk.CellData(SkillDescriptionColumn, &CellData{}) }, "CellData must not panic")
 	c.NotPanics(func() {
-		clone := sk.Clone(LibraryFile{}, e, nil, false)
+		clone := sk.Clone(LibraryFile{}, e, nil, Reference)
 		c.True(clone.IsTechnique(), "the clone must still be a technique")
 		c.True(clone.TechniqueDefault == nil, "the clone must still have no default")
 	}, "cloning a technique without a default must not panic")
@@ -161,7 +161,7 @@ func TestSkillWithNullDefaultEntry(t *testing.T) {
 	c.NotPanics(func() { Hash64(&sk) }, "hashing must not panic")
 	c.NotPanics(func() { sk.FillWithNameableKeys(make(map[string]string), nil) },
 		"nameable extraction must not panic")
-	c.NotPanics(func() { sk.Clone(LibraryFile{}, e, nil, false) }, "cloning must not panic")
+	c.NotPanics(func() { sk.Clone(LibraryFile{}, e, nil, Reference) }, "cloning must not panic")
 
 	// A nil that reaches the list some other way must be skipped rather than handed back to callers that dereference
 	// it, since resolveToSpecificDefaults' own nil guard used to append it anyway.

--- a/model/gurps/source.go
+++ b/model/gurps/source.go
@@ -236,16 +236,21 @@ func (sm *SrcMatcher) Match(data SrcProvider) (state srcstate.Value, match any) 
 	return srcstate.Missing, nil
 }
 
-// AdjustSource adjusts TID and Source based on original. preserveID keeps original's TID instead of
-// minting a fresh one. ref, only meaningful when original has no Source of its own, anchors Source to
-// reference original; when false, Source is always copied from original verbatim (which may be empty).
-func (s *SourcedID) AdjustSource(from LibraryFile, original SourcedID, preserveID, ref bool) {
-	if preserveID {
+// AdjustSource adjusts TID and Source based on `original` and the clone `mode`.
+//
+// A 'Copy' keeps original's TID instead of minting a fresh one.
+// A 'Reference' when original has no Source of its own, anchors Source to reference the original.
+// Otherwise Source is copied directly from the original.
+func (s *SourcedID) AdjustSource(from LibraryFile, original SourcedID, mode CloneMode) {
+	// For a 'Copy' it shoudl be identical, including IDs
+	if mode == Copy {
 		s.TID = original.TID
 	}
-	s.Source = original.Source
-	if ref && s.Source.Library == "" {
-		s.Source.LibraryFile = from
-		s.Source.TID = original.TID
+	if mode == Reference && original.Source.Library == "" {
+		// If this is for a 'Reference' *and* the original is "root" data, create a new reference source
+		s.Source = Source{LibraryFile: from, TID: original.TID}
+	} else {
+		// Copy source data as-is from the original
+		s.Source = original.Source
 	}
 }

--- a/model/gurps/source.go
+++ b/model/gurps/source.go
@@ -242,7 +242,7 @@ func (sm *SrcMatcher) Match(data SrcProvider) (state srcstate.Value, match any) 
 // A 'Reference' when original has no Source of its own, anchors Source to reference the original.
 // Otherwise Source is copied directly from the original.
 func (s *SourcedID) AdjustSource(from LibraryFile, original SourcedID, mode CloneMode) {
-	// For a 'Copy' it shoudl be identical, including IDs
+	// For a 'Copy' it should be identical, including IDs
 	if mode == Copy {
 		s.TID = original.TID
 	}

--- a/model/gurps/source.go
+++ b/model/gurps/source.go
@@ -236,13 +236,15 @@ func (sm *SrcMatcher) Match(data SrcProvider) (state srcstate.Value, match any) 
 	return srcstate.Missing, nil
 }
 
-// AdjustSource adjusts the source of a SourcedID to match the given LibraryFile.
-func (s *SourcedID) AdjustSource(from LibraryFile, original SourcedID, preserve bool) {
-	if preserve {
+// AdjustSource adjusts TID and Source based on original. preserveID keeps original's TID instead of
+// minting a fresh one. ref, only meaningful when original has no Source of its own, anchors Source to
+// reference original; when false, Source is always copied from original verbatim (which may be empty).
+func (s *SourcedID) AdjustSource(from LibraryFile, original SourcedID, preserveID, ref bool) {
+	if preserveID {
 		s.TID = original.TID
 	}
 	s.Source = original.Source
-	if s.Source.Library == "" {
+	if ref && s.Source.Library == "" {
 		s.Source.LibraryFile = from
 		s.Source.TID = original.TID
 	}

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -269,7 +269,7 @@ func (s *Spell) IsRitualMagic() bool {
 }
 
 // Clone implements Node.
-func (s *Spell) Clone(from LibraryFile, owner DataOwner, parent *Spell, preserveID bool) *Spell {
+func (s *Spell) Clone(from LibraryFile, owner DataOwner, parent *Spell, mode CloneMode) *Spell {
 	var other *Spell
 	if s.IsRitualMagic() {
 		other = NewRitualMagicSpell(owner, parent, false)
@@ -277,14 +277,14 @@ func (s *Spell) Clone(from LibraryFile, owner DataOwner, parent *Spell, preserve
 		other = NewSpell(owner, parent, s.Container())
 		other.SetOpen(s.IsOpen())
 	}
-	other.AdjustSource(from, s.SourcedID, preserveID)
+	other.AdjustSource(from, s.SourcedID, mode == Copy, mode == Reference)
 	other.ThirdParty = s.ThirdParty
-	other.copyFrom(other, &s.SpellEditData, s.Container(), false)
+	other.copyFrom(other, &s.SpellEditData, s.Container(), false, mode)
 	PropagateNodeNoteClosedState(s, other)
 	if s.HasChildren() {
 		other.Children = make([]*Spell, 0, len(s.Children))
 		for _, child := range s.Children {
-			other.Children = append(other.Children, child.Clone(from, owner, other, preserveID))
+			other.Children = append(other.Children, child.Clone(from, owner, other, mode))
 		}
 	}
 	return other
@@ -1226,7 +1226,7 @@ func (s *Spell) SyncWithSource() {
 					s.SpellNonContainerOnlySyncData = other.SpellNonContainerOnlySyncData
 					s.College = slices.Clone(s.College)
 					s.Prereq = other.Prereq.CloneResolvingEmpty(false, true)
-					s.Weapons = CloneWeapons(other.Weapons, s, false)
+					s.Weapons = CloneWeapons(other.Weapons, s, Reference)
 					s.Features = other.Features.Clone()
 				}
 			}
@@ -1285,7 +1285,7 @@ func (s *SpellNonContainerOnlySyncData) hash(h hash.Hash) {
 
 // CopyFrom implements node.EditorData.
 func (s *SpellEditData) CopyFrom(other *Spell) {
-	s.copyFrom(other, &other.SpellEditData, other.Container(), false)
+	s.copyFrom(other, &other.SpellEditData, other.Container(), false, Copy)
 }
 
 // SetNameableReplacements sets the replacements to be used with Nameables.
@@ -1295,10 +1295,14 @@ func (s *SpellEditData) SetNameableReplacements(replacements map[string]string) 
 
 // ApplyTo implements node.EditorData.
 func (s *SpellEditData) ApplyTo(other *Spell) {
-	other.copyFrom(other, s, other.Container(), true)
+	other.copyFrom(other, s, other.Container(), true, Copy)
 }
 
-func (s *SpellEditData) copyFrom(spell *Spell, other *SpellEditData, isContainer, isApply bool) {
+// copyFrom copies other into s. isApply distinguishes staging the editor's working copy from committing it
+// back, and only affects how an empty Prereq list is resolved. mode controls how cloned weapons are
+// cloned -- CopyFrom/ApplyTo above always use Copy, since that's staging or committing the same spell's own
+// data, not producing a new one; Clone passes its own mode through.
+func (s *SpellEditData) copyFrom(spell *Spell, other *SpellEditData, isContainer, isApply bool, mode CloneMode) {
 	*s = *other
 	s.Tags = slices.Clone(other.Tags)
 	s.Replacements = maps.Clone(other.Replacements)
@@ -1308,7 +1312,7 @@ func (s *SpellEditData) copyFrom(spell *Spell, other *SpellEditData, isContainer
 	}
 	s.College = slices.Clone(other.College)
 	s.Prereq = s.Prereq.CloneResolvingEmpty(isContainer, isApply)
-	s.Weapons = CloneWeapons(other.Weapons, spell, isApply)
+	s.Weapons = CloneWeapons(other.Weapons, spell, mode)
 	s.Features = other.Features.Clone()
 	if len(other.Study) != 0 {
 		s.Study = make([]*Study, len(other.Study))

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -277,7 +277,7 @@ func (s *Spell) Clone(from LibraryFile, owner DataOwner, parent *Spell, mode Clo
 		other = NewSpell(owner, parent, s.Container())
 		other.SetOpen(s.IsOpen())
 	}
-	other.AdjustSource(from, s.SourcedID, mode == Copy, mode == Reference)
+	other.AdjustSource(from, s.SourcedID, mode)
 	other.ThirdParty = s.ThirdParty
 	other.copyFrom(other, &s.SpellEditData, s.Container(), false, mode)
 	PropagateNodeNoteClosedState(s, other)

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -232,7 +232,7 @@ func (t *Trait) SetOpen(open bool) {
 // Clone implements Node.
 func (t *Trait) Clone(from LibraryFile, owner DataOwner, parent *Trait, mode CloneMode) *Trait {
 	other := NewTrait(owner, parent, t.Container())
-	other.AdjustSource(from, t.SourcedID, mode == Copy, mode == Reference)
+	other.AdjustSource(from, t.SourcedID, mode)
 	other.SetOpen(t.IsOpen())
 	other.ThirdParty = t.ThirdParty
 	other.copyFrom(other, &t.TraitEditData, false, mode)

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -230,17 +230,17 @@ func (t *Trait) SetOpen(open bool) {
 }
 
 // Clone implements Node.
-func (t *Trait) Clone(from LibraryFile, owner DataOwner, parent *Trait, preserveID bool) *Trait {
+func (t *Trait) Clone(from LibraryFile, owner DataOwner, parent *Trait, mode CloneMode) *Trait {
 	other := NewTrait(owner, parent, t.Container())
-	other.AdjustSource(from, t.SourcedID, preserveID)
+	other.AdjustSource(from, t.SourcedID, mode == Copy, mode == Reference)
 	other.SetOpen(t.IsOpen())
 	other.ThirdParty = t.ThirdParty
-	other.copyFrom(other, &t.TraitEditData, false)
+	other.copyFrom(other, &t.TraitEditData, false, mode)
 	PropagateNodeNoteClosedState(t, other)
 	if t.HasChildren() {
 		other.Children = make([]*Trait, 0, len(t.Children))
 		for _, child := range t.Children {
-			other.Children = append(other.Children, child.Clone(from, owner, other, preserveID))
+			other.Children = append(other.Children, child.Clone(from, owner, other, mode))
 		}
 	}
 	return other
@@ -1088,7 +1088,7 @@ func (t *Trait) SyncWithSource() {
 					t.TemplatePicker = other.TemplatePicker.Clone()
 				} else {
 					t.TraitNonContainerSyncData = other.TraitNonContainerSyncData
-					t.Weapons = CloneWeapons(other.Weapons, t, false)
+					t.Weapons = CloneWeapons(other.Weapons, t, Reference)
 					t.Features = other.Features.Clone()
 				}
 			}
@@ -1144,7 +1144,7 @@ func (t *TraitContainerSyncData) hash(h hash.Hash) {
 
 // CopyFrom implements node.EditorData.
 func (t *TraitEditData) CopyFrom(other *Trait) {
-	t.copyFrom(other, &other.TraitEditData, false)
+	t.copyFrom(other, &other.TraitEditData, false, Copy)
 }
 
 // SetNameableReplacements sets the replacements to be used with Nameables.
@@ -1154,10 +1154,14 @@ func (t *TraitEditData) SetNameableReplacements(replacements map[string]string) 
 
 // ApplyTo implements node.EditorData.
 func (t *TraitEditData) ApplyTo(other *Trait) {
-	other.copyFrom(other, t, true)
+	other.copyFrom(other, t, true, Copy)
 }
 
-func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply bool) {
+// copyFrom copies other into t. isApply distinguishes staging the editor's working copy from committing it
+// back, and only affects how an empty Prereq list is resolved. mode controls how nested modifiers and
+// weapons are cloned -- CopyFrom/ApplyTo above always use Copy, since that's staging or committing the same
+// trait's own data, not producing a new one; Clone passes its own mode through.
+func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply bool, mode CloneMode) {
 	*t = *other
 	t.Tags = slices.Clone(other.Tags)
 	t.Replacements = maps.Clone(other.Replacements)
@@ -1176,7 +1180,7 @@ func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply boo
 			// opposed to duplicating in place), it passes the *source* library as the first
 			// argument to `Clone`. That path, combined with the IDs from the source nodes, is
 			// what builds the `source` values for the clone.
-			cloned := one.Clone(trait.Source.LibraryFile, trait.owner, nil, isApply)
+			cloned := one.Clone(trait.Source.LibraryFile, trait.owner, nil, mode)
 			// Point the copy at the trait it belongs to, so that a "use level from owner" modifier can resolve its
 			// level. Prior to this, the copies held in an editor only acquired their trait as a side effect of a point
 			// cost computation.
@@ -1185,7 +1189,7 @@ func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply boo
 		}
 	}
 	t.Prereq = t.Prereq.CloneResolvingEmpty(false, isApply)
-	t.Weapons = CloneWeapons(other.Weapons, trait, isApply)
+	t.Weapons = CloneWeapons(other.Weapons, trait, mode)
 	t.Features = other.Features.Clone()
 	if len(other.Study) != 0 {
 		t.Study = make([]*Study, len(other.Study))

--- a/model/gurps/trait_modifier.go
+++ b/model/gurps/trait_modifier.go
@@ -203,9 +203,9 @@ func (t *TraitModifier) SetOpen(open bool) {
 }
 
 // Clone implements Node.
-func (t *TraitModifier) Clone(from LibraryFile, owner DataOwner, parent *TraitModifier, preserveID bool) *TraitModifier {
+func (t *TraitModifier) Clone(from LibraryFile, owner DataOwner, parent *TraitModifier, mode CloneMode) *TraitModifier {
 	other := NewTraitModifier(owner, parent, t.Container())
-	other.AdjustSource(from, t.SourcedID, preserveID)
+	other.AdjustSource(from, t.SourcedID, mode == Copy, mode == Reference)
 	other.SetOpen(t.IsOpen())
 	other.ThirdParty = t.ThirdParty
 	other.CopyFrom(t)
@@ -213,7 +213,7 @@ func (t *TraitModifier) Clone(from LibraryFile, owner DataOwner, parent *TraitMo
 	if t.HasChildren() {
 		other.Children = make([]*TraitModifier, 0, len(t.Children))
 		for _, child := range t.Children {
-			other.Children = append(other.Children, child.Clone(from, owner, other, preserveID))
+			other.Children = append(other.Children, child.Clone(from, owner, other, mode))
 		}
 	}
 	return other

--- a/model/gurps/trait_modifier.go
+++ b/model/gurps/trait_modifier.go
@@ -205,7 +205,7 @@ func (t *TraitModifier) SetOpen(open bool) {
 // Clone implements Node.
 func (t *TraitModifier) Clone(from LibraryFile, owner DataOwner, parent *TraitModifier, mode CloneMode) *TraitModifier {
 	other := NewTraitModifier(owner, parent, t.Container())
-	other.AdjustSource(from, t.SourcedID, mode == Copy, mode == Reference)
+	other.AdjustSource(from, t.SourcedID, mode)
 	other.SetOpen(t.IsOpen())
 	other.ThirdParty = t.ThirdParty
 	other.CopyFrom(t)

--- a/model/gurps/trait_modifier_test.go
+++ b/model/gurps/trait_modifier_test.go
@@ -28,7 +28,7 @@ func TestTraitModifierCloneDoesNotShareReplacements(t *testing.T) {
 	library.Replacements = map[string]string{"Element": "Fire"}
 
 	// Dropping it onto a sheet's trait row clones it...
-	dup := library.Clone(LibraryFile{}, nil, nil, false)
+	dup := library.Clone(LibraryFile{}, nil, nil, Reference)
 	c.Equal(map[string]string{"Element": "Fire"}, dup.Replacements, "the copy carries the replacements")
 
 	// ...and the next attachment pass migrates the copy's map into the trait, which has none of its own.

--- a/model/gurps/trait_test.go
+++ b/model/gurps/trait_test.go
@@ -306,7 +306,7 @@ func TestTraitCloneModifiersBelongToTheClone(t *testing.T) {
 	source.Modifiers = []*TraitModifier{mod}
 	source.SetDataOwner(nil)
 
-	clone := source.Clone(LibraryFile{}, nil, nil, false)
+	clone := source.Clone(LibraryFile{}, nil, nil, Reference)
 	c.Equal(1, len(clone.Modifiers), "the modifier was copied")
 	// Compared as pointers: the two traits are equal by value at this point, so only identity distinguishes them.
 	c.True(clone.Modifiers[0].OwningTrait() == clone, "the copy belongs to the clone, not the trait cloned from")
@@ -329,7 +329,7 @@ func TestTraitCloneModifiersBelongToTheClone(t *testing.T) {
 	source.parent = parent
 	parent.Children = []*Trait{source}
 	parent.SetDataOwner(nil)
-	clonedContainer := parent.Clone(LibraryFile{}, nil, nil, false)
+	clonedContainer := parent.Clone(LibraryFile{}, nil, nil, Reference)
 	c.Equal(1, len(clonedContainer.Children), "the child was cloned")
 	clonedChild := clonedContainer.Children[0]
 	c.True(clonedChild.Modifiers[0].OwningTrait() == clonedChild, "a cloned child's modifier belongs to that child")

--- a/model/gurps/weapon.go
+++ b/model/gurps/weapon.go
@@ -177,22 +177,22 @@ func (w *Weapon) IsRanged() bool {
 // original's owner over, since it has no way to know the new one, so the owner must be supplied here: a weapon resolves
 // its nameable replacements, skill defaults and strength requirements through its owner, so a copy left pointing at the
 // node it was copied from reports that node's values rather than its own holder's.
-func CloneWeapons(list []*Weapon, owner WeaponOwner, preserveIDs bool) []*Weapon {
+func CloneWeapons(list []*Weapon, owner WeaponOwner, mode CloneMode) []*Weapon {
 	if len(list) == 0 {
 		return nil
 	}
 	weapons := make([]*Weapon, len(list))
 	for i, w := range list {
-		weapons[i] = w.Clone(LibraryFile{}, nil, nil, preserveIDs)
+		weapons[i] = w.Clone(LibraryFile{}, nil, nil, mode)
 		weapons[i].SetOwner(owner)
 	}
 	return weapons
 }
 
 // Clone implements Node.
-func (w *Weapon) Clone(_ LibraryFile, _ DataOwner, _ *Weapon, preserveID bool) *Weapon {
+func (w *Weapon) Clone(_ LibraryFile, _ DataOwner, _ *Weapon, mode CloneMode) *Weapon {
 	other := *w
-	if !preserveID {
+	if mode != Copy {
 		other.TID = tid.MustNewTID(w.TID[0])
 		other.ClonedFromTID = w.TID
 	}
@@ -1041,7 +1041,7 @@ func (w *Weapon) ColumnHasData(columnID int) bool {
 
 // CopyFrom implements node.EditorData.
 func (w *Weapon) CopyFrom(t *Weapon) {
-	*w = *t.Clone(LibraryFile{}, t.DataOwner(), nil, false)
+	*w = *t.Clone(LibraryFile{}, t.DataOwner(), nil, Duplicate)
 }
 
 // ApplyTo implements node.EditorData.
@@ -1052,7 +1052,7 @@ func (w *Weapon) ApplyTo(t *Weapon) {
 	// a trait, skill or spell editor back to the weapon it came from.
 	savedTID := t.TID
 	savedClonedFromTID := t.ClonedFromTID
-	*t = *w.Clone(LibraryFile{}, t.DataOwner(), nil, true)
+	*t = *w.Clone(LibraryFile{}, t.DataOwner(), nil, Copy)
 	t.TID = savedTID
 	t.ClonedFromTID = savedClonedFromTID
 }

--- a/ux/editor.go
+++ b/ux/editor.go
@@ -253,7 +253,7 @@ func (e *editor[N, D]) createToolbar(helpMD string, initToolbar func(*editor[N, 
 }
 
 func (e *editor[N, D]) prepareForSubstitutions() (tmpNode N, m map[string]string) {
-	tmpNode = e.target.Clone(e.target.GetSource().LibraryFile, e.target.DataOwner(), nil, true)
+	tmpNode = e.target.Clone(e.target.GetSource().LibraryFile, e.target.DataOwner(), nil, gurps.Copy)
 	e.editorData.ApplyTo(tmpNode)
 	m = make(map[string]string)
 	tmpNode.FillWithNameableKeys(m, nil)
@@ -313,7 +313,7 @@ func (e *editor[N, D]) Modified() bool {
 // to avoid cloning the target on every call, since Modified is invoked frequently during layout and redraw.
 func (e *editor[N, D]) hasNameableKeys() bool {
 	if xreflect.IsNil(e.nameablesScratch) {
-		e.nameablesScratch = e.target.Clone(e.target.GetSource().LibraryFile, e.target.DataOwner(), nil, true)
+		e.nameablesScratch = e.target.Clone(e.target.GetSource().LibraryFile, e.target.DataOwner(), nil, gurps.Copy)
 		e.nameablesKeys = make(map[string]string)
 	} else {
 		clear(e.nameablesKeys)

--- a/ux/equipment_editor.go
+++ b/ux/equipment_editor.go
@@ -153,7 +153,7 @@ func extendedWeightForEditor(target *gurps.Equipment, overlay *gurps.EquipmentEd
 }
 
 func cloneEquipmentWithOverlay(e *gurps.Equipment, overlay *gurps.EquipmentEditData) *gurps.Equipment {
-	clone := e.Clone(e.Source.LibraryFile, e.DataOwner(), e.Parent(), true)
+	clone := e.Clone(e.Source.LibraryFile, e.DataOwner(), e.Parent(), gurps.Copy)
 	clone.EquipmentEditData = *overlay
 	return clone
 }

--- a/ux/equipment_provider.go
+++ b/ux/equipment_provider.go
@@ -135,7 +135,7 @@ func (p *equipmentProvider) AltDropSupport() *AltDropSupport {
 				rows := make([]*gurps.EquipmentModifier, 0, len(tableDragData.Rows))
 				libraryFile := libraryFileFromTable(tableDragData.Table)
 				for _, row := range tableDragData.Rows {
-					rows = append(rows, row.Data().Clone(libraryFile, dataOwner, nil, false))
+					rows = append(rows, row.Data().Clone(libraryFile, dataOwner, nil, gurps.Reference))
 				}
 				rowData := p.table.RowFromIndex(rowIndex).Data()
 				rowData.Modifiers = append(rowData.Modifiers, rows...)

--- a/ux/loot.go
+++ b/ux/loot.go
@@ -692,7 +692,7 @@ or under the maximum value of $%s with the available items.`),
 		}
 		loot := gurps.NewLoot()
 		for item, quantity := range m {
-			clone := item.Clone(gurps.LibraryFile{}, gurps.EntityFromNode(item), nil, false)
+			clone := item.Clone(gurps.LibraryFile{}, gurps.EntityFromNode(item), nil, gurps.Reference)
 			clone.Quantity = fxp.FromInteger(quantity)
 			loot.Equipment = append(loot.Equipment, clone)
 		}

--- a/ux/table.go
+++ b/ux/table.go
@@ -563,7 +563,7 @@ func DuplicateSelection[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 				continue
 			}
 			parent := target.Parent()
-			clone := target.Clone(gurps.LibraryFile{}, gurps.EntityFromNode(target), parent, false)
+			clone := target.Clone(gurps.LibraryFile{}, gurps.EntityFromNode(target), parent, gurps.Duplicate)
 			selMap[clone.ID()] = true
 			if parent == zero {
 				for i, child := range topLevelData {

--- a/ux/table_node.go
+++ b/ux/table_node.go
@@ -88,7 +88,7 @@ func (n *Node[T]) CloneForTarget(target unison.Paneler, newParent *Node[T]) *Nod
 		owner = provider.DataOwner()
 	}
 	return NewNode(table, newParent,
-		n.data.Clone(libraryFileFromTable(n.table), owner, newParent.Data(), false), false)
+		n.data.Clone(libraryFileFromTable(n.table), owner, newParent.Data(), gurps.Reference), false)
 }
 
 // ID implements unison.TableRowData.

--- a/ux/trait_editor.go
+++ b/ux/trait_editor.go
@@ -178,7 +178,7 @@ func initTraitEditor(e *editor[*gurps.Trait, *gurps.TraitEditData], content *uni
 }
 
 func cloneTraitWithOverlay(t *gurps.Trait, overlay *gurps.TraitEditData) *gurps.Trait {
-	clone := t.Clone(t.Source.LibraryFile, t.DataOwner(), t.Parent(), true)
+	clone := t.Clone(t.Source.LibraryFile, t.DataOwner(), t.Parent(), gurps.Copy)
 	clone.TraitEditData = *overlay
 	return clone
 }

--- a/ux/traits_provider.go
+++ b/ux/traits_provider.go
@@ -111,7 +111,7 @@ func (p *traitsProvider) AltDropSupport() *AltDropSupport {
 				rows := make([]*gurps.TraitModifier, 0, len(tableDragData.Rows))
 				libraryFile := libraryFileFromTable(tableDragData.Table)
 				for _, row := range tableDragData.Rows {
-					rows = append(rows, row.Data().Clone(libraryFile, dataOwner, nil, false))
+					rows = append(rows, row.Data().Clone(libraryFile, dataOwner, nil, gurps.Reference))
 				}
 				rowData := p.table.RowFromIndex(rowIndex).Data()
 				rowData.Modifiers = append(rowData.Modifiers, rows...)


### PR DESCRIPTION
Clone previously conflated three distinct scenarios (copying into a different list, duplicating within the same list, and the editor's own in-memory staging round trip) behind a single preserveID bool, threaded inconsistently into nested modifier/weapon clones and into AdjustSource's source anchoring fallback. As a result, simply opening a Trait/Skill/Spell/Equipment editor and clicking Apply silently reassigned fresh IDs to every nested modifier and weapon, and duplicating a sourceless custom item spuriously gave it a self-referencing Source it never had.

Replaced preserveID with an explicit CloneMode (Reference/Duplicate/Copy) so each scenario's ID and Source handling is unambiguous at every call site, and thread it through every Clone implementer, the editor's staging copyFrom, and all external callers.