### PR TITLE
Default nameables to 'unset' via a sentinal value

### DIFF
--- a/model/gurps/skill_nameable_test.go
+++ b/model/gurps/skill_nameable_test.go
@@ -12,6 +12,7 @@ package gurps
 import (
 	"testing"
 
+	"github.com/richardwilkes/gcs/v5/model/nameable"
 	"github.com/richardwilkes/toolbox/v2/check"
 )
 
@@ -27,10 +28,10 @@ func TestSkillFillWithNameableKeys(t *testing.T) {
 	m := make(map[string]string)
 	s.FillWithNameableKeys(m, nil)
 	c.Equal(map[string]string{
-		"who":  "who",
-		"spec": "spec",
-		"opt":  "opt",
-		"note": "note",
+		"who":  nameable.Unset,
+		"spec": nameable.Unset,
+		"opt":  nameable.Unset,
+		"note": nameable.Unset,
 	}, m)
 }
 
@@ -44,5 +45,5 @@ func TestSkillOptionalSpecializationOnlyNameableKey(t *testing.T) {
 	s.OptionalSpecialization = "@region@"
 	m := make(map[string]string)
 	s.FillWithNameableKeys(m, nil)
-	c.Equal(map[string]string{"region": "region"}, m)
+	c.Equal(map[string]string{"region": nameable.Unset}, m)
 }

--- a/model/gurps/spell_features_test.go
+++ b/model/gurps/spell_features_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/stlimit"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/wsel"
 	"github.com/richardwilkes/gcs/v5/model/jio"
+	"github.com/richardwilkes/gcs/v5/model/nameable"
 	"github.com/richardwilkes/toolbox/v2/check"
 	"github.com/richardwilkes/toolbox/v2/tid"
 )
@@ -336,8 +337,8 @@ func TestSpellFillWithNameableKeysIncludesFeatures(t *testing.T) {
 	m := make(map[string]string)
 	spell.FillWithNameableKeys(m, nil)
 	c.Equal(map[string]string{
-		"what":  "what",
-		"skill": "skill",
-		"spec":  "spec",
+		"what":  nameable.Unset,
+		"skill": nameable.Unset,
+		"spec":  nameable.Unset,
 	}, m, "the keys from the spell's features are offered along with its own")
 }

--- a/model/nameable/marker.go
+++ b/model/nameable/marker.go
@@ -197,22 +197,6 @@ func (m *Marker) Key() string {
 	return sb.String()
 }
 
