### PR TITLE
Template Choices config not saving

### DIFF
--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -384,7 +384,7 @@ func (s *Skill) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 }
 
 // TemplatePickerData returns the TemplatePicker data, if any.
-func (s *Skill) TemplatePickerData() *TemplatePicker {
+func (s *SkillContainerOnlySyncData) TemplatePickerData() *TemplatePicker {
 	return s.TemplatePicker
 }
 

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -385,7 +385,7 @@ func (s *Spell) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 }
 
 // TemplatePickerData returns the TemplatePicker data, if any.
-func (s *Spell) TemplatePickerData() *TemplatePicker {
+func (s *SpellContainerOnlySyncData) TemplatePickerData() *TemplatePicker {
 	return s.TemplatePicker
 }
 

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -97,7 +97,7 @@ type SpellEditData struct {
 	ItemSwitch
 	preconfigurable
 	SpellNonContainerOnlyEditData
-	SkillContainerOnlySyncData
+	SpellContainerOnlySyncData
 }
 
 // SpellNonContainerOnlyEditData holds the Spell data that is only applicable to spells that aren't containers.
@@ -107,6 +107,11 @@ type SpellNonContainerOnlyEditData struct {
 	Points           fxp.Int     `json:"points,omitzero"`
 	Study            []*Study    `json:"study,omitzero"`
 	StudyHoursNeeded study.Level `json:"study_hours_needed,omitzero"`
+}
+
+// SpellContainerOnlySyncData holds the spell sync data that is only applicable to spells that are containers.
+type SpellContainerOnlySyncData struct {
+	TemplatePicker *TemplatePicker `json:"template_picker,omitzero"`
 }
 
 // SpellSyncData holds the spell sync data that is common to both containers and non-containers.
@@ -1196,7 +1201,7 @@ func (s *Spell) ClearUnusedFieldsForType() {
 			s.TemplatePicker = &TemplatePicker{}
 		}
 	} else {
-		s.SkillContainerOnlySyncData = SkillContainerOnlySyncData{}
+		s.SpellContainerOnlySyncData = SpellContainerOnlySyncData{}
 		s.Children = nil
 		s.Difficulty.omit = false
 	}
@@ -1220,7 +1225,7 @@ func (s *Spell) SyncWithSource() {
 				s.SpellSyncData = other.SpellSyncData
 				s.Tags = slices.Clone(other.Tags)
 				if s.Container() {
-					s.SkillContainerOnlySyncData = other.SkillContainerOnlySyncData
+					s.SpellContainerOnlySyncData = other.SpellContainerOnlySyncData
 					s.TemplatePicker = other.TemplatePicker.Clone()
 				} else {
 					s.SpellNonContainerOnlySyncData = other.SpellNonContainerOnlySyncData
@@ -1239,7 +1244,7 @@ func (s *Spell) SyncWithSource() {
 func (s *Spell) Hash(h hash.Hash) {
 	s.SpellSyncData.hash(h)
 	if s.Container() {
-		s.SkillContainerOnlySyncData.hash(h)
+		s.SpellContainerOnlySyncData.hash(h)
 	} else {
 		s.SpellNonContainerOnlySyncData.hash(h)
 	}
@@ -1254,6 +1259,10 @@ func (s *SpellSyncData) hash(h hash.Hash) {
 	for _, tag := range s.Tags {
 		xhash.StringWithLen(h, tag)
 	}
+}
+
+func (s *SpellContainerOnlySyncData) hash(h hash.Hash) {
+	s.TemplatePicker.Hash(h)
 }
 
 func (s *SpellNonContainerOnlySyncData) hash(h hash.Hash) {

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -357,7 +357,7 @@ func (t *Trait) EffectivelyDisabled() bool {
 }
 
 // TemplatePickerData returns the TemplatePicker data, if any.
-func (t *Trait) TemplatePickerData() *TemplatePicker {
+func (t *TraitContainerSyncData) TemplatePickerData() *TemplatePicker {
 	return t.TemplatePicker
 }
 

--- a/ux/choices.go
+++ b/ux/choices.go
@@ -33,7 +33,7 @@ func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent 
 	}
 
 	var tp *gurps.TemplatePicker
-	if pickable, ok := any(e.target).(gurps.TemplatePickerProvider); ok {
+	if pickable, ok := any(e.editorData).(gurps.TemplatePickerProvider); ok {
 		tp = pickable.TemplatePickerData()
 	} else {
 		return typePopup, comparisonPopup, field

--- a/ux/choices_test.go
+++ b/ux/choices_test.go
@@ -27,7 +27,9 @@ func newChoices(pickerType picker.Type, compare criteria.NumericComparison) (typ
 	trait.TemplatePicker.Type = pickerType
 	trait.TemplatePicker.Qualifier.Compare = compare
 	trait.TemplatePicker.Qualifier.Qualifier = fxp.One
-	return addChoices(&editor[*gurps.Trait, *gurps.TraitData]{target: trait}, unison.NewPanel(), false)
+	e := &editor[*gurps.Trait, *gurps.TraitEditData]{target: trait, editorData: &gurps.TraitEditData{}}
+	e.editorData.CopyFrom(trait)
+	return addChoices(e, unison.NewPanel(), false)
 }
 
 // TestChoicesOpeningState verifies that a freshly opened editor blanks the picker's comparison popup
@@ -57,7 +59,10 @@ func TestChoicesOpeningState(t *testing.T) {
 }
 
 // TestChoicesFollowTheTypeSelection verifies that choosing a picker type updates the comparison popup
-// and qualifier field, and that returning to Not Applicable blanks them both again.
+// and qualifier field, and that returning to Not Applicable blanks them both again. A Not Applicable
+// picker's qualifier data is meaningless and is normalized away (see TemplatePicker.Clone) as soon as the
+// editor stages the data, so putting a fresh picker to use starts with the comparison blank until one is
+// chosen, rather than resurrecting whatever was set before it went out of use.
 func TestChoicesFollowTheTypeSelection(t *testing.T) {
 	c := check.New(t)
 	typePopup, comparison, field := newChoices(picker.NotApplicable, criteria.EqualsNumber)
@@ -66,7 +71,10 @@ func TestChoicesFollowTheTypeSelection(t *testing.T) {
 
 	typePopup.Select(picker.Count)
 	c.True(comparison.Enabled(), "putting the picker to use must offer a comparison")
-	c.True(field.AsPanel().Enabled(), "putting the picker to use must offer a qualifier")
+	c.False(field.AsPanel().Enabled(), "a freshly enabled picker has no comparison yet, so no qualifier to offer")
+
+	comparison.SelectIndex(criteria.ExtractNumericComparisonIndex(string(criteria.EqualsNumber)))
+	c.True(field.AsPanel().Enabled(), "choosing a comparison that takes a qualifier must offer one")
 
 	typePopup.Select(picker.NotApplicable)
 	c.False(comparison.Enabled(), "taking the picker out of use must withdraw the comparison")


### PR DESCRIPTION
When editing a container, changing the template choices config wouldn't mark the record as change and the changes would not save as expected.

The issue was a simple mistaken use of `e.target` vs `e.editorData`.

During this exploration I also discovered that the spell container sync data was using the one from skills. While they are identical, this was prone to future issues.

I also switched to an embedded templatePicker implementation that's now shared by Traits, Skills, and Spells.