### PR TITLE
Refactor template picker usage

### DIFF
--- a/cmd/enumgen/main.go
+++ b/cmd/enumgen/main.go
@@ -1003,9 +1003,9 @@ var allEnums = []*enumInfo{
 		Name: "type",
 		Desc: "holds the type of template picker",
 		Values: []*enumValue{
-			{Key: "not_applicable"},
-			{Key: "count"},
-			{Key: "points"},
+			{Key: "not_applicable", Groups: []string{"*"}},
+			{Key: "count", Groups: []string{"*"}},
+			{Key: "points", Groups: []string{"traits", "skills", "spells"}},
 		},
 	},
 	{

--- a/model/gurps/enums/picker/type_gen.go
+++ b/model/gurps/enums/picker/type_gen.go
@@ -40,6 +40,27 @@ var Types = []Type{
 	Points,
 }
 
+// TypesForSkills holds the Types valid for the "skills" group.
+var TypesForSkills = []Type{
+	NotApplicable,
+	Count,
+	Points,
+}
+
+// TypesForSpells holds the Types valid for the "spells" group.
+var TypesForSpells = []Type{
+	NotApplicable,
+	Count,
+	Points,
+}
+
+// TypesForTraits holds the Types valid for the "traits" group.
+var TypesForTraits = []Type{
+	NotApplicable,
+	Count,
+	Points,
+}
+
 // Type holds the type of template picker.
 type Type byte
 

--- a/model/gurps/organize_traits_test.go
+++ b/model/gurps/organize_traits_test.go
@@ -264,7 +264,6 @@ func TestOrganizeTraitsSetsParentsAndOwner(t *testing.T) {
 	for _, one := range organized {
 		c.True(one.Container(), "every top-level entry is a container")
 		c.Nil(one.Parent(), "a top-level container has no parent")
-		c.NotNil(one.TemplatePicker, "a created container has a template picker")
 		c.True(e == one.DataOwner(), "a created container belongs to the owner passed in")
 		for _, child := range one.Children {
 			c.True(one == child.Parent(), "a filed trait points at its container")

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -25,6 +25,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/cell"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/difficulty"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/display"
+	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/srcstate"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/study"
 	"github.com/richardwilkes/gcs/v5/model/jio"
@@ -130,7 +131,7 @@ type SkillNonContainerOnlySyncData struct {
 
 // SkillContainerOnlySyncData holds the skill sync data that is only applicable to skills that are containers.
 type SkillContainerOnlySyncData struct {
-	TemplatePicker *TemplatePicker `json:"template_picker,omitzero"`
+	TemplatePicker TemplatePicker `json:"template_picker,omitzero"`
 }
 
 type skillListData struct {
@@ -176,9 +177,7 @@ func NewSkill(owner DataOwner, parent *Skill, container bool) *Skill {
 	s.TID = tid.MustNewTID(skillKind(container))
 	s.parent = parent
 	s.owner = owner
-	if container {
-		s.TemplatePicker = &TemplatePicker{}
-	} else {
+	if !container {
 		s.Difficulty.Attribute = AttributeIDFor(EntityFromNode(&s), DexterityID)
 		s.Difficulty.Difficulty = difficulty.Average
 		s.Points = fxp.One
@@ -388,14 +387,9 @@ func (s *Skill) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	return nil
 }
 
-// TemplatePickerData returns the TemplatePicker data, if any.
-func (s *SkillContainerOnlySyncData) TemplatePickerData() *TemplatePicker {
-	return s.TemplatePicker
-}
-
-// SetTemplatePickerData sets the TemplatePicker data.
-func (s *SkillContainerOnlySyncData) SetTemplatePickerData(tp *TemplatePicker) {
-	s.TemplatePicker = tp
+// TemplatePickerData implements TemplatePickerProvider.
+func (s *SkillContainerOnlySyncData) TemplatePickerData() ([]picker.Type, *TemplatePicker) {
+	return picker.TypesForSkills, &s.TemplatePicker
 }
 
 // SkillsHeaderData returns the header data information for the given skill column.
@@ -1412,9 +1406,6 @@ func (s *Skill) ClearUnusedFieldsForType() {
 		// Clearing the switch keeps a stale on-state from being carried around with no way for the user to reach it.
 		s.ItemSwitch = ItemSwitch{}
 		s.Difficulty = AttributeDifficulty{omit: true}
-		if s.TemplatePicker == nil {
-			s.TemplatePicker = &TemplatePicker{}
-		}
 	} else {
 		s.SkillContainerOnlySyncData = SkillContainerOnlySyncData{}
 		s.Children = nil
@@ -1447,7 +1438,6 @@ func (s *Skill) SyncWithSource() {
 				s.Tags = slices.Clone(other.Tags)
 				if s.Container() {
 					s.SkillContainerOnlySyncData = other.SkillContainerOnlySyncData
-					s.TemplatePicker = other.TemplatePicker.Clone()
 				} else {
 					s.SkillNonContainerOnlySyncData = other.SkillNonContainerOnlySyncData
 					if len(other.Defaults) != 0 {
@@ -1596,5 +1586,4 @@ func (s *SkillEditData) copyFrom(skill *Skill, other *SkillEditData, isContainer
 			s.Study[i] = other.Study[i].Clone()
 		}
 	}
-	s.TemplatePicker = other.TemplatePicker.Clone()
 }

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -25,6 +25,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/cell"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/difficulty"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/display"
+	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/srcstate"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/study"
 	"github.com/richardwilkes/gcs/v5/model/jio"
@@ -115,7 +116,7 @@ type SpellNonContainerOnlyEditData struct {
 
 // SpellContainerOnlySyncData holds the spell sync data that is only applicable to spells that are containers.
 type SpellContainerOnlySyncData struct {
-	TemplatePicker *TemplatePicker `json:"template_picker,omitzero"`
+	TemplatePicker TemplatePicker `json:"template_picker,omitzero"`
 }
 
 // SpellSyncData holds the spell sync data that is common to both containers and non-containers.
@@ -181,9 +182,7 @@ func NewSpell(owner DataOwner, parent *Spell, container bool) *Spell {
 	s.TID = tid.MustNewTID(spellKind(container))
 	s.parent = parent
 	s.owner = owner
-	if container {
-		s.TemplatePicker = &TemplatePicker{}
-	} else {
+	if !container {
 		s.Difficulty.Attribute = AttributeIDFor(EntityFromNode(&s), IntelligenceID)
 		s.Difficulty.Difficulty = difficulty.Hard
 		s.PowerSource = "Arcane"
@@ -389,14 +388,9 @@ func (s *Spell) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	return nil
 }
 
-// TemplatePickerData returns the TemplatePicker data, if any.
-func (s *SpellContainerOnlySyncData) TemplatePickerData() *TemplatePicker {
-	return s.TemplatePicker
-}
-
-// SetTemplatePickerData sets the TemplatePicker data.
-func (s *SpellContainerOnlySyncData) SetTemplatePickerData(tp *TemplatePicker) {
-	s.TemplatePicker = tp
+// TemplatePickerData implements TemplatePickerProvider.
+func (s *SpellContainerOnlySyncData) TemplatePickerData() ([]picker.Type, *TemplatePicker) {
+	return picker.TypesForSpells, &s.TemplatePicker
 }
 
 // SpellsHeaderData returns the header data information for the given spell column.
@@ -1208,9 +1202,6 @@ func (s *Spell) ClearUnusedFieldsForType() {
 		// Clearing the switch keeps a stale on-state from being carried around with no way for the user to reach it.
 		s.ItemSwitch = ItemSwitch{}
 		s.Difficulty = AttributeDifficulty{omit: true}
-		if s.TemplatePicker == nil {
-			s.TemplatePicker = &TemplatePicker{}
-		}
 	} else {
 		s.SpellContainerOnlySyncData = SpellContainerOnlySyncData{}
 		s.Children = nil
@@ -1237,7 +1228,6 @@ func (s *Spell) SyncWithSource() {
 				s.Tags = slices.Clone(other.Tags)
 				if s.Container() {
 					s.SpellContainerOnlySyncData = other.SpellContainerOnlySyncData
-					s.TemplatePicker = other.TemplatePicker.Clone()
 				} else {
 					s.SpellNonContainerOnlySyncData = other.SpellNonContainerOnlySyncData
 					s.College = slices.Clone(s.College)
@@ -1340,5 +1330,4 @@ func (s *SpellEditData) copyFrom(spell *Spell, other *SpellEditData, isContainer
 			s.Study[i] = other.Study[i].Clone()
 		}
 	}
-	s.TemplatePicker = s.TemplatePicker.Clone()
 }

--- a/model/gurps/template_picker.go
+++ b/model/gurps/template_picker.go
@@ -20,10 +20,10 @@ import (
 	"github.com/richardwilkes/toolbox/v2/xhash"
 )
 
-// TemplatePickerProvider defines the methods a TemplatePicker provider has.
+// TemplatePickerProvider provides the method used to get a list of valid picker type and to access the picker data
 type TemplatePickerProvider interface {
-	TemplatePickerData() *TemplatePicker
-	SetTemplatePickerData(*TemplatePicker)
+	// TemplatePickerData returns a list of valid picker types and valid, non-nil, pointer to a TemplatePicker struct
+	TemplatePickerData() ([]picker.Type, *TemplatePicker)
 }
 
 // TemplatePicker holds the data necessary to allow a template choice to be made.
@@ -32,21 +32,12 @@ type TemplatePicker struct {
 	Qualifier criteria.Number `json:"qualifier,omitzero"`
 }
 
-// Clone creates a copy of the TemplatePicker.
-func (t *TemplatePicker) Clone() *TemplatePicker {
-	if t.IsZero() {
-		return &TemplatePicker{}
-	}
-	p := *t
-	return &p
-}
-
 // IsZero implements json.isZero.
-func (t *TemplatePicker) IsZero() bool {
-	return t == nil || t.Type == picker.NotApplicable
+func (t TemplatePicker) IsZero() bool {
+	return t.Type == picker.NotApplicable
 }
 
-func (t *TemplatePicker) String() string {
+func (t TemplatePicker) String() string {
 	if t.IsZero() {
 		return ""
 	}
@@ -65,7 +56,7 @@ func (t *TemplatePicker) String() string {
 }
 
 // Hash writes this object's contents into the hasher.
-func (t *TemplatePicker) Hash(h hash.Hash) {
+func (t TemplatePicker) Hash(h hash.Hash) {
 	xhash.Num8(h, t.Type)
 	t.Qualifier.Hash(h)
 }

--- a/model/gurps/template_picker.go
+++ b/model/gurps/template_picker.go
@@ -58,5 +58,7 @@ func (t TemplatePicker) String() string {
 // Hash writes this object's contents into the hasher.
 func (t TemplatePicker) Hash(h hash.Hash) {
 	xhash.Num8(h, t.Type)
-	t.Qualifier.Hash(h)
+	if t.Type.EnsureValid() != picker.NotApplicable {
+		t.Qualifier.Hash(h)
+	}
 }

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -27,6 +27,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/emweight"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/frequency"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/maxusesmod"
+	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/selector"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/selfctrl"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/srcstate"
@@ -133,9 +134,9 @@ type TraitNonContainerSyncData struct {
 
 // TraitContainerSyncData holds the Trait sync data that is only applicable to traits that are containers.
 type TraitContainerSyncData struct {
-	Ancestry       string          `json:"ancestry,omitzero"`
-	TemplatePicker *TemplatePicker `json:"template_picker,omitzero"`
-	ContainerType  container.Type  `json:"container_type,omitzero"`
+	Ancestry       string         `json:"ancestry,omitzero"`
+	TemplatePicker TemplatePicker `json:"template_picker,omitzero"`
+	ContainerType  container.Type `json:"container_type,omitzero"`
 }
 
 type traitListData struct {
@@ -174,9 +175,6 @@ func NewTrait(owner DataOwner, parent *Trait, isContainer bool) *Trait {
 	t.parent = parent
 	t.owner = owner
 	t.Name = t.Kind()
-	if t.Container() {
-		t.TemplatePicker = &TemplatePicker{}
-	}
 	t.SetOpen(isContainer)
 	return &t
 }
@@ -361,14 +359,9 @@ func (t *Trait) EffectivelyDisabled() bool {
 	return false
 }
 
-// TemplatePickerData returns the TemplatePicker data, if any.
-func (t *TraitContainerSyncData) TemplatePickerData() *TemplatePicker {
-	return t.TemplatePicker
-}
-
-// SetTemplatePickerData sets the TemplatePicker data.
-func (t *TraitContainerSyncData) SetTemplatePickerData(tp *TemplatePicker) {
-	t.TemplatePicker = tp
+// TemplatePickerData implements TemplatePickerProvider.
+func (t *TraitContainerSyncData) TemplatePickerData() ([]picker.Type, *TemplatePicker) {
+	return picker.TypesForTraits, &t.TemplatePicker
 }
 
 // TraitsHeaderData returns the header data information for the given trait column.
@@ -1064,9 +1057,6 @@ func (t *Trait) Kind() string {
 func (t *Trait) ClearUnusedFieldsForType() {
 	if t.Container() {
 		t.TraitNonContainerOnlyEditData = TraitNonContainerOnlyEditData{}
-		if t.TemplatePicker == nil {
-			t.TemplatePicker = &TemplatePicker{}
-		}
 	} else {
 		t.TraitContainerSyncData = TraitContainerSyncData{}
 		t.Children = nil
@@ -1098,7 +1088,6 @@ func (t *Trait) SyncWithSource() {
 				t.Prereq = other.Prereq.CloneResolvingEmpty(false, true)
 				if t.Container() {
 					t.TraitContainerSyncData = other.TraitContainerSyncData
-					t.TemplatePicker = other.TemplatePicker.Clone()
 				} else {
 					t.TraitNonContainerSyncData = other.TraitNonContainerSyncData
 					t.Weapons = CloneWeapons(other.Weapons, t, Reference)
@@ -1210,7 +1199,6 @@ func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply boo
 			t.Study[i] = other.Study[i].Clone()
 		}
 	}
-	t.TemplatePicker = t.TemplatePicker.Clone()
 }
 
 // CanPreconfigureContainer implements Preconfigurable.

--- a/ux/choices.go
+++ b/ux/choices.go
@@ -32,20 +32,17 @@ func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent 
 		return typePopup, comparisonPopup, field
 	}
 
+	var types []picker.Type
 	var tp *gurps.TemplatePicker
 	if pickable, ok := any(e.editorData).(gurps.TemplatePickerProvider); ok {
-		tp = pickable.TemplatePickerData()
+		types, tp = pickable.TemplatePickerData()
 	} else {
 		return typePopup, comparisonPopup, field
 	}
 
-	if tp == nil {
-		tp = &gurps.TemplatePicker{}
-	}
-
 	last := tp.Type
 	wrapper := addFlowWrapper(parent, i18n.Text("Choices"), 3)
-	typePopup = addPopup(wrapper, picker.Types, &tp.Type)
+	typePopup = addPopup(wrapper, types, &tp.Type)
 	text := i18n.Text("Choice Quantifier")
 	comparisonPopup, field = addNumericCriteriaPanel(wrapper, nil, "", "", text, &tp.Qualifier, fxp.Min, fxp.Max, 1, false, false)
 
@@ -60,11 +57,12 @@ func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent 
 	}
 
 	typePopup.SelectionChangedCallback = func(p *unison.PopupMenu[picker.Type]) {
-		if item, ok := p.Selected(); ok {
+		if item, selected := p.Selected(); selected {
 			tp.Type = item
 			if last == picker.NotApplicable && item != picker.NotApplicable {
 				tp.Qualifier.Qualifier = fxp.One
-				if syncer, ok2 := field.(Syncer); ok2 {
+				comparisonPopup.SelectIndex(criteria.ExtractNumericComparisonIndex(string(criteria.AnyNumber)))
+				if syncer, ok := field.(Syncer); ok {
 					syncer.Sync()
 				}
 			}

--- a/ux/template.go
+++ b/ux/template.go
@@ -802,9 +802,10 @@ func rawPoints[T gurps.Node[T]](child T) fxp.Int {
 	}
 	if child.Container() {
 		if pickable, ok := any(child).(gurps.TemplatePickerProvider); ok {
-			tp := pickable.TemplatePickerData()
-			if tp != nil && tp.Type == picker.Points && tp.Qualifier.Compare == criteria.EqualsNumber {
-				return tp.Qualifier.Qualifier
+			if _, tp := pickable.TemplatePickerData(); tp.Type == picker.Points {
+				if tp.Qualifier.Compare == criteria.EqualsNumber {
+					return tp.Qualifier.Qualifier
+				}
 			}
 		}
 	}

--- a/ux/template_picker.go
+++ b/ux/template_picker.go
@@ -47,7 +47,11 @@ func processPickerRow[T gurps.Node[T]](row T) (revised []T, abort bool) {
 	}
 	children := row.NodeChildren()
 	tpp, ok := any(row).(gurps.TemplatePickerProvider)
-	if !ok || tpp.TemplatePickerData().IsZero() {
+	var tp *gurps.TemplatePicker
+	if ok {
+		_, tp = tpp.TemplatePickerData()
+	}
+	if !ok || tp.IsZero() {
 		rowChildren := make([]T, 0, len(children))
 		for _, child := range children {
 			var result []T
@@ -61,7 +65,6 @@ func processPickerRow[T gurps.Node[T]](row T) (revised []T, abort bool) {
 		SetParents(rowChildren, row)
 		return []T{row}, false
 	}
-	tp := tpp.TemplatePickerData()
 
 	list := unison.NewPanel()
 	list.SetBorder(unison.NewEmptyBorder(geom.NewUniformInsets(unison.StdHSpacing)))
@@ -126,7 +129,7 @@ func processPickerRow[T gurps.Node[T]](row T) (revised []T, abort bool) {
 		}
 	}
 	for _, child := range children {
-		boxes = addPickerRow(list, child, callback, boxes)
+		boxes = addPickerRow(list, child, tp.Type, callback, boxes)
 	}
 
 	scroll := unison.NewScrollPanel()
@@ -219,7 +222,7 @@ func pickerMatchStateColor(matches bool) unison.Color {
 	return unison.ThemeError.GetColor()
 }
 
-func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, callback func(), boxes []*unison.CheckBox) []*unison.CheckBox {
+func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, pt picker.Type, callback func(), boxes []*unison.CheckBox) []*unison.CheckBox {
 	wrapper := unison.NewPanel()
 	wrapper.SetLayout(&unison.FlexLayout{
 		Columns:  2,
@@ -227,7 +230,7 @@ func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, callback func(),
 	})
 	parent.AddChild(wrapper)
 	checkBox := unison.NewCheckBox()
-	updatePickerCheckBoxTitle(checkBox, row)
+	updatePickerCheckBoxTitle(checkBox, row, pt)
 	checkBox.ClickCallback = callback
 	wrapper.AddChild(checkBox)
 	boxes = append(boxes, checkBox)
@@ -237,19 +240,19 @@ func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, callback func(),
 	switch actual := any(row).(type) {
 	case *gurps.Trait:
 		if actual.IsLeveled() {
-			onClick = func() { pickerRowLevelEditor(actual, checkBox, callback) }
+			onClick = func() { pickerRowLevelEditor(actual, checkBox, pt, callback) }
 		}
 		pageRef = actual.PageRef
 		pageRefHighlight = actual.PageRefHighlight
 	case *gurps.Skill:
 		if !actual.Container() {
-			onClick = func() { pickerRowPointEditor(actual, checkBox, callback) }
+			onClick = func() { pickerRowPointEditor(actual, checkBox, pt, callback) }
 		}
 		pageRef = actual.PageRef
 		pageRefHighlight = actual.PageRefHighlight
 	case *gurps.Spell:
 		if !actual.Container() {
-			onClick = func() { pickerRowPointEditor(actual, checkBox, callback) }
+			onClick = func() { pickerRowPointEditor(actual, checkBox, pt, callback) }
 		}
 		pageRef = actual.PageRef
 		pageRefHighlight = actual.PageRefHighlight
@@ -293,20 +296,27 @@ func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, callback func(),
 	return boxes
 }
 
-func updatePickerCheckBoxTitle[T gurps.Node[T]](checkBox *unison.CheckBox, row T) {
+func updatePickerCheckBoxTitle[T gurps.Node[T]](checkBox *unison.CheckBox, row T, pt picker.Type) {
 	title := row.String()
-	points := rawPoints(row)
-	if points != 0 {
-		pointsLabel := i18n.Text("points")
-		if points == fxp.One {
-			pointsLabel = i18n.Text("point")
+	switch pt {
+	case picker.Points:
+		points := rawPoints(row)
+		if points != 0 {
+			pointsLabel := i18n.Text("points")
+			if points == fxp.One {
+				pointsLabel = i18n.Text("point")
+			}
+			title += fmt.Sprintf(" [%s %s]", points.Comma(), pointsLabel)
 		}
-		title += fmt.Sprintf(" [%s %s]", points.Comma(), pointsLabel)
+	case picker.Count:
+		// NOP
+	default:
+		// NOP
 	}
 	checkBox.SetTitle(title)
 }
 
-func pickerRowLevelEditor(trait *gurps.Trait, checkBox *unison.CheckBox, callback func()) {
+func pickerRowLevelEditor(trait *gurps.Trait, checkBox *unison.CheckBox, pt picker.Type, callback func()) {
 	levels := trait.Levels
 	maximum := trait.ResolvedMaxLevels()
 	fieldMax := fxp.MaxBasePoints
@@ -343,7 +353,7 @@ func pickerRowLevelEditor(trait *gurps.Trait, checkBox *unison.CheckBox, callbac
 		return
 	}
 	trait.Levels = levels
-	updatePickerCheckBoxTitle(checkBox, trait)
+	updatePickerCheckBoxTitle(checkBox, trait, pt)
 	callback()
 	checkBox.MarkForLayoutRecursivelyUpward()
 	checkBox.MarkForRedraw()
@@ -354,7 +364,7 @@ type pickerRowPointEditorTypes[T gurps.Node[T]] interface {
 	gurps.RawPointsAdjuster
 }
 
-func pickerRowPointEditor[T pickerRowPointEditorTypes[T]](node T, checkBox *unison.CheckBox, callback func()) {
+func pickerRowPointEditor[T pickerRowPointEditorTypes[T]](node T, checkBox *unison.CheckBox, pt picker.Type, callback func()) {
 	points := node.RawPoints()
 	panel := unison.NewPanel()
 	panel.SetLayout(&unison.FlexLayout{
@@ -381,7 +391,7 @@ func pickerRowPointEditor[T pickerRowPointEditorTypes[T]](node T, checkBox *unis
 		return
 	}
 	node.SetRawPoints(points)
-	updatePickerCheckBoxTitle(checkBox, node)
+	updatePickerCheckBoxTitle(checkBox, node, pt)
 	callback()
 	checkBox.MarkForLayoutRecursivelyUpward()
 	checkBox.MarkForRedraw()

--- a/ux/widgets.go
+++ b/ux/widgets.go
@@ -11,6 +11,7 @@ package ux
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/richardwilkes/gcs/v5/model/criteria"
@@ -506,6 +507,10 @@ func addLabelAndPopup[T comparable](parent *unison.Panel, labelText, tooltip str
 }
 
 func addPopup[T comparable](parent *unison.Panel, choices []T, fieldData *T) *unison.PopupMenu[T] {
+	// Ensure that the passed field value is in the list of choices
+	if fieldData != nil && len(choices) > 0 && !slices.Contains(choices, *fieldData) {
+		*fieldData = choices[0]
+	}
 	popup := unison.NewPopupMenu[T]()
 	for _, one := range choices {
 		popup.AddItem(one)


### PR DESCRIPTION
The existing 'TemplatePicker' struct and 'TemplatePickerProvider' interface have several issues, the biggest being that there's no way to define a set of allowed picker types based on the containing node. This refactor changes from using direct access to the 'TemplatePicker' struct to having the interface capable of returning an allowed list of types and a reference to the underlying 'TemplatePicker' data. The interface also contractually promises that the returned 'TemplatePicker' will never be nil due to the backing `TemplatePicker` no longer being a pointer. This allowed for the remove of a lot of code that was there just to deal with `TemplatePicker` being nilable. The json output is there same due to the use of the `omitzero` flag and TemplatePicker.IsZero()`.