### PR TITLE
Small code cleanups

### DIFF
--- a/ux/choices.go
+++ b/ux/choices.go
@@ -1,0 +1,76 @@
+// Copyright (c) 1998-2026 by Richard A. Wilkes. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, version 2.0. If a copy of the MPL was not distributed with
+// this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, version 2.0.
+
+package ux
+
+import (
+	"github.com/richardwilkes/gcs/v5/model/criteria"
+	"github.com/richardwilkes/gcs/v5/model/fxp"
+	"github.com/richardwilkes/gcs/v5/model/gurps"
+	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
+	"github.com/richardwilkes/toolbox/v2/i18n"
+	"github.com/richardwilkes/toolbox/v2/xreflect"
+	"github.com/richardwilkes/unison"
+)
+
+func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent *unison.Panel, templateOnly bool) (*unison.PopupMenu[picker.Type], *unison.PopupMenu[string], unison.Paneler) {
+	if templateOnly && !HasOwner[*Template](parent) {
+		return nil, nil, nil
+	}
+
+	if xreflect.IsNil(e.target) || !e.target.Container() {
+		return nil, nil, nil
+	}
+
+	var tp *gurps.TemplatePicker
+	if pickable, ok := any(e.target).(gurps.TemplatePickerProvider); ok {
+		tp = pickable.TemplatePickerData()
+	} else {
+		return nil, nil, nil
+	}
+
+	if tp == nil {
+		tp = &gurps.TemplatePicker{}
+	}
+
+	last := tp.Type
+	wrapper := addFlowWrapper(parent, i18n.Text("Choices"), 3)
+	typePopup := addPopup(wrapper, picker.Types, &tp.Type)
+	text := i18n.Text("Choice Quantifier")
+	comparisonPopup, field := addNumericCriteriaPanel(wrapper, nil, "", "", text, &tp.Qualifier, fxp.Min, fxp.Max, 1, false, false)
+
+	// A picker that isn't in use has nothing to quantify, so both the comparison and the qualifier are blanked out. The
+	// qualifier is blanked as well whenever the comparison doesn't use one. The opening state must be settled the same
+	// way the selection callback settles it, or an untouched editor lets the user alter a picker that will be dropped
+	// on save, or refuses edits to one that will be kept.
+	adjust := func(pickerType picker.Type) {
+		notApplicable := pickerType == picker.NotApplicable
+		adjustPopupBlank(comparisonPopup, notApplicable)
+		adjustFieldBlank(field, notApplicable || tp.Qualifier.Compare == criteria.AnyNumber)
+	}
+
+	typePopup.SelectionChangedCallback = func(p *unison.PopupMenu[picker.Type]) {
+		if item, ok := p.Selected(); ok {
+			tp.Type = item
+			if last == picker.NotApplicable && item != picker.NotApplicable {
+				tp.Qualifier.Qualifier = fxp.One
+				if syncer, ok2 := field.(Syncer); ok2 {
+					syncer.Sync()
+				}
+			}
+			last = item
+			adjust(item)
+			MarkModified(parent)
+		}
+	}
+
+	adjust(tp.Type)
+
+	return typePopup, comparisonPopup, field
+}

--- a/ux/choices.go
+++ b/ux/choices.go
@@ -19,20 +19,24 @@ import (
 	"github.com/richardwilkes/unison"
 )
 