-// DefaultValue returns the default value for this marker when no replacement is provided.
-func (m *Marker) DefaultValue() string {
-	if m.Legacy {
-		// Legacy markers default to their own raw text for backward compatibility.
-		return m.Raw
-	}
-	if !m.AllowEmpty && len(m.Options) > 0 {
-		return m.Options[0]
-	}
-	if len(m.Options) == 0 && m.FreeForm && m.AllowEmpty && m.Tooltip == "" {
-		// A simple marker has no default and simply returns the label, retaining previous behavior.
-		return m.Label
-	}
-	return ""
-}
-
 func unique[S ~[]T, T comparable](in S) S {
 	seen := make(map[T]struct{}, len(in))
 	out := make(S, 0, len(in))

--- a/model/nameable/marker_test.go
+++ b/model/nameable/marker_test.go
@@ -197,22 +197,6 @@ func TestParseMarkerSingleSegmentIsCurrentFormNotLegacy(t *testing.T) {
 	c.Equal("Element", marker.Label)
 }
 
-func TestDefaultValue(t *testing.T) {
-	c := check.New(t)
-
-	marker, ok := nameable.NewMarker("Weapon Name")
-	c.True(ok)
-	c.Equal("Weapon Name", marker.DefaultValue())
-
-	marker, ok = nameable.NewMarker("Element|Fire|Water")
-	c.True(ok)
-	c.Equal("Fire", marker.DefaultValue())
-
-	marker, ok = nameable.NewMarker("Element|Fire|Water|?")
-	c.True(ok)
-	c.Equal("", marker.DefaultValue())
-}
-
 func TestKeyPlainLegacyLabel(t *testing.T) {
 	c := check.New(t)
 	m, ok := nameable.NewMarker("Weapon Name")
@@ -319,17 +303,17 @@ func TestExtractPipeDelimited(t *testing.T) {
 	c := check.New(t)
 	m := make(map[string]string)
 	nameable.Extract(m, nil, "A @Element|Fire|Water@ spell")
-	c.Equal("Fire", m["Element|Fire|Water"])
+	c.Equal(nameable.Unset, m["Element|Fire|Water"])
 
 	m = make(map[string]string)
 	nameable.Extract(m, nil, "A @Element|Fire|Water|?@ spell")
-	c.Equal("", m["Element|Fire|Water|?"])
+	c.Equal(nameable.Unset, m["Element|Fire|Water|?"])
 }
 
 func TestExtractWithNilTargetCreatesMap(t *testing.T) {
 	c := check.New(t)
 	got := nameable.Extract(nil, nil, "A @Element|Fire|Water@ spell")
-	c.Equal("Fire", got["Element|Fire|Water"])
+	c.Equal(nameable.Unset, got["Element|Fire|Water"])
 }
 
 func TestExtractUsesExistingValueWhenKeyMatches(t *testing.T) {

--- a/model/nameable/nameable.go
+++ b/model/nameable/nameable.go
@@ -15,6 +15,11 @@ import (
 	"strings"
 )
 
+// Unset is a sentinel value used in the nameables map produced by Extract to indicate that a marker has no
+// recorded replacement yet. It is bracketed with NUL bytes so it won't collide with a value a user typed
+// or that came from file content. Callers that read Extract's output must treat it the same as the key being absent
+const Unset = "\x00unset\x00"
+
 // Filler defines the method for filling the nameable key map.
 type Filler interface {
 	// FillWithNameableKeys fills the map with nameable keys.
@@ -41,7 +46,7 @@ type Applier interface {
 }
 
 // Extract nameable markers from the provided strings
-// Each extracted marker will be a key and it's value will come from existing or be the default for the marker.
+// Each extracted marker will be a key and its value will come from replacements, or be Unset.
 func Extract(nameables, replacements map[string]string, in ...string) map[string]string {
 	if nameables == nil {
 		nameables = make(map[string]string)
@@ -55,7 +60,7 @@ func Extract(nameables, replacements map[string]string, in ...string) map[string
 					if v, exists := replacements[m.Key()]; exists {
 						nameables[m.Key()] = v
 					} else {
-						nameables[m.Key()] = m.DefaultValue()
+						nameables[m.Key()] = Unset
 					}
 				}
 			}
@@ -152,6 +157,10 @@ func ApplyToList(in []string, replacements map[string]string) []string {
 // load-time normalization (see Normalize) or the output of a previous Reduce call. Reduce does not itself
 // normalize either map's keys.
 //
+// A replacements entry still holding the Unset sentinel (i.e. the substitutions dialog was shown but the user
+// never explicitly chose a value for that marker) is dropped rather than kept, so an untouched marker is never
+// persisted as if it had been resolved.
+//
 // Returns nil, not an empty map, when there is nothing to keep -- callers that assign the result directly to a
 // stored Replacements field and later write into it without a nil check (e.g. `x.Replacements[k] = v`) must guard
 // for nil first.
@@ -163,6 +172,9 @@ func Reduce(nameables, replacements map[string]string) map[string]string {
 
 	ret := make(map[string]string, min(len(nameables), len(replacements)))
 	for k, v := range replacements {
+		if v == Unset {
+			continue
+		}
 		if _, found := nameables[k]; found {
 			ret[k] = v
 		}

--- a/model/nameable/nameable_test.go
+++ b/model/nameable/nameable_test.go
@@ -153,6 +153,13 @@ func TestReduceOmitsReplacementsNotInNameables(t *testing.T) {
 	c.Equal(map[string]string{"Habit": "Nail-biting"}, nameable.Reduce(nameables, replacements))
 }
 
+func TestReduceOmitsUnsetReplacements(t *testing.T) {
+	c := check.New(t)
+	nameables := map[string]string{"Habit": "Bad Habit", "Weapon Name": "A weapon name"}
+	replacements := map[string]string{"Habit": "Nail-biting", "Weapon Name": nameable.Unset}
+	c.Equal(map[string]string{"Habit": "Nail-biting"}, nameable.Reduce(nameables, replacements))
+}
+
 func TestNormalizeRewritesUnnormalizedReplacementKey(t *testing.T) {
 	c := check.New(t)
 	// A replacements map loaded from an old file may be keyed on an unnormalized ordering of a current-format

--- a/ux/nameables_processing.go
+++ b/ux/nameables_processing.go
@@ -197,9 +197,13 @@ func ShowNameablesDialog(titles []string, nameables []map[string]string, visible
 // always included too -- for now; that's this function's call, not NewComboField's, since NewComboField itself has
 // no opinion on whether "not set" should be offered (see its docs) -- and it's now the only way to clear a
 // substitution, there's no separate "clear" button in the dialog.
+//
+// m's value for this marker's key comes from nameable.Extract, which uses nameable.Unset to mark a marker with
+// no recorded replacement -- every nameable defaults to "not set" here unless a real replacement was already
+// on record, regardless of the marker's Options/AllowEmpty configuration.
 func createNameableField(marker *nameable.Marker, m map[string]string) unison.Paneler {
 	var initial *string
-	if v, ok := m[marker.Key()]; ok {
+	if v, ok := m[marker.Key()]; ok && v != nameable.Unset {
 		initial = &v
 	}
 	options := make([]*string, 0, len(marker.Options)+2)


### PR DESCRIPTION
The current default value behavior is sub-optimal. This switches it so that a nameable always defaults to the "unset" state unless there is a previously set replacement value.