### PR TITLE
Switch from omitzero to omitempty for maps and slices

### DIFF
--- a/model/gurps/ancestry.go
+++ b/model/gurps/ancestry.go
@@ -27,7 +27,7 @@ const DefaultAncestry = "Human"
 type Ancestry struct {
 	Name          string                     `json:"name,omitzero"`
 	CommonOptions *AncestryOptions           `json:"common_options,omitzero"`
-	GenderOptions []*WeightedAncestryOptions `json:"gender_options,omitzero"`
+	GenderOptions []*WeightedAncestryOptions `json:"gender_options,omitempty"`
 }
 
 type ancestryData struct {

--- a/model/gurps/ancestry_options.go
+++ b/model/gurps/ancestry_options.go
@@ -40,11 +40,11 @@ type AncestryOptionsData struct {
 	HeightScript      string                  `json:"height_script,omitzero"`
 	WeightScript      string                  `json:"weight_script,omitzero"`
 	AgeScript         string                  `json:"age_script,omitzero"`
-	HairOptions       []*WeightedStringOption `json:"hair_options,omitzero"`
-	EyeOptions        []*WeightedStringOption `json:"eye_options,omitzero"`
-	SkinOptions       []*WeightedStringOption `json:"skin_options,omitzero"`
-	HandednessOptions []*WeightedStringOption `json:"handedness_options,omitzero"`
-	NameGenerators    []string                `json:"name_generators,omitzero"`
+	HairOptions       []*WeightedStringOption `json:"hair_options,omitempty"`
+	EyeOptions        []*WeightedStringOption `json:"eye_options,omitempty"`
+	SkinOptions       []*WeightedStringOption `json:"skin_options,omitempty"`
+	HandednessOptions []*WeightedStringOption `json:"handedness_options,omitempty"`
+	NameGenerators    []string                `json:"name_generators,omitempty"`
 }
 
 // MarshalJSONTo implements json.MarshalerTo.

--- a/model/gurps/attribute_def.go
+++ b/model/gurps/attribute_def.go
@@ -54,7 +54,7 @@ type AttributeDefData struct {
 	Base                 string              `json:"base,omitzero"`
 	CostPerPoint         fxp.Int             `json:"cost_per_point,omitzero"`
 	CostAdjPercentPerSM  fxp.Int             `json:"cost_adj_percent_per_sm,omitzero"`
-	Thresholds           []*PoolThreshold    `json:"thresholds,omitzero"`
+	Thresholds           []*PoolThreshold    `json:"thresholds,omitempty"`
 }
 
 // MarshalJSONTo implements json.MarshalerTo.

--- a/model/gurps/body.go
+++ b/model/gurps/body.go
@@ -36,7 +36,7 @@ var embeddedFS embed.FS
 type BodyData struct {
 	Name      string         `json:"name,omitzero"`
 	Roll      dice.Dice      `json:"roll"`
-	Locations []*HitLocation `json:"locations,omitzero"`
+	Locations []*HitLocation `json:"locations,omitempty"`
 }
 
 // Body holds a set of hit locations.

--- a/model/gurps/campaign.go
+++ b/model/gurps/campaign.go
@@ -31,14 +31,14 @@ type CampaignData struct {
 	Version       int            `json:"version"`
 	ID            tid.TID        `json:"id"`
 	SheetSettings *SheetSettings `json:"settings,omitzero"`
-	Traits        []*Trait       `json:"traits,omitzero"`
-	Skills        []*Skill       `json:"skills,omitzero"`
-	Spells        []*Spell       `json:"spells,omitzero"`
-	Equipment     []*Equipment   `json:"equipment,omitzero"`
-	Notes         []*Note        `json:"notes,omitzero"`
-	Templates     []*Template    `json:"templates,omitzero"`
-	Characters    []*Entity      `json:"characters,omitzero"`
-	Documents     []*Document    `json:"documents,omitzero"`
+	Traits        []*Trait       `json:"traits,omitempty"`
+	Skills        []*Skill       `json:"skills,omitempty"`
+	Spells        []*Spell       `json:"spells,omitempty"`
+	Equipment     []*Equipment   `json:"equipment,omitempty"`
+	Notes         []*Note        `json:"notes,omitempty"`
+	Templates     []*Template    `json:"templates,omitempty"`
+	Characters    []*Entity      `json:"characters,omitempty"`
+	Documents     []*Document    `json:"documents,omitempty"`
 }
 
 // NewCampaignFromFile loads a Campaign from a file.

--- a/model/gurps/dr_bonus.go
+++ b/model/gurps/dr_bonus.go
@@ -30,7 +30,7 @@ var _ Bonus = &DRBonus{}
 type DRBonusData struct {
 	Type feature.Type `json:"type"`
 	FeatureSwitch
-	Locations      []string `json:"locations,omitzero"`
+	Locations      []string `json:"locations,omitempty"`
 	Specialization string   `json:"specialization,omitzero"`
 	LeveledAmount
 }

--- a/model/gurps/entity.go
+++ b/model/gurps/entity.go
@@ -75,19 +75,19 @@ type EntityData struct {
 	Version          int             `json:"version"`
 	ID               tid.TID         `json:"id"`
 	TotalPoints      fxp.Int         `json:"total_points"`
-	PointsRecord     []*PointsRecord `json:"points_record,omitzero"`
+	PointsRecord     []*PointsRecord `json:"points_record,omitempty"`
 	Profile          Profile         `json:"profile"`
 	SheetSettings    *SheetSettings  `json:"settings,omitzero"`
 	Attributes       *Attributes     `json:"attributes,omitzero"`
-	Traits           []*Trait        `json:"traits,omitzero"`
-	Skills           []*Skill        `json:"skills,omitzero"`
-	Spells           []*Spell        `json:"spells,omitzero"`
-	CarriedEquipment []*Equipment    `json:"equipment,omitzero"`
-	OtherEquipment   []*Equipment    `json:"other_equipment,omitzero"`
-	Notes            []*Note         `json:"notes,omitzero"`
+	Traits           []*Trait        `json:"traits,omitempty"`
+	Skills           []*Skill        `json:"skills,omitempty"`
+	Spells           []*Spell        `json:"spells,omitempty"`
+	CarriedEquipment []*Equipment    `json:"equipment,omitempty"`
+	OtherEquipment   []*Equipment    `json:"other_equipment,omitempty"`
+	Notes            []*Note         `json:"notes,omitempty"`
 	CreatedOn        jio.Time        `json:"created_date"`
 	ModifiedOn       jio.Time        `json:"modified_date"`
-	ThirdParty       map[string]any  `json:"third_party,omitzero"`
+	ThirdParty       map[string]any  `json:"third_party,omitempty"`
 }
 
 type features struct {

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -81,8 +81,8 @@ type Equipment struct {
 type EquipmentData struct {
 	SourcedID
 	EquipmentEditData
-	ThirdParty map[string]any `json:"third_party,omitzero"`
-	Children   []*Equipment   `json:"children,omitzero"` // Only for containers
+	ThirdParty map[string]any `json:"third_party,omitempty"`
+	Children   []*Equipment   `json:"children,omitempty"` // Only for containers
 	parent     *Equipment
 }
 
@@ -90,8 +90,8 @@ type EquipmentData struct {
 type EquipmentEditData struct {
 	EquipmentSyncData
 	VTTNotes     string               `json:"vtt_notes,omitzero"`
-	Replacements map[string]string    `json:"replacements,omitzero"`
-	Modifiers    []*EquipmentModifier `json:"modifiers,omitzero"`
+	Replacements map[string]string    `json:"replacements,omitempty"`
+	Modifiers    []*EquipmentModifier `json:"modifiers,omitempty"`
 	RatedST      fxp.Int              `json:"rated_strength,omitzero"`
 	Quantity     fxp.Int              `json:"quantity"`
 	Level        fxp.Int              `json:"level,omitzero"`
@@ -109,13 +109,13 @@ type EquipmentSyncData struct {
 	LocalNotes             string      `json:"local_notes,omitzero"`
 	TechLevel              string      `json:"tech_level,omitzero"`
 	LegalityClass          string      `json:"legality_class,omitzero"`
-	Tags                   []string    `json:"tags,omitzero"`
+	Tags                   []string    `json:"tags,omitempty"`
 	BaseValue              string      `json:"base_value,omitzero"`
 	BaseWeight             string      `json:"base_weight,omitzero"`
 	MaxUses                int         `json:"max_uses,omitzero"`
 	Prereq                 *PrereqList `json:"prereqs,omitzero"`
-	Weapons                []*Weapon   `json:"weapons,omitzero"`
-	Features               Features    `json:"features,omitzero"`
+	Weapons                []*Weapon   `json:"weapons,omitempty"`
+	Features               Features    `json:"features,omitempty"`
 	WeightIgnoredForSkills bool        `json:"ignore_weight_for_skills,omitzero"`
 }
 

--- a/model/gurps/equipment_modifier.go
+++ b/model/gurps/equipment_modifier.go
@@ -65,8 +65,8 @@ type EquipmentModifier struct {
 type EquipmentModifierData struct {
 	SourcedID
 	EquipmentModifierEditData
-	ThirdParty map[string]any       `json:"third_party,omitzero"`
-	Children   []*EquipmentModifier `json:"children,omitzero"` // Only for containers
+	ThirdParty map[string]any       `json:"third_party,omitempty"`
+	Children   []*EquipmentModifier `json:"children,omitempty"` // Only for containers
 	parent     *EquipmentModifier
 }
 
@@ -74,7 +74,7 @@ type EquipmentModifierData struct {
 type EquipmentModifierEditData struct {
 	EquipmentModifierSyncData
 	VTTNotes     string            `json:"vtt_notes,omitzero"`
-	Replacements map[string]string `json:"replacements,omitzero"` // Not actually used any longer, but kept so that we can migrate old data
+	Replacements map[string]string `json:"replacements,omitempty"` // Not actually used any longer, but kept so that we can migrate old data
 	EquipmentModifierEditDataNonContainerOnly
 }
 
@@ -91,7 +91,7 @@ type EquipmentModifierSyncData struct {
 	PageRef          string   `json:"reference,omitzero"`
 	PageRefHighlight string   `json:"reference_highlight,omitzero"`
 	LocalNotes       string   `json:"local_notes,omitzero"`
-	Tags             []string `json:"tags,omitzero"`
+	Tags             []string `json:"tags,omitempty"`
 }
 
 // EquipmentModifierNonContainerSyncData holds the EquipmentModifier sync data that is only applicable to Equipment
@@ -106,7 +106,7 @@ type EquipmentModifierNonContainerSyncData struct {
 	TechLevel         string        `json:"tech_level,omitzero"`
 	CostAmount        string        `json:"cost,omitzero"`
 	WeightAmount      string        `json:"weight,omitzero"`
-	Features          Features      `json:"features,omitzero"`
+	Features          Features      `json:"features,omitempty"`
 }
 
 type equipmentModifierListData struct {

--- a/model/gurps/hit_location.go
+++ b/model/gurps/hit_location.go
@@ -77,7 +77,7 @@ func (h *HitLocation) MarshalJSONTo(enc *jsontext.Encoder) error {
 	}
 	type calc struct {
 		RollRange string         `json:"roll_range"`
-		DR        map[string]int `json:"dr,omitzero"`
+		DR        map[string]int `json:"dr,omitempty"`
 	}
 	data := struct {
 		HitLocationData

--- a/model/gurps/library.go
+++ b/model/gurps/library.go
@@ -94,7 +94,7 @@ type libraryPersistentData struct {
 	Title       string   `json:"title,omitzero"`
 	AccessToken string   `json:"access_token,omitzero"`
 	PathOnDisk  string   `json:"path,omitzero"`
-	Favorites   []string `json:"favorites,omitzero"`
+	Favorites   []string `json:"favorites,omitempty"`
 	UseLatest   bool     `json:"use_latest,omitzero"`
 }
 

--- a/model/gurps/loot.go
+++ b/model/gurps/loot.go
@@ -43,8 +43,8 @@ type LootData struct {
 	Location   string       `json:"location,omitzero"`
 	Session    string       `json:"session,omitzero"`
 	ModifiedOn jio.Time     `json:"modified_date"`
-	Equipment  []*Equipment `json:"equipment,omitzero"`
-	Notes      []*Note      `json:"notes,omitzero"`
+	Equipment  []*Equipment `json:"equipment,omitempty"`
+	Notes      []*Note      `json:"notes,omitempty"`
 }
 
 // NewLootFromFile loads Loot from a file.

--- a/model/gurps/name_generator.go
+++ b/model/gurps/name_generator.go
@@ -34,8 +34,8 @@ type NameGeneratorRef struct {
 // in the order listed here.
 type TrainingData struct {
 	BuiltIn    namegen.Builtin `json:"built_in_training_data,omitzero"`
-	Weighted   map[string]int  `json:"weighted_training_data,omitzero"`
-	Unweighted []string        `json:"training_data,omitzero"`
+	Weighted   map[string]int  `json:"weighted_training_data,omitempty"`
+	Unweighted []string        `json:"training_data,omitempty"`
 }
 
 func (t *TrainingData) data() map[string]int {
@@ -79,7 +79,7 @@ type NameGenerator struct {
 	NoFirstToUpper bool             `json:"no_first_to_upper,omitzero"`
 	Separator      string           `json:"separator,omitzero"` // Only valid for namegen.Compound
 	Depth          int              `json:"depth,omitzero"`     // Only valid for namegen.MarkovLetter
-	Compound       []*NameGenerator `json:"compound,omitzero"`  // Only valid for namegen.Compound
+	Compound       []*NameGenerator `json:"compound,omitempty"` // Only valid for namegen.Compound
 	TrainingData
 	namer names.Namer
 }

--- a/model/gurps/note.go
+++ b/model/gurps/note.go
@@ -54,15 +54,15 @@ type Note struct {
 type NoteData struct {
 	SourcedID
 	NoteEditData
-	ThirdParty map[string]any `json:"third_party,omitzero"`
-	Children   []*Note        `json:"children,omitzero"` // Only for containers
+	ThirdParty map[string]any `json:"third_party,omitempty"`
+	Children   []*Note        `json:"children,omitempty"` // Only for containers
 	parent     *Note
 }
 
 // NoteEditData holds the Note data that can be edited by the UI detail editor.
 type NoteEditData struct {
 	NoteSyncData
-	Replacements map[string]string `json:"replacements,omitzero"`
+	Replacements map[string]string `json:"replacements,omitempty"`
 	preconfigurable
 }
 
@@ -71,7 +71,7 @@ type NoteSyncData struct {
 	MarkDown         string   `json:"markdown,omitzero"`
 	PageRef          string   `json:"reference,omitzero"`
 	PageRefHighlight string   `json:"reference_highlight,omitzero"`
-	Tags             []string `json:"tags,omitzero"`
+	Tags             []string `json:"tags,omitempty"`
 }
 
 type noteListData struct {

--- a/model/gurps/pool_threshold.go
+++ b/model/gurps/pool_threshold.go
@@ -33,7 +33,7 @@ type PoolThresholdData struct {
 	State       string         `json:"state"`
 	Value       string         `json:"value"`
 	Explanation string         `json:"explanation,omitzero"`
-	Ops         []threshold.Op `json:"ops,omitzero"`
+	Ops         []threshold.Op `json:"ops,omitempty"`
 }
 
 // MarshalJSONTo implements json.MarshalerTo.

--- a/model/gurps/prereq_list.go
+++ b/model/gurps/prereq_list.go
@@ -28,7 +28,7 @@ type PrereqList struct {
 	Type    prereq.Type     `json:"type"`
 	All     bool            `json:"all"`
 	WhenTL  criteria.Number `json:"when_tl,omitzero"`
-	Prereqs Prereqs         `json:"prereqs,omitzero"`
+	Prereqs Prereqs         `json:"prereqs,omitempty"`
 }
 
 // NewPrereqList creates a new PrereqList.

--- a/model/gurps/profile.go
+++ b/model/gurps/profile.go
@@ -43,7 +43,7 @@ type Profile struct {
 	Organization        string        `json:"organization,omitzero"`
 	Religion            string        `json:"religion,omitzero"`
 	TechLevel           string        `json:"tech_level,omitzero"`
-	PortraitData        []byte        `json:"portrait,omitzero"`
+	PortraitData        []byte        `json:"portrait,omitempty"`
 	PortraitImage       *unison.Image `json:"-"`
 	SizeModifier        int           `json:"SM,omitzero"`
 	SizeModifierBonus   fxp.Int       `json:"-"`

--- a/model/gurps/settings.go
+++ b/model/gurps/settings.go
@@ -60,7 +60,7 @@ var (
 
 // NavigatorSettings holds settings for the navigator view.
 type NavigatorSettings struct {
-	Nodes map[string]*NavNodeInfo `json:"nodes,omitzero"`
+	Nodes map[string]*NavNodeInfo `json:"nodes,omitempty"`
 }
 
 // NavNodeInfo holds the ID and last used timestamp for a navigator node.
@@ -71,7 +71,7 @@ type NavNodeInfo struct {
 
 // PDFInfo holds IDs and last opened timestamp for a PDF's table of contents.
 type PDFInfo struct {
-	TOC        map[string]map[int]tid.TID `json:"toc,omitzero"`
+	TOC        map[string]map[int]tid.TID `json:"toc,omitempty"`
 	LastOpened int64                      `json:"last"`
 }
 
@@ -79,13 +79,13 @@ type PDFInfo struct {
 type Settings struct {
 	LastSeenGCSVersion string                     `json:"last_seen_gcs_version,omitzero"`
 	General            *GeneralSettings           `json:"general,omitzero"`
-	LibrarySet         Libraries                  `json:"libraries,omitzero"`
+	LibrarySet         Libraries                  `json:"libraries,omitempty"`
 	LibraryExplorer    NavigatorSettings          `json:"library_explorer"`
 	ThemeMode          thememode.Enum             `json:"theme_mode"`
-	RecentFiles        []string                   `json:"recent_files,omitzero"`
-	DeepSearch         []string                   `json:"deep_search,omitzero"`
-	LastDirs           map[string]string          `json:"last_dirs,omitzero"`
-	ColumnSizing       map[string]map[int]float32 `json:"column_sizing,omitzero"`
+	RecentFiles        []string                   `json:"recent_files,omitempty"`
+	DeepSearch         []string                   `json:"deep_search,omitempty"`
+	LastDirs           map[string]string          `json:"last_dirs,omitempty"`
+	ColumnSizing       map[string]map[int]float32 `json:"column_sizing,omitempty"`
 	PageRefs           PageRefs                   `json:"page_refs,omitzero"`
 	KeyBindings        KeyBindings                `json:"key_bindings,omitzero"`
 	WorkspaceFrame     *geom.Rect                 `json:"workspace_frame,omitzero"`
@@ -94,9 +94,9 @@ type Settings struct {
 	Colors             colors.Colors              `json:"theme_colors"`
 	Fonts              fonts.Fonts                `json:"fonts"`
 	Sheet              *SheetSettings             `json:"sheet_settings,omitzero"`
-	OpenInWindow       []dgroup.Group             `json:"open_in_window,omitzero"`
-	Closed             map[string]int64           `json:"closed,omitzero"`
-	PDFs               map[string]*PDFInfo        `json:"pdfs,omitzero"`
+	OpenInWindow       []dgroup.Group             `json:"open_in_window,omitempty"`
+	Closed             map[string]int64           `json:"closed,omitempty"`
+	PDFs               map[string]*PDFInfo        `json:"pdfs,omitempty"`
 	LootGenMinValue    fxp.Int                    `json:"loot_gen_min_value"`
 	LootGenMaxValue    fxp.Int                    `json:"loot_gen_max_value"`
 }

--- a/model/gurps/sheet_layout.go
+++ b/model/gurps/sheet_layout.go
@@ -203,7 +203,7 @@ type SheetLayoutNode struct {
 	Key       string             `json:"key,omitzero"`        // Block only
 	Weight    fxp.Int            `json:"weight,omitzero"`     // Share of the width when the parent is a Row; <= 0 is 1
 	MinHeight paper.Length       `json:"min_height,omitzero"` // Block only; 0 means use the natural height
-	Children  []*SheetLayoutNode `json:"children,omitzero"`   // Row and Column only
+	Children  []*SheetLayoutNode `json:"children,omitempty"`  // Row and Column only
 	// Square is Block only. In a Row, the block's width is taken from the row's height so that its content is square,
 	// instead of from its weight; ignored elsewhere.
 	Square bool `json:"square,omitzero"`
@@ -250,7 +250,7 @@ func (n *SheetLayoutNode) Hash(h hash.Hash) {
 // the blocks it doesn't know about.
 type SheetLayout struct {
 	Root   *SheetLayoutNode `json:"root"`
-	Hidden []string         `json:"hidden,omitzero"`
+	Hidden []string         `json:"hidden,omitempty"`
 }
 
 // blockNode creates a new Block node for the given key.

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -75,8 +75,8 @@ type Skill struct {
 type SkillData struct {
 	SourcedID
 	SkillEditData
-	ThirdParty map[string]any `json:"third_party,omitzero"`
-	Children   []*Skill       `json:"children,omitzero"` // Only for containers
+	ThirdParty map[string]any `json:"third_party,omitempty"`
+	Children   []*Skill       `json:"children,omitempty"` // Only for containers
 	parent     *Skill
 }
 
@@ -84,7 +84,7 @@ type SkillData struct {
 type SkillEditData struct {
 	SkillSyncData
 	VTTNotes     string            `json:"vtt_notes,omitzero"`
-	Replacements map[string]string `json:"replacements,omitzero"`
+	Replacements map[string]string `json:"replacements,omitempty"`
 	ItemSwitch
 	preconfigurable
 	SkillNonContainerOnlyEditData
@@ -98,7 +98,7 @@ type SkillNonContainerOnlyEditData struct {
 	TechLevel              *string       `json:"tech_level,omitzero"`
 	Points                 fxp.Int       `json:"points,omitzero"`
 	DefaultedFrom          *SkillDefault `json:"defaulted_from,omitzero"`
-	Study                  []*Study      `json:"study,omitzero"`
+	Study                  []*Study      `json:"study,omitempty"`
 	StudyHoursNeeded       study.Level   `json:"study_hours_needed,omitzero"`
 }
 
@@ -108,7 +108,7 @@ type SkillSyncData struct {
 	PageRef          string   `json:"reference,omitzero"`
 	PageRefHighlight string   `json:"reference_highlight,omitzero"`
 	LocalNotes       string   `json:"local_notes,omitzero"`
-	Tags             []string `json:"tags,omitzero"`
+	Tags             []string `json:"tags,omitempty"`
 }
 
 // SkillNonContainerOnlySyncData holds the Skill sync data that is only applicable to skills that aren't containers.
@@ -116,12 +116,12 @@ type SkillNonContainerOnlySyncData struct {
 	Specialization               string              `json:"specialization,omitzero"`
 	Difficulty                   AttributeDifficulty `json:"difficulty,omitzero"`
 	EncumbrancePenaltyMultiplier fxp.Int             `json:"encumbrance_penalty_multiplier,omitzero"`
-	Defaults                     []*SkillDefault     `json:"defaults,omitzero"`
+	Defaults                     []*SkillDefault     `json:"defaults,omitempty"`
 	TechniqueDefault             *SkillDefault       `json:"default,omitzero"`
 	TechniqueLimitModifier       *fxp.Int            `json:"limit,omitzero"`
 	Prereq                       *PrereqList         `json:"prereqs,omitzero"`
-	Weapons                      []*Weapon           `json:"weapons,omitzero"`
-	Features                     Features            `json:"features,omitzero"`
+	Weapons                      []*Weapon           `json:"weapons,omitempty"`
+	Features                     Features            `json:"features,omitempty"`
 }
 
 // SkillContainerOnlySyncData holds the skill sync data that is only applicable to skills that are containers.

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -84,8 +84,8 @@ type Spell struct {
 type SpellData struct {
 	SourcedID
 	SpellEditData
-	ThirdParty map[string]any `json:"third_party,omitzero"`
-	Children   []*Spell       `json:"children,omitzero"` // Only for containers
+	ThirdParty map[string]any `json:"third_party,omitempty"`
+	Children   []*Spell       `json:"children,omitempty"` // Only for containers
 	parent     *Spell
 }
 
@@ -93,7 +93,7 @@ type SpellData struct {
 type SpellEditData struct {
 	SpellSyncData
 	VTTNotes     string            `json:"vtt_notes,omitzero"`
-	Replacements map[string]string `json:"replacements,omitzero"`
+	Replacements map[string]string `json:"replacements,omitempty"`
 	ItemSwitch
 	preconfigurable
 	SpellNonContainerOnlyEditData
@@ -105,7 +105,7 @@ type SpellNonContainerOnlyEditData struct {
 	SpellNonContainerOnlySyncData
 	TechLevel        *string     `json:"tech_level,omitzero"`
 	Points           fxp.Int     `json:"points,omitzero"`
-	Study            []*Study    `json:"study,omitzero"`
+	Study            []*Study    `json:"study,omitempty"`
 	StudyHoursNeeded study.Level `json:"study_hours_needed,omitzero"`
 }
 
@@ -120,13 +120,13 @@ type SpellSyncData struct {
 	PageRef          string   `json:"reference,omitzero"`
 	PageRefHighlight string   `json:"reference_highlight,omitzero"`
 	LocalNotes       string   `json:"local_notes,omitzero"`
-	Tags             []string `json:"tags,omitzero"`
+	Tags             []string `json:"tags,omitempty"`
 }
 
 // SpellNonContainerOnlySyncData holds the spell sync data that is only applicable to traits that aren't containers.
 type SpellNonContainerOnlySyncData struct {
 	Difficulty      AttributeDifficulty `json:"difficulty,omitzero"`
-	College         CollegeList         `json:"college,omitzero"`
+	College         CollegeList         `json:"college,omitempty"`
 	PowerSource     string              `json:"power_source,omitzero"`
 	Class           string              `json:"spell_class,omitzero"`
 	Resist          string              `json:"resist,omitzero"`
@@ -138,8 +138,8 @@ type SpellNonContainerOnlySyncData struct {
 	RitualSkillName string              `json:"base_skill,omitzero"`
 	PrereqCount     int                 `json:"prereq_count,omitzero"`
 	Prereq          *PrereqList         `json:"prereqs,omitzero"`
-	Weapons         []*Weapon           `json:"weapons,omitzero"`
-	Features        Features            `json:"features,omitzero"`
+	Weapons         []*Weapon           `json:"weapons,omitempty"`
+	Features        Features            `json:"features,omitempty"`
 }
 
 type spellListData struct {

--- a/model/gurps/template.go
+++ b/model/gurps/template.go
@@ -40,11 +40,11 @@ type Template struct {
 type TemplateData struct {
 	Version   int          `json:"version"`
 	ID        tid.TID      `json:"id"`
-	Traits    []*Trait     `json:"traits,omitzero"`
-	Skills    []*Skill     `json:"skills,omitzero"`
-	Spells    []*Spell     `json:"spells,omitzero"`
-	Equipment []*Equipment `json:"equipment,omitzero"`
-	Notes     []*Note      `json:"notes,omitzero"`
+	Traits    []*Trait     `json:"traits,omitempty"`
+	Skills    []*Skill     `json:"skills,omitempty"`
+	Spells    []*Spell     `json:"spells,omitempty"`
+	Equipment []*Equipment `json:"equipment,omitempty"`
+	Notes     []*Note      `json:"notes,omitempty"`
 	BodyType  *Body        `json:"body_type,omitzero"`
 }
 

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -76,8 +76,8 @@ type Trait struct {
 type TraitData struct {
 	SourcedID
 	TraitEditData
-	ThirdParty map[string]any `json:"third_party,omitzero"`
-	Children   []*Trait       `json:"children,omitzero"` // Only for containers
+	ThirdParty map[string]any `json:"third_party,omitempty"`
+	Children   []*Trait       `json:"children,omitempty"` // Only for containers
 	parent     *Trait
 }
 
@@ -86,8 +86,8 @@ type TraitEditData struct {
 	TraitSyncData
 	VTTNotes     string            `json:"vtt_notes,omitzero"`
 	UserDesc     string            `json:"userdesc,omitzero"`
-	Replacements map[string]string `json:"replacements,omitzero"`
-	Modifiers    []*TraitModifier  `json:"modifiers,omitzero"`
+	Replacements map[string]string `json:"replacements,omitempty"`
+	Modifiers    []*TraitModifier  `json:"modifiers,omitempty"`
 	SelfControl  selfctrl.Roll     `json:"cr,omitzero"`
 	Frequency    frequency.Roll    `json:"frequency,omitzero"`
 	Disabled     bool              `json:"disabled,omitzero"`
@@ -101,7 +101,7 @@ type TraitEditData struct {
 type TraitNonContainerOnlyEditData struct {
 	TraitNonContainerSyncData
 	Levels           fxp.Int     `json:"levels,omitzero"`
-	Study            []*Study    `json:"study,omitzero"`
+	Study            []*Study    `json:"study,omitempty"`
 	StudyHoursNeeded study.Level `json:"study_hours_needed,omitzero"`
 }
 
@@ -111,7 +111,7 @@ type TraitSyncData struct {
 	PageRef          string              `json:"reference,omitzero"`
 	PageRefHighlight string              `json:"reference_highlight,omitzero"`
 	LocalNotes       string              `json:"local_notes,omitzero"`
-	Tags             []string            `json:"tags,omitzero"`
+	Tags             []string            `json:"tags,omitempty"`
 	Prereq           *PrereqList         `json:"prereqs,omitzero"`
 	SelfControlAdj   selfctrl.Adjustment `json:"cr_adj,omitzero"`
 }
@@ -121,8 +121,8 @@ type TraitNonContainerSyncData struct {
 	BasePoints     fxp.Int   `json:"base_points,omitzero"`
 	PointsPerLevel fxp.Int   `json:"points_per_level,omitzero"`
 	MaxLevels      string    `json:"max_levels,omitzero"`
-	Weapons        []*Weapon `json:"weapons,omitzero"`
-	Features       Features  `json:"features,omitzero"`
+	Weapons        []*Weapon `json:"weapons,omitempty"`
+	Features       Features  `json:"features,omitempty"`
 	RoundCostDown  bool      `json:"round_down,omitzero"`
 	CanLevel       bool      `json:"can_level,omitzero"`
 }

--- a/model/gurps/trait_modifier.go
+++ b/model/gurps/trait_modifier.go
@@ -74,8 +74,8 @@ type TraitModifier struct {
 type TraitModifierData struct {
 	SourcedID
 	TraitModifierEditData
-	ThirdParty map[string]any   `json:"third_party,omitzero"`
-	Children   []*TraitModifier `json:"children,omitzero"` // Only for containers
+	ThirdParty map[string]any   `json:"third_party,omitempty"`
+	Children   []*TraitModifier `json:"children,omitempty"` // Only for containers
 	parent     *TraitModifier
 }
 
@@ -83,7 +83,7 @@ type TraitModifierData struct {
 type TraitModifierEditData struct {
 	TraitModifierSyncData
 	VTTNotes     string            `json:"vtt_notes,omitzero"`
-	Replacements map[string]string `json:"replacements,omitzero"` // Not actually used any longer, but kept so that we can migrate old data
+	Replacements map[string]string `json:"replacements,omitempty"` // Not actually used any longer, but kept so that we can migrate old data
 	TraitModifierEditDataNonContainerOnly
 }
 
@@ -101,7 +101,7 @@ type TraitModifierSyncData struct {
 	PageRef          string   `json:"reference,omitzero"`
 	PageRefHighlight string   `json:"reference_highlight,omitzero"`
 	LocalNotes       string   `json:"local_notes,omitzero"`
-	Tags             []string `json:"tags,omitzero"`
+	Tags             []string `json:"tags,omitempty"`
 }
 
 // TraitModifierNonContainerSyncData holds the TraitModifier sync data that is only applicable to TraitModifiers that
@@ -111,7 +111,7 @@ type TraitModifierNonContainerSyncData struct {
 	UseLevelFromTrait bool           `json:"use_level_from_trait,omitzero"`
 	ShowNotesOnWeapon bool           `json:"show_notes_on_weapon,omitzero"`
 	Affects           affects.Option `json:"affects,omitzero"`
-	Features          Features       `json:"features,omitzero"`
+	Features          Features       `json:"features,omitempty"`
 }
 
 type traitModifierListData struct {

--- a/model/gurps/weapon.go
+++ b/model/gurps/weapon.go
@@ -95,7 +95,7 @@ type WeaponData struct {
 	Shots      WeaponShots     `json:"shots,omitzero"`
 	Bulk       WeaponBulk      `json:"bulk,omitzero"`
 	Recoil     WeaponRecoil    `json:"recoil,omitzero"`
-	Defaults   []*SkillDefault `json:"defaults,omitzero"`
+	Defaults   []*SkillDefault `json:"defaults,omitempty"`
 	Hide       bool            `json:"hide,omitzero"`
 }
 


### PR DESCRIPTION
Using `omitzero` will still output an empty slice or map. Switching to `omitempty` cause a slcie/map to omit rendering in JSON when it's nil or empty.