### PR TITLE
Adding ability to define subset groups for enums

### DIFF
--- a/cmd/enumgen/enum.go.tmpl
+++ b/cmd/enumgen/enum.go.tmpl
@@ -45,6 +45,15 @@ var {{$name}}s = []{{$name}}{
     {{- end}}
 }
 
+{{range $group, $ids := .Groups -}}
+{{wrapComment (printf "%ssFor%s holds the %ss valid for the %q group." $name (toIdentifier $group) $name $group) 116}}
+var {{$name}}sFor{{toIdentifier $group}} = []{{$name}}{
+    {{- range $ids}}
+    {{.}},
+    {{- end}}
+}
+
+{{end -}}
 {{wrapComment (printf "%s %s." $name .Desc) 120}}
 type {{$name}} byte
 

--- a/cmd/enumgen/main.go
+++ b/cmd/enumgen/main.go
@@ -44,6 +44,7 @@ type enumValue struct {
 	OldKeys       []string
 	String        string
 	Alt           string
+	Groups        []string
 	NoLocalize    bool
 	NoLocalizeAlt bool
 	EmptyStringOK bool
@@ -211,6 +212,51 @@ func (e *enumInfo) RealValues() []*enumValue {
 
 	}
 	return e.Values
+}
+
+// Groups returns the raw group memberships declared on this enum's values, keyed by group name, each holding the
+// identifiers of the member values in declaration order. The template is responsible for turning a group name into a
+// proper Go identifier and deciding what to name and how to render the resulting variable.
+//
+// A value whose Groups includes "*" is treated as a member of every other named group declared anywhere in this
+// enum's values, in addition to any groups it names explicitly. If the enum declares no named groups at all, "*" has
+// nothing to expand into and is ignored.
+func (e *enumInfo) Groups() map[string][]string {
+	if len(e.Values) == 0 {
+		return nil
+	}
+	named := make(map[string]bool)
+	for _, v := range e.Values {
+		for _, g := range v.Groups {
+			if g != "*" {
+				named[g] = true
+			}
+		}
+	}
+	if len(named) == 0 {
+		return nil
+	}
+	groups := make(map[string][]string)
+	for _, v := range e.Values {
+		id := e.IDFor(v)
+		added := make(map[string]bool)
+		add := func(name string) {
+			if !added[name] {
+				added[name] = true
+				groups[name] = append(groups[name], id)
+			}
+		}
+		for _, g := range v.Groups {
+			if g == "*" {
+				for name := range named {
+					add(name)
+				}
+			} else {
+				add(g)
+			}
+		}
+	}
+	return groups
 }
 
 func (e *enumInfo) NeedI18N() bool {


### PR DESCRIPTION
This is additional functionality for the enum generator to allow programmatic creation of subsets of enums that are used for various things in GCS. This does not convert any of the existing manually-defined subsets, just sets the stage for later conversion.