-func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent *unison.Panel, templateOnly bool) (*unison.PopupMenu[picker.Type], *unison.PopupMenu[string], unison.Paneler) {
+func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent *unison.Panel, templateOnly bool) (
+	typePopup *unison.PopupMenu[picker.Type],
+	comparisonPopup *unison.PopupMenu[string],
+	field unison.Paneler,
+) {
 	if templateOnly && !HasOwner[*Template](parent) {
-		return nil, nil, nil
+		return
 	}
 
 	if xreflect.IsNil(e.target) || !e.target.Container() {
-		return nil, nil, nil
+		return
 	}
 
 	var tp *gurps.TemplatePicker
 	if pickable, ok := any(e.target).(gurps.TemplatePickerProvider); ok {
 		tp = pickable.TemplatePickerData()
 	} else {
-		return nil, nil, nil
+		return
 	}
 
 	if tp == nil {
@@ -41,9 +45,9 @@ func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent 
 
 	last := tp.Type
 	wrapper := addFlowWrapper(parent, i18n.Text("Choices"), 3)
-	typePopup := addPopup(wrapper, picker.Types, &tp.Type)
+	typePopup = addPopup(wrapper, picker.Types, &tp.Type)
 	text := i18n.Text("Choice Quantifier")
-	comparisonPopup, field := addNumericCriteriaPanel(wrapper, nil, "", "", text, &tp.Qualifier, fxp.Min, fxp.Max, 1, false, false)
+	comparisonPopup, field = addNumericCriteriaPanel(wrapper, nil, "", "", text, &tp.Qualifier, fxp.Min, fxp.Max, 1, false, false)
 
 	// A picker that isn't in use has nothing to quantify, so both the comparison and the qualifier are blanked out. The
 	// qualifier is blanked as well whenever the comparison doesn't use one. The opening state must be settled the same
@@ -72,5 +76,5 @@ func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent 
 
 	adjust(tp.Type)
 
-	return typePopup, comparisonPopup, field
+	return
 }

--- a/ux/choices.go
+++ b/ux/choices.go
@@ -25,18 +25,18 @@ func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent 
 	field unison.Paneler,
 ) {
 	if templateOnly && !HasOwner[*Template](parent) {
-		return
+		return typePopup, comparisonPopup, field
 	}
 
 	if xreflect.IsNil(e.target) || !e.target.Container() {
-		return
+		return typePopup, comparisonPopup, field
 	}
 
 	var tp *gurps.TemplatePicker
 	if pickable, ok := any(e.target).(gurps.TemplatePickerProvider); ok {
 		tp = pickable.TemplatePickerData()
 	} else {
-		return
+		return typePopup, comparisonPopup, field
 	}
 
 	if tp == nil {
@@ -76,5 +76,5 @@ func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent 
 
 	adjust(tp.Type)
 
-	return
+	return typePopup, comparisonPopup, field
 }

--- a/ux/choices_test.go
+++ b/ux/choices_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 1998-2026 by Richard A. Wilkes. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, version 2.0. If a copy of the MPL was not distributed with
+// this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, version 2.0.
+
+package ux
+
+import (
+	"testing"
+
+	"github.com/richardwilkes/gcs/v5/model/criteria"
+	"github.com/richardwilkes/gcs/v5/model/fxp"
+	"github.com/richardwilkes/gcs/v5/model/gurps"
+	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
+	"github.com/richardwilkes/toolbox/v2/check"
+	"github.com/richardwilkes/unison"
+)
+
+// newChoices builds the "Choices" row an item editor shows for a picker, returning the two
+// popups and the qualifier field it is made of.
+func newChoices(pickerType picker.Type, compare criteria.NumericComparison) (typePopup *unison.PopupMenu[picker.Type], comparisonPopup *unison.PopupMenu[string], field unison.Paneler) {
+	trait := gurps.NewTrait(nil, nil, true)
+	trait.TemplatePicker.Type = pickerType
+	trait.TemplatePicker.Qualifier.Compare = compare
+	trait.TemplatePicker.Qualifier.Qualifier = fxp.One
+	return addChoices(&editor[*gurps.Trait, *gurps.TraitData]{target: trait}, unison.NewPanel(), false)
+}
+
+// TestChoicesOpeningState verifies that a freshly opened editor blanks the picker's comparison popup
+// and qualifier field under exactly the conditions its own selection callback uses. A picker set to Not Applicable is
+// zero, so anything entered for it is dropped when the item is saved; leaving the comparison popup live let the user
+// make a selection that set the comparison, un-blanked the qualifier and marked the item modified, all for edits that
+// could never be kept. In the other direction, a saved picker whose comparison takes no qualifier opened with the
+// qualifier editable, even though every later pass through the callback blanks it.
+func TestChoicesOpeningState(t *testing.T) {
+	c := check.New(t)
+
+	// The default for every new trait, skill and spell container. Nothing about it can be saved, so nothing about it
+	// may be edited.
+	_, comparison, field := newChoices(picker.NotApplicable, criteria.AnyNumber)
+	c.False(comparison.Enabled(), "a picker that isn't in use must not offer a comparison")
+	c.False(field.AsPanel().Enabled(), "a picker that isn't in use must not offer a qualifier")
+
+	// In use, but comparing against anything, which needs no number to compare with.
+	_, comparison, field = newChoices(picker.Count, criteria.AnyNumber)
+	c.True(comparison.Enabled(), "a picker in use must offer a comparison")
+	c.False(field.AsPanel().Enabled(), "a comparison that takes no qualifier must not offer one")
+
+	// In use with a comparison that needs a number, so everything is editable.
+	_, comparison, field = newChoices(picker.Points, criteria.AtLeastNumber)
+	c.True(comparison.Enabled(), "a picker in use must offer a comparison")
+	c.True(field.AsPanel().Enabled(), "a comparison that takes a qualifier must offer one")
+}
+
+// TestChoicesFollowTheTypeSelection verifies that choosing a picker type updates the comparison popup
+// and qualifier field, and that returning to Not Applicable blanks them both again.
+func TestChoicesFollowTheTypeSelection(t *testing.T) {
+	c := check.New(t)
+	typePopup, comparison, field := newChoices(picker.NotApplicable, criteria.EqualsNumber)
+	c.False(comparison.Enabled(), "a picker that isn't in use must not offer a comparison")
+	c.False(field.AsPanel().Enabled(), "a picker that isn't in use must not offer a qualifier")
+
+	typePopup.Select(picker.Count)
+	c.True(comparison.Enabled(), "putting the picker to use must offer a comparison")
+	c.True(field.AsPanel().Enabled(), "putting the picker to use must offer a qualifier")
+
+	typePopup.Select(picker.NotApplicable)
+	c.False(comparison.Enabled(), "taking the picker out of use must withdraw the comparison")
+	c.False(field.AsPanel().Enabled(), "taking the picker out of use must withdraw the qualifier")
+}

--- a/ux/editor.go
+++ b/ux/editor.go
@@ -284,6 +284,10 @@ func (e *editor[N, D]) Owner() Rebuildable {
 	return e.owner
 }
 
+func (e *editor[N, D]) Target() N {
+	return e.target
+}
+
 var pruneIDFields = regexp.MustCompile(`\s*"id":\s*"[^"]+",?\s*`)
 
 func (e *editor[N, D]) isModified() bool {

--- a/ux/editor.go
+++ b/ux/editor.go
@@ -35,6 +35,7 @@ var (
 	_ unison.UndoManagerProvider = &editor[*gurps.Note, *gurps.NoteEditData]{}
 	_ GroupedCloser              = &editor[*gurps.Note, *gurps.NoteEditData]{}
 	_ Rebuildable                = &editor[*gurps.Note, *gurps.NoteEditData]{}
+	_ Owned                      = &editor[*gurps.Note, *gurps.NoteEditData]{}
 )
 
 // nameableReplacementsSetter is implemented by editor data that can have its nameable replacements set directly.
@@ -277,6 +278,10 @@ func (e *editor[N, D]) String() string {
 
 func (e *editor[N, D]) Tooltip() string {
 	return ""
+}
+
+func (e *editor[N, D]) Owner() Rebuildable {
+	return e.owner
 }
 
 var pruneIDFields = regexp.MustCompile(`\s*"id":\s*"[^"]+",?\s*`)

--- a/ux/editor.go
+++ b/ux/editor.go
@@ -142,8 +142,8 @@ func displayEditor[N gurps.Node[N], D gurps.EditorData[N]](owner Rebuildable, ta
 	})
 
 	e.AddChild(e.createToolbar(helpMD, initToolbar))
-	e.modificationCallback = initContent(e, content)
 	e.AddChild(e.scroll)
+	e.modificationCallback = initContent(e, content)
 	e.ClientData()[AssociatedIDKey] = target.ID()
 	e.promptForSave = true
 	e.scroll.Content().AsPanel().ValidateScrollRoot()

--- a/ux/preconfigurable.go
+++ b/ux/preconfigurable.go
@@ -16,8 +16,7 @@ import (
 )
 
 func addPreconfigurable[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent *unison.Panel) {
-	owner := e.owner.AsPanel().Self
-	if _, ownerIsTemplate := owner.(*Template); !ownerIsTemplate {
+	if !HasOwner[*Template](parent) {
 		return
 	}
 	if p, ok := any(e.editorData).(gurps.Preconfigurable); ok && !xreflect.IsNil(p) {

--- a/ux/skill_editor.go
+++ b/ux/skill_editor.go
@@ -47,9 +47,8 @@ func initSkillEditor(e *editor[*gurps.Skill, *gurps.SkillEditData], content *uni
 	}
 	addPreconfigurable(e, content)
 	entity := gurps.EntityFromNode(e.target)
-	if e.target.Container() {
-		addTemplateChoices(content, nil, "", &e.editorData.TemplatePicker)
-	} else {
+	addChoices(e, content, true)
+	if !e.target.Container() {
 		if e.target.IsTechnique() {
 			if e.editorData.TechniqueDefault == nil {
 				// Data loaded from JSON without a "default" field leaves this nil, so give the editor something to

--- a/ux/spell_editor.go
+++ b/ux/spell_editor.go
@@ -96,9 +96,8 @@ func initSpellEditor(e *editor[*gurps.Spell, *gurps.SpellEditData], content *uni
 	}
 	addTagsLabelAndField(content, &e.editorData.Tags)
 	addPreconfigurable(e, content)
-	if e.target.Container() {
-		addTemplateChoices(content, nil, "", &e.editorData.TemplatePicker)
-	} else {
+	addChoices(e, content, true)
+	if !e.target.Container() {
 		addSwitchedOnCheckBox(content, &e.editorData.SwitchedOn)
 	}
 	addPageRefLabelAndField(content, &e.editorData.PageRef)

--- a/ux/template.go
+++ b/ux/template.go
@@ -794,15 +794,26 @@ func mergeNewlySelectedRows[T gurps.Node[T]](table *unison.Table[*Node[T]], merg
 }
 
 func rawPoints[T gurps.Node[T]](child T) fxp.Int {
-	if xreflect.IsNil(child) || !child.Container() {
+	if xreflect.IsNil(child) {
 		return 0
 	}
-	if pickable, ok := any(child).(gurps.TemplatePickerProvider); ok {
-		tp := pickable.TemplatePickerData()
-		if tp != nil && tp.Type == picker.Points && tp.Qualifier.Compare == criteria.EqualsNumber {
-			return tp.Qualifier.Qualifier
+	if child.Container() {
+		if pickable, ok := any(child).(gurps.TemplatePickerProvider); ok {
+			tp := pickable.TemplatePickerData()
+			if tp != nil && tp.Type == picker.Points && tp.Qualifier.Compare == criteria.EqualsNumber {
+				return tp.Qualifier.Qualifier
+			}
 		}
 	}
+	// Covers skills and spells
+	if rp, ok := any(child).(interface{ RawPoints() fxp.Int }); ok {
+		return rp.RawPoints()
+	}
+	// Covers traits
+	if rp, ok := any(child).(interface{ AdjustedPoints() fxp.Int }); ok {
+		return rp.AdjustedPoints()
+	}
+	// Fallback
 	return 0
 }
 

--- a/ux/template.go
+++ b/ux/template.go
@@ -793,29 +793,17 @@ func mergeNewlySelectedRows[T gurps.Node[T]](table *unison.Table[*Node[T]], merg
 	rebuildAsModified(table.AncestorOrSelf[Rebuildable](), true)
 }
 
-func rawPoints(child any) fxp.Int {
-	switch nc := child.(type) {
-	case *gurps.Skill:
-		if nc.Container() && nc.TemplatePicker != nil && nc.TemplatePicker.Type == picker.Points &&
-			nc.TemplatePicker.Qualifier.Compare == criteria.EqualsNumber {
-			return nc.TemplatePicker.Qualifier.Qualifier
-		}
-		return nc.RawPoints()
-	case *gurps.Spell:
-		if nc.Container() && nc.TemplatePicker != nil && nc.TemplatePicker.Type == picker.Points &&
-			nc.TemplatePicker.Qualifier.Compare == criteria.EqualsNumber {
-			return nc.TemplatePicker.Qualifier.Qualifier
-		}
-		return nc.RawPoints()
-	case *gurps.Trait:
-		if nc.Container() && nc.TemplatePicker != nil && nc.TemplatePicker.Type == picker.Points &&
-			nc.TemplatePicker.Qualifier.Compare == criteria.EqualsNumber {
-			return nc.TemplatePicker.Qualifier.Qualifier
-		}
-		return nc.AdjustedPoints()
-	default:
+func rawPoints[T gurps.Node[T]](child T) fxp.Int {
+	if xreflect.IsNil(child) || !child.Container() {
 		return 0
 	}
+	if pickable, ok := any(child).(gurps.TemplatePickerProvider); ok {
+		tp := pickable.TemplatePickerData()
+		if tp != nil && tp.Type == picker.Points && tp.Qualifier.Compare == criteria.EqualsNumber {
+			return tp.Qualifier.Qualifier
+		}
+	}
+	return 0
 }
 
 // installNewItemCmdHandlers installs the handlers for the "New ..." commands that add an item to one of the template's

--- a/ux/trait_editor.go
+++ b/ux/trait_editor.go
@@ -123,8 +123,8 @@ func initTraitEditor(e *editor[*gurps.Trait, *gurps.TraitEditData], content *uni
 		}
 		ancestryPopup = addLabelAndPopup(content, i18n.Text("Ancestry"), "", choices, &e.editorData.Ancestry)
 		adjustPopupBlank(ancestryPopup, e.editorData.ContainerType != container.Ancestry)
-		addTemplateChoices(content, nil, "", &e.editorData.TemplatePicker)
 	}
+	addChoices(e, content, true)
 	addPageRefLabelAndField(content, &e.editorData.PageRef)
 	addPageRefHighlightLabelAndField(content, &e.editorData.PageRefHighlight)
 	addSourceFields(content, &e.target.SourcedID)

--- a/ux/widgets.go
+++ b/ux/widgets.go
@@ -43,7 +43,7 @@ type Owned interface {
 // FindOwner follow the lineage of a panel up locate a parent that satisfies `Owned`
 func FindOwner[T Rebuildable](panel *unison.Panel) T {
 	for panel != nil {
-		if owned, ok := any(panel.Self).(Owned); ok {
+		if owned, ok := any(panel.Self).(Owned); ok && !xreflect.IsNil(owned) && !xreflect.IsNil(owned.Owner()) {
 			if owner, ok2 := owned.Owner().AsPanel().Self.(T); ok2 {
 				return owner
 			}

--- a/ux/widgets.go
+++ b/ux/widgets.go
@@ -44,7 +44,7 @@ type Owned interface {
 func FindOwner[T Rebuildable](panel *unison.Panel) T {
 	for panel != nil {
 		if owned, ok := any(panel.Self).(Owned); ok {
-			if owner, ok := owned.Owner().AsPanel().Self.(T); ok {
+			if owner, ok2 := owned.Owner().AsPanel().Self.(T); ok2 {
 				return owner
 			}
 			panel = owned.Owner().AsPanel()

--- a/ux/widgets.go
+++ b/ux/widgets.go
@@ -60,6 +60,22 @@ func HasOwner[T Rebuildable](panel *unison.Panel) bool {
 	return !xreflect.IsNil(FindOwner[T](panel))
 }
 
+// Targeted defines the methods a value with a node target should have
+type Targeted[N gurps.Node[N]] interface {
+	Target() N
+}
+
+func FindTarget[T gurps.Node[T]](panel *unison.Panel) T {
+	for panel != nil {
+		if targeted, ok := any(panel.Self).(Targeted[T]); ok {
+			return targeted.Target()
+		}
+		panel = panel.Parent()
+	}
+	var zero T
+	return zero
+}
+
 // Syncer should be called to sync an object's UI state to its model.
 type Syncer interface {
 	Sync()

--- a/ux/widgets.go
+++ b/ux/widgets.go
@@ -40,6 +40,7 @@ type Owned interface {
 	Owner() Rebuildable
 }
 
+// FindOwner follow the lineage of a panel up locate a parent that satisfies `Owned`
 func FindOwner[T Rebuildable](panel *unison.Panel) T {
 	for panel != nil {
 		if owned, ok := any(panel.Self).(Owned); ok {
@@ -55,6 +56,7 @@ func FindOwner[T Rebuildable](panel *unison.Panel) T {
 	return zero
 }
 
+// HasOwner follow the lineage of a panel up to determine if parent satisfies `Owned`
 func HasOwner[T Rebuildable](panel *unison.Panel) bool {
 	return !xreflect.IsNil(FindOwner[T](panel))
 }
@@ -64,6 +66,7 @@ type Targeted[N gurps.Node[N]] interface {
 	Target() N
 }
 
+// FindTarget follow the lineage of a panel up locate a parent that satisfies `Targeted`
 func FindTarget[T gurps.Node[T]](panel *unison.Panel) T {
 	for panel != nil {
 		if targeted, ok := any(panel.Self).(Targeted[T]); ok {

--- a/ux/widgets.go
+++ b/ux/widgets.go
@@ -17,7 +17,6 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/fxp"
 	"github.com/richardwilkes/gcs/v5/model/gurps"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/difficulty"
-	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
 	"github.com/richardwilkes/gcs/v5/svg"
 	"github.com/richardwilkes/toolbox/v2/geom"
 	"github.com/richardwilkes/toolbox/v2/i18n"
@@ -758,46 +757,6 @@ func addLeveledAmountPanel(parent *unison.Panel, targetMgr *TargetMgr, targetKey
 	parent.AddChild(field)
 	checkBox = addCheckBox(parent, title, &amount.PerLevel)
 	return field, checkBox
-}
-
-func addTemplateChoices(parent *unison.Panel, targetmgr *TargetMgr, targetKey string, tp **gurps.TemplatePicker) (typePopup *unison.PopupMenu[picker.Type], comparisonPopup *unison.PopupMenu[string], field unison.Paneler) {
-	if !HasOwner[*Template](parent) {
-		return
-	}
-	if *tp == nil {
-		*tp = &gurps.TemplatePicker{}
-	}
-	last := (*tp).Type
-	wrapper := addFlowWrapper(parent, i18n.Text("Choices"), 3)
-	typePopup = addPopup(wrapper, picker.Types, &(*tp).Type)
-	text := i18n.Text("Choice Quantifier")
-	comparisonPopup, field = addNumericCriteriaPanel(wrapper, targetmgr, targetKey, "", text, &(*tp).Qualifier, fxp.Min,
-		fxp.Max, 1, false, false)
-	// A picker that isn't in use has nothing to quantify, so both the comparison and the qualifier are blanked out. The
-	// qualifier is blanked as well whenever the comparison doesn't use one. The opening state must be settled the same
-	// way the selection callback settles it, or an untouched editor lets the user alter a picker that will be dropped
-	// on save, or refuses edits to one that will be kept.
-	adjust := func(pickerType picker.Type) {
-		notApplicable := pickerType == picker.NotApplicable
-		adjustPopupBlank(comparisonPopup, notApplicable)
-		adjustFieldBlank(field, notApplicable || (*tp).Qualifier.Compare == criteria.AnyNumber)
-	}
-	typePopup.SelectionChangedCallback = func(p *unison.PopupMenu[picker.Type]) {
-		if item, ok := p.Selected(); ok {
-			(*tp).Type = item
-			if last == picker.NotApplicable && item != picker.NotApplicable {
-				(*tp).Qualifier.Qualifier = fxp.One
-				if syncer, ok2 := field.(Syncer); ok2 {
-					syncer.Sync()
-				}
-			}
-			last = item
-			adjust(item)
-			MarkModified(parent)
-		}
-	}
-	adjust((*tp).Type)
-	return typePopup, comparisonPopup, field
 }
 
 func addScriptField(parent *unison.Panel, targetMgr *TargetMgr, targetKey, undoTitle, tooltip string, get func() string, set func(string), includeMarkdownButton bool) *StringField {

--- a/ux/widgets.go
+++ b/ux/widgets.go
@@ -36,6 +36,30 @@ type Rebuildable interface {
 	Rebuild(full bool)
 }
 
+// Owned defines the methods a value owned by a Rebuildable should have
+type Owned interface {
+	Owner() Rebuildable
+}
+
+func FindOwner[T Rebuildable](panel *unison.Panel) T {
+	for panel != nil {
+		if owned, ok := any(panel.Self).(Owned); ok {
+			if owner, ok := owned.Owner().AsPanel().Self.(T); ok {
+				return owner
+			}
+			panel = owned.Owner().AsPanel()
+		} else {
+			panel = panel.Parent()
+		}
+	}
+	var zero T
+	return zero
+}
+
+func HasOwner[T Rebuildable](panel *unison.Panel) bool {
+	return !xreflect.IsNil(FindOwner[T](panel))
+}
+
 // Syncer should be called to sync an object's UI state to its model.
 type Syncer interface {
 	Sync()

--- a/ux/widgets.go
+++ b/ux/widgets.go
@@ -745,13 +745,16 @@ func addLeveledAmountPanel(parent *unison.Panel, targetMgr *TargetMgr, targetKey
 }
 
 func addTemplateChoices(parent *unison.Panel, targetmgr *TargetMgr, targetKey string, tp **gurps.TemplatePicker) (typePopup *unison.PopupMenu[picker.Type], comparisonPopup *unison.PopupMenu[string], field unison.Paneler) {
+	if !HasOwner[*Template](parent) {
+		return
+	}
 	if *tp == nil {
 		*tp = &gurps.TemplatePicker{}
 	}
 	last := (*tp).Type
-	wrapper := addFlowWrapper(parent, i18n.Text("Template Choices"), 3)
+	wrapper := addFlowWrapper(parent, i18n.Text("Choices"), 3)
 	typePopup = addPopup(wrapper, picker.Types, &(*tp).Type)
-	text := i18n.Text("Template Choice Quantifier")
+	text := i18n.Text("Choice Quantifier")
 	comparisonPopup, field = addNumericCriteriaPanel(wrapper, targetmgr, targetKey, "", text, &(*tp).Qualifier, fxp.Min,
 		fxp.Max, 1, false, false)
 	// A picker that isn't in use has nothing to quantify, so both the comparison and the qualifier are blanked out. The

--- a/ux/widgets_test.go
+++ b/ux/widgets_test.go
@@ -14,12 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/richardwilkes/gcs/v5/model/criteria"
-	"github.com/richardwilkes/gcs/v5/model/fxp"
-	"github.com/richardwilkes/gcs/v5/model/gurps"
-	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
 	"github.com/richardwilkes/toolbox/v2/check"
-	"github.com/richardwilkes/unison"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 )
@@ -72,57 +67,4 @@ func TestMarkdownHardLineBreaksPreservesParagraphs(t *testing.T) {
 	rendered := renderTooltipMarkdown(c, markdownHardLineBreaks("first\n\nsecond"))
 	c.Equal(2, strings.Count(rendered, "<p>"), "paragraph break should be preserved as two paragraphs")
 	c.Equal(0, strings.Count(rendered, "<br>"), "a lone paragraph break should not introduce a hard line break")
-}
-
-// newTemplateChoices builds the "Template Choices" row an item editor shows for a template picker, returning the two
-// popups and the qualifier field it is made of.
-func newTemplateChoices(pickerType picker.Type, compare criteria.NumericComparison) (typePopup *unison.PopupMenu[picker.Type], comparisonPopup *unison.PopupMenu[string], field unison.Paneler) {
-	trait := gurps.NewTrait(nil, nil, true)
-	trait.TemplatePicker.Type = pickerType
-	trait.TemplatePicker.Qualifier.Compare = compare
-	trait.TemplatePicker.Qualifier.Qualifier = fxp.One
-	return addChoices(&editor[*gurps.Trait, *gurps.TraitData]{target: trait}, unison.NewPanel(), false)
-}
-
-// TestTemplateChoicesOpeningState verifies that a freshly opened editor blanks the template picker's comparison popup
-// and qualifier field under exactly the conditions its own selection callback uses. A picker set to Not Applicable is
-// zero, so anything entered for it is dropped when the item is saved; leaving the comparison popup live let the user
-// make a selection that set the comparison, un-blanked the qualifier and marked the item modified, all for edits that
-// could never be kept. In the other direction, a saved picker whose comparison takes no qualifier opened with the
-// qualifier editable, even though every later pass through the callback blanks it.
-func TestTemplateChoicesOpeningState(t *testing.T) {
-	c := check.New(t)
-
-	// The default for every new trait, skill and spell container. Nothing about it can be saved, so nothing about it
-	// may be edited.
-	_, comparison, field := newTemplateChoices(picker.NotApplicable, criteria.AnyNumber)
-	c.False(comparison.Enabled(), "a picker that isn't in use must not offer a comparison")
-	c.False(field.AsPanel().Enabled(), "a picker that isn't in use must not offer a qualifier")
-
-	// In use, but comparing against anything, which needs no number to compare with.
-	_, comparison, field = newTemplateChoices(picker.Count, criteria.AnyNumber)
-	c.True(comparison.Enabled(), "a picker in use must offer a comparison")
-	c.False(field.AsPanel().Enabled(), "a comparison that takes no qualifier must not offer one")
-
-	// In use with a comparison that needs a number, so everything is editable.
-	_, comparison, field = newTemplateChoices(picker.Points, criteria.AtLeastNumber)
-	c.True(comparison.Enabled(), "a picker in use must offer a comparison")
-	c.True(field.AsPanel().Enabled(), "a comparison that takes a qualifier must offer one")
-}
-
-// TestTemplateChoicesFollowTheTypeSelection verifies that choosing a template picker type updates the comparison popup
-// and qualifier field, and that returning to Not Applicable blanks them both again.
-func TestTemplateChoicesFollowTheTypeSelection(t *testing.T) {
-	c := check.New(t)
-	typePopup, comparison, field := newTemplateChoices(picker.NotApplicable, criteria.EqualsNumber)
-	c.False(comparison.Enabled(), "a picker that isn't in use must not offer a comparison")
-	c.False(field.AsPanel().Enabled(), "a picker that isn't in use must not offer a qualifier")
-
-	typePopup.Select(picker.Count)
-	c.True(comparison.Enabled(), "putting the picker to use must offer a comparison")
-	c.True(field.AsPanel().Enabled(), "putting the picker to use must offer a qualifier")
-
-	typePopup.Select(picker.NotApplicable)
-	c.False(comparison.Enabled(), "taking the picker out of use must withdraw the comparison")
-	c.False(field.AsPanel().Enabled(), "taking the picker out of use must withdraw the qualifier")
 }

--- a/ux/widgets_test.go
+++ b/ux/widgets_test.go
@@ -77,10 +77,11 @@ func TestMarkdownHardLineBreaksPreservesParagraphs(t *testing.T) {
 // newTemplateChoices builds the "Template Choices" row an item editor shows for a template picker, returning the two
 // popups and the qualifier field it is made of.
 func newTemplateChoices(pickerType picker.Type, compare criteria.NumericComparison) (typePopup *unison.PopupMenu[picker.Type], comparisonPopup *unison.PopupMenu[string], field unison.Paneler) {
-	tp := &gurps.TemplatePicker{Type: pickerType}
-	tp.Qualifier.Compare = compare
-	tp.Qualifier.Qualifier = fxp.One
-	return addTemplateChoices(unison.NewPanel(), nil, "", &tp)
+	trait := gurps.NewTrait(nil, nil, true)
+	trait.TemplatePicker.Type = pickerType
+	trait.TemplatePicker.Qualifier.Compare = compare
+	trait.TemplatePicker.Qualifier.Qualifier = fxp.One
+	return addChoices(&editor[*gurps.Trait, *gurps.TraitData]{target: trait}, unison.NewPanel(), false)
 }
 
 // TestTemplateChoicesOpeningState verifies that a freshly opened editor blanks the template picker's comparison popup


### PR DESCRIPTION
- Adjust when an editor calls `initContent` to ensure the passed content panel has a full lineage
- Add code to help locate a panel "owner"
- Add code to help locate a panel "target"
- Refactor how template choices are added to an editor for future expansion
- Refactor the `rawPoints` helpers to better leverage interfaces and drop concrete type refs