### PR TITLE
Adding Equipment Template Choices

### DIFF
--- a/cmd/enumgen/main.go
+++ b/cmd/enumgen/main.go
@@ -1006,6 +1006,9 @@ var allEnums = []*enumInfo{
 			{Key: "not_applicable", Groups: []string{"*"}},
 			{Key: "count", Groups: []string{"*"}},
 			{Key: "points", Groups: []string{"traits", "skills", "spells"}},
+			{Key: "quantity", Groups: []string{"equipment"}},
+			{Key: "cost", Groups: []string{"equipment"}},
+			{Key: "weight", Groups: []string{"equipment"}},
 		},
 	},
 	{

--- a/cmd/enumgen/main.go
+++ b/cmd/enumgen/main.go
@@ -1003,9 +1003,9 @@ var allEnums = []*enumInfo{
 		Name: "type",
 		Desc: "holds the type of template picker",
 		Values: []*enumValue{
-			{Key: "not_applicable"},
-			{Key: "count"},
-			{Key: "points"},
+			{Key: "not_applicable", Groups: []string{"*"}},
+			{Key: "count", Groups: []string{"*"}},
+			{Key: "points", Groups: []string{"traits", "skills", "spells"}},
 		},
 	},
 	{

--- a/model/gurps/enums/picker/type_gen.go
+++ b/model/gurps/enums/picker/type_gen.go
@@ -40,6 +40,27 @@ var Types = []Type{
 	Points,
 }
 
+// TypesForSkills holds the Types valid for the "skills" group.
+var TypesForSkills = []Type{
+	NotApplicable,
+	Count,
+	Points,
+}
+
+// TypesForSpells holds the Types valid for the "spells" group.
+var TypesForSpells = []Type{
+	NotApplicable,
+	Count,
+	Points,
+}
+
+// TypesForTraits holds the Types valid for the "traits" group.
+var TypesForTraits = []Type{
+	NotApplicable,
+	Count,
+	Points,
+}
+
 // Type holds the type of template picker.
 type Type byte
 

--- a/model/gurps/enums/picker/type_gen.go
+++ b/model/gurps/enums/picker/type_gen.go
@@ -22,6 +22,9 @@ const (
 	NotApplicable Type = iota
 	Count
 	Points
+	Quantity
+	Cost
+	Weight
 )
 
 // DefaultType is the default value.
@@ -31,13 +34,25 @@ const DefaultType Type = NotApplicable
 const FirstType Type = NotApplicable
 
 // LastType is the last valid value.
-const LastType Type = Points
+const LastType Type = Weight
 
 // Types holds all possible values.
 var Types = []Type{
 	NotApplicable,
 	Count,
 	Points,
+	Quantity,
+	Cost,
+	Weight,
+}
+
+// TypesForEquipment holds the Types valid for the "equipment" group.
+var TypesForEquipment = []Type{
+	NotApplicable,
+	Count,
+	Quantity,
+	Cost,
+	Weight,
 }
 
 // TypesForSkills holds the Types valid for the "skills" group.
@@ -81,6 +96,12 @@ func (enum Type) Key() string {
 		return "count"
 	case Points:
 		return "points"
+	case Quantity:
+		return "quantity"
+	case Cost:
+		return "cost"
+	case Weight:
+		return "weight"
 	default:
 		return DefaultType.Key()
 	}
@@ -95,6 +116,12 @@ func (enum Type) String() string {
 		return i18n.Text(`Count`)
 	case Points:
 		return i18n.Text(`Points`)
+	case Quantity:
+		return i18n.Text(`Quantity`)
+	case Cost:
+		return i18n.Text(`Cost`)
+	case Weight:
+		return i18n.Text(`Weight`)
 	default:
 		return DefaultType.String()
 	}

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -24,6 +24,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/display"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/equipmentsel"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/maxusesmod"
+	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/skillsel"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/srcstate"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/wsel"
@@ -47,6 +48,10 @@ var (
 	_ LeveledOwner      = &Equipment{}
 	_ TechLevelProvider = &Equipment{}
 	_ FeatureSwitcher   = &Equipment{}
+
+	_ TemplatePickerProvider = &EquipmentData{}
+	_ TemplatePickerProvider = &EquipmentEditData{}
+	_ TemplatePickerProvider = &EquipmentContainerOnlySyncData{}
 )
 
 // Columns that can be used with the equipment method .CellData()
@@ -89,6 +94,7 @@ type EquipmentData struct {
 // EquipmentEditData holds the Equipment data that can be edited by the UI detail editor.
 type EquipmentEditData struct {
 	EquipmentSyncData
+	EquipmentContainerOnlySyncData
 	VTTNotes     string               `json:"vtt_notes,omitzero"`
 	Replacements map[string]string    `json:"replacements,omitempty"`
 	Modifiers    []*EquipmentModifier `json:"modifiers,omitempty"`
@@ -117,6 +123,20 @@ type EquipmentSyncData struct {
 	Weapons                []*Weapon   `json:"weapons,omitempty"`
 	Features               Features    `json:"features,omitempty"`
 	WeightIgnoredForSkills bool        `json:"ignore_weight_for_skills,omitzero"`
+}
+
+// EquipmentContainerOnlySyncData holds the skill sync data that is only applicable to equipment that are containers.
+type EquipmentContainerOnlySyncData struct {
+	TemplatePicker TemplatePicker `json:"template_picker,omitzero"`
+}
+
+// TemplatePickerData implements TemplatePickerProvider.
+func (e *EquipmentContainerOnlySyncData) TemplatePickerData() ([]picker.Type, *TemplatePicker) {
+	return picker.TypesForEquipment, &e.TemplatePicker
+}
+
+func (e *EquipmentContainerOnlySyncData) hash(h hash.Hash) {
+	e.TemplatePicker.Hash(h)
 }
 
 type equipmentListData struct {
@@ -433,6 +453,7 @@ func (e *Equipment) CellData(columnID int, data *CellData) {
 		data.Secondary = e.SecondaryText(func(option display.Option) bool { return option.Inline() })
 		data.UnsatisfiedReason = e.UnsatisfiedReason
 		data.Tooltip = e.SecondaryText(func(option display.Option) bool { return option.Tooltip() })
+		data.TemplateInfo = e.TemplatePicker.String()
 	case EquipmentTLColumn:
 		data.Type = cell.Text
 		data.Primary = e.TechLevel
@@ -1072,11 +1093,13 @@ func (e *Equipment) CanConvertToFromContainer() bool {
 // ConvertToContainer converts this node to a container.
 func (e *Equipment) ConvertToContainer() {
 	e.TID = tid.TID(kinds.EquipmentContainer) + e.TID[1:]
+	e.ClearUnusedFieldsForType()
 }
 
 // ConvertToNonContainer converts this node to a non-container.
 func (e *Equipment) ConvertToNonContainer() {
 	e.TID = tid.TID(kinds.Equipment) + e.TID[1:]
+	e.ClearUnusedFieldsForType()
 }
 
 // Kind returns the kind of data.
@@ -1091,6 +1114,7 @@ func (e *Equipment) Kind() string {
 func (e *Equipment) ClearUnusedFieldsForType() {
 	if !e.Container() {
 		e.Children = nil
+		e.EquipmentContainerOnlySyncData = EquipmentContainerOnlySyncData{}
 	}
 }
 
@@ -1110,7 +1134,9 @@ func (e *Equipment) SyncWithSource() {
 		if state, data := e.owner.SourceMatcher().Match(e); state == srcstate.Mismatched {
 			if other, ok := data.(*Equipment); ok {
 				e.EquipmentSyncData = other.EquipmentSyncData
+				e.EquipmentContainerOnlySyncData = other.EquipmentContainerOnlySyncData
 				e.Tags = slices.Clone(other.Tags)
+				e.TemplatePicker = other.TemplatePicker
 				e.Prereq = other.Prereq.CloneResolvingEmpty(false, true)
 				e.Weapons = CloneWeapons(other.Weapons, e, Reference)
 				e.Features = other.Features.Clone()
@@ -1122,10 +1148,16 @@ func (e *Equipment) SyncWithSource() {
 // Hash writes this object's contents into the hasher. Note that this only hashes the data that is considered to be
 // "source" data, i.e. not expected to be modified by the user after copying from a library.
 func (e *Equipment) Hash(h hash.Hash) {
-	e.hash(h)
+	e.EquipmentSyncData.hash(h)
+	if e.Container() {
+		e.EquipmentContainerOnlySyncData.hash(h)
+	}
 }
 
 func (e *EquipmentSyncData) hash(h hash.Hash) {
+	if e == nil {
+		return
+	}
 	xhash.StringWithLen(h, e.Name)
 	xhash.StringWithLen(h, e.PageRef)
 	xhash.StringWithLen(h, e.PageRefHighlight)

--- a/model/gurps/organize_traits_test.go
+++ b/model/gurps/organize_traits_test.go
@@ -264,7 +264,6 @@ func TestOrganizeTraitsSetsParentsAndOwner(t *testing.T) {
 	for _, one := range organized {
 		c.True(one.Container(), "every top-level entry is a container")
 		c.Nil(one.Parent(), "a top-level container has no parent")
-		c.NotNil(one.TemplatePicker, "a created container has a template picker")
 		c.True(e == one.DataOwner(), "a created container belongs to the owner passed in")
 		for _, child := range one.Children {
 			c.True(one == child.Parent(), "a filed trait points at its container")

--- a/model/gurps/skill.go
+++ b/model/gurps/skill.go
@@ -25,6 +25,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/cell"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/difficulty"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/display"
+	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/srcstate"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/study"
 	"github.com/richardwilkes/gcs/v5/model/jio"
@@ -130,7 +131,7 @@ type SkillNonContainerOnlySyncData struct {
 
 // SkillContainerOnlySyncData holds the skill sync data that is only applicable to skills that are containers.
 type SkillContainerOnlySyncData struct {
-	TemplatePicker *TemplatePicker `json:"template_picker,omitzero"`
+	TemplatePicker TemplatePicker `json:"template_picker,omitzero"`
 }
 
 type skillListData struct {
@@ -176,9 +177,7 @@ func NewSkill(owner DataOwner, parent *Skill, container bool) *Skill {
 	s.TID = tid.MustNewTID(skillKind(container))
 	s.parent = parent
 	s.owner = owner
-	if container {
-		s.TemplatePicker = &TemplatePicker{}
-	} else {
+	if !container {
 		s.Difficulty.Attribute = AttributeIDFor(EntityFromNode(&s), DexterityID)
 		s.Difficulty.Difficulty = difficulty.Average
 		s.Points = fxp.One
@@ -388,14 +387,9 @@ func (s *Skill) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	return nil
 }
 
-// TemplatePickerData returns the TemplatePicker data, if any.
-func (s *SkillContainerOnlySyncData) TemplatePickerData() *TemplatePicker {
-	return s.TemplatePicker
-}
-
-// SetTemplatePickerData sets the TemplatePicker data.
-func (s *SkillContainerOnlySyncData) SetTemplatePickerData(tp *TemplatePicker) {
-	s.TemplatePicker = tp
+// TemplatePickerData implements TemplatePickerProvider.
+func (s *SkillContainerOnlySyncData) TemplatePickerData() ([]picker.Type, *TemplatePicker) {
+	return picker.TypesForSkills, &s.TemplatePicker
 }
 
 // SkillsHeaderData returns the header data information for the given skill column.
@@ -1412,9 +1406,6 @@ func (s *Skill) ClearUnusedFieldsForType() {
 		// Clearing the switch keeps a stale on-state from being carried around with no way for the user to reach it.
 		s.ItemSwitch = ItemSwitch{}
 		s.Difficulty = AttributeDifficulty{omit: true}
-		if s.TemplatePicker == nil {
-			s.TemplatePicker = &TemplatePicker{}
-		}
 	} else {
 		s.SkillContainerOnlySyncData = SkillContainerOnlySyncData{}
 		s.Children = nil
@@ -1447,7 +1438,6 @@ func (s *Skill) SyncWithSource() {
 				s.Tags = slices.Clone(other.Tags)
 				if s.Container() {
 					s.SkillContainerOnlySyncData = other.SkillContainerOnlySyncData
-					s.TemplatePicker = other.TemplatePicker.Clone()
 				} else {
 					s.SkillNonContainerOnlySyncData = other.SkillNonContainerOnlySyncData
 					if len(other.Defaults) != 0 {
@@ -1596,5 +1586,4 @@ func (s *SkillEditData) copyFrom(skill *Skill, other *SkillEditData, isContainer
 			s.Study[i] = other.Study[i].Clone()
 		}
 	}
-	s.TemplatePicker = other.TemplatePicker.Clone()
 }

--- a/model/gurps/spell.go
+++ b/model/gurps/spell.go
@@ -25,6 +25,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/cell"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/difficulty"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/display"
+	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/srcstate"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/study"
 	"github.com/richardwilkes/gcs/v5/model/jio"
@@ -115,7 +116,7 @@ type SpellNonContainerOnlyEditData struct {
 
 // SpellContainerOnlySyncData holds the spell sync data that is only applicable to spells that are containers.
 type SpellContainerOnlySyncData struct {
-	TemplatePicker *TemplatePicker `json:"template_picker,omitzero"`
+	TemplatePicker TemplatePicker `json:"template_picker,omitzero"`
 }
 
 // SpellSyncData holds the spell sync data that is common to both containers and non-containers.
@@ -181,9 +182,7 @@ func NewSpell(owner DataOwner, parent *Spell, container bool) *Spell {
 	s.TID = tid.MustNewTID(spellKind(container))
 	s.parent = parent
 	s.owner = owner
-	if container {
-		s.TemplatePicker = &TemplatePicker{}
-	} else {
+	if !container {
 		s.Difficulty.Attribute = AttributeIDFor(EntityFromNode(&s), IntelligenceID)
 		s.Difficulty.Difficulty = difficulty.Hard
 		s.PowerSource = "Arcane"
@@ -389,14 +388,9 @@ func (s *Spell) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	return nil
 }
 
-// TemplatePickerData returns the TemplatePicker data, if any.
-func (s *SpellContainerOnlySyncData) TemplatePickerData() *TemplatePicker {
-	return s.TemplatePicker
-}
-
-// SetTemplatePickerData sets the TemplatePicker data.
-func (s *SpellContainerOnlySyncData) SetTemplatePickerData(tp *TemplatePicker) {
-	s.TemplatePicker = tp
+// TemplatePickerData implements TemplatePickerProvider.
+func (s *SpellContainerOnlySyncData) TemplatePickerData() ([]picker.Type, *TemplatePicker) {
+	return picker.TypesForSpells, &s.TemplatePicker
 }
 
 // SpellsHeaderData returns the header data information for the given spell column.
@@ -1208,9 +1202,6 @@ func (s *Spell) ClearUnusedFieldsForType() {
 		// Clearing the switch keeps a stale on-state from being carried around with no way for the user to reach it.
 		s.ItemSwitch = ItemSwitch{}
 		s.Difficulty = AttributeDifficulty{omit: true}
-		if s.TemplatePicker == nil {
-			s.TemplatePicker = &TemplatePicker{}
-		}
 	} else {
 		s.SpellContainerOnlySyncData = SpellContainerOnlySyncData{}
 		s.Children = nil
@@ -1237,7 +1228,6 @@ func (s *Spell) SyncWithSource() {
 				s.Tags = slices.Clone(other.Tags)
 				if s.Container() {
 					s.SpellContainerOnlySyncData = other.SpellContainerOnlySyncData
-					s.TemplatePicker = other.TemplatePicker.Clone()
 				} else {
 					s.SpellNonContainerOnlySyncData = other.SpellNonContainerOnlySyncData
 					s.College = slices.Clone(s.College)
@@ -1340,5 +1330,4 @@ func (s *SpellEditData) copyFrom(spell *Spell, other *SpellEditData, isContainer
 			s.Study[i] = other.Study[i].Clone()
 		}
 	}
-	s.TemplatePicker = s.TemplatePicker.Clone()
 }

--- a/model/gurps/template_picker.go
+++ b/model/gurps/template_picker.go
@@ -50,6 +50,12 @@ func (t TemplatePicker) String() string {
 			points = i18n.Text("point")
 		}
 		return fmt.Sprintf(i18n.Text("Pick %s %s worth"), t.Qualifier.AltString(), points)
+	case picker.Quantity:
+		return fmt.Sprintf(i18n.Text("Pick %s in quantity"), t.Qualifier.AltString())
+	case picker.Cost:
+		return fmt.Sprintf(i18n.Text("Pick %s worth of cost"), t.Qualifier.AltString())
+	case picker.Weight:
+		return fmt.Sprintf(i18n.Text("Pick %s worth of weight"), t.Qualifier.AltString())
 	default:
 		return ""
 	}

--- a/model/gurps/template_picker.go
+++ b/model/gurps/template_picker.go
@@ -20,10 +20,10 @@ import (
 	"github.com/richardwilkes/toolbox/v2/xhash"
 )
 
-// TemplatePickerProvider defines the methods a TemplatePicker provider has.
+// TemplatePickerProvider provides the method used to get a list of valid picker type and to access the picker data
 type TemplatePickerProvider interface {
-	TemplatePickerData() *TemplatePicker
-	SetTemplatePickerData(*TemplatePicker)
+	// TemplatePickerData returns a list of valid picker types and valid, non-nil, pointer to a TemplatePicker struct
+	TemplatePickerData() ([]picker.Type, *TemplatePicker)
 }
 
 // TemplatePicker holds the data necessary to allow a template choice to be made.
@@ -32,21 +32,12 @@ type TemplatePicker struct {
 	Qualifier criteria.Number `json:"qualifier,omitzero"`
 }
 
-// Clone creates a copy of the TemplatePicker.
-func (t *TemplatePicker) Clone() *TemplatePicker {
-	if t.IsZero() {
-		return &TemplatePicker{}
-	}
-	p := *t
-	return &p
-}
-
 // IsZero implements json.isZero.
-func (t *TemplatePicker) IsZero() bool {
-	return t == nil || t.Type == picker.NotApplicable
+func (t TemplatePicker) IsZero() bool {
+	return t.Type == picker.NotApplicable
 }
 
-func (t *TemplatePicker) String() string {
+func (t TemplatePicker) String() string {
 	if t.IsZero() {
 		return ""
 	}
@@ -65,7 +56,7 @@ func (t *TemplatePicker) String() string {
 }
 
 // Hash writes this object's contents into the hasher.
-func (t *TemplatePicker) Hash(h hash.Hash) {
+func (t TemplatePicker) Hash(h hash.Hash) {
 	xhash.Num8(h, t.Type)
 	t.Qualifier.Hash(h)
 }

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -27,6 +27,7 @@ import (
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/emweight"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/frequency"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/maxusesmod"
+	"github.com/richardwilkes/gcs/v5/model/gurps/enums/picker"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/selector"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/selfctrl"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/srcstate"
@@ -133,9 +134,9 @@ type TraitNonContainerSyncData struct {
 
 // TraitContainerSyncData holds the Trait sync data that is only applicable to traits that are containers.
 type TraitContainerSyncData struct {
-	Ancestry       string          `json:"ancestry,omitzero"`
-	TemplatePicker *TemplatePicker `json:"template_picker,omitzero"`
-	ContainerType  container.Type  `json:"container_type,omitzero"`
+	Ancestry       string         `json:"ancestry,omitzero"`
+	TemplatePicker TemplatePicker `json:"template_picker,omitzero"`
+	ContainerType  container.Type `json:"container_type,omitzero"`
 }
 
 type traitListData struct {
@@ -174,9 +175,6 @@ func NewTrait(owner DataOwner, parent *Trait, isContainer bool) *Trait {
 	t.parent = parent
 	t.owner = owner
 	t.Name = t.Kind()
-	if t.Container() {
-		t.TemplatePicker = &TemplatePicker{}
-	}
 	t.SetOpen(isContainer)
 	return &t
 }
@@ -361,14 +359,9 @@ func (t *Trait) EffectivelyDisabled() bool {
 	return false
 }
 
-// TemplatePickerData returns the TemplatePicker data, if any.
-func (t *TraitContainerSyncData) TemplatePickerData() *TemplatePicker {
-	return t.TemplatePicker
-}
-
-// SetTemplatePickerData sets the TemplatePicker data.
-func (t *TraitContainerSyncData) SetTemplatePickerData(tp *TemplatePicker) {
-	t.TemplatePicker = tp
+// TemplatePickerData implements TemplatePickerProvider.
+func (t *TraitContainerSyncData) TemplatePickerData() ([]picker.Type, *TemplatePicker) {
+	return picker.TypesForTraits, &t.TemplatePicker
 }
 
 // TraitsHeaderData returns the header data information for the given trait column.
@@ -1064,9 +1057,6 @@ func (t *Trait) Kind() string {
 func (t *Trait) ClearUnusedFieldsForType() {
 	if t.Container() {
 		t.TraitNonContainerOnlyEditData = TraitNonContainerOnlyEditData{}
-		if t.TemplatePicker == nil {
-			t.TemplatePicker = &TemplatePicker{}
-		}
 	} else {
 		t.TraitContainerSyncData = TraitContainerSyncData{}
 		t.Children = nil
@@ -1098,7 +1088,6 @@ func (t *Trait) SyncWithSource() {
 				t.Prereq = other.Prereq.CloneResolvingEmpty(false, true)
 				if t.Container() {
 					t.TraitContainerSyncData = other.TraitContainerSyncData
-					t.TemplatePicker = other.TemplatePicker.Clone()
 				} else {
 					t.TraitNonContainerSyncData = other.TraitNonContainerSyncData
 					t.Weapons = CloneWeapons(other.Weapons, t, Reference)
@@ -1210,7 +1199,6 @@ func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply boo
 			t.Study[i] = other.Study[i].Clone()
 		}
 	}
-	t.TemplatePicker = t.TemplatePicker.Clone()
 }
 
 // CanPreconfigureContainer implements Preconfigurable.

--- a/ux/choices.go
+++ b/ux/choices.go
@@ -32,20 +32,17 @@ func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent 
 		return typePopup, comparisonPopup, field
 	}
 
+	var types []picker.Type
 	var tp *gurps.TemplatePicker
 	if pickable, ok := any(e.editorData).(gurps.TemplatePickerProvider); ok {
-		tp = pickable.TemplatePickerData()
+		types, tp = pickable.TemplatePickerData()
 	} else {
 		return typePopup, comparisonPopup, field
 	}
 
-	if tp == nil {
-		tp = &gurps.TemplatePicker{}
-	}
-
 	last := tp.Type
 	wrapper := addFlowWrapper(parent, i18n.Text("Choices"), 3)
-	typePopup = addPopup(wrapper, picker.Types, &tp.Type)
+	typePopup = addPopup(wrapper, types, &tp.Type)
 	text := i18n.Text("Choice Quantifier")
 	comparisonPopup, field = addNumericCriteriaPanel(wrapper, nil, "", "", text, &tp.Qualifier, fxp.Min, fxp.Max, 1, false, false)
 
@@ -60,11 +57,12 @@ func addChoices[N gurps.Node[N], D gurps.EditorData[N]](e *editor[N, D], parent 
 	}
 
 	typePopup.SelectionChangedCallback = func(p *unison.PopupMenu[picker.Type]) {
-		if item, ok := p.Selected(); ok {
+		if item, selected := p.Selected(); selected {
 			tp.Type = item
 			if last == picker.NotApplicable && item != picker.NotApplicable {
 				tp.Qualifier.Qualifier = fxp.One
-				if syncer, ok2 := field.(Syncer); ok2 {
+				comparisonPopup.SelectIndex(criteria.ExtractNumericComparisonIndex(string(criteria.AnyNumber)))
+				if syncer, ok := field.(Syncer); ok {
 					syncer.Sync()
 				}
 			}

--- a/ux/equipment_editor.go
+++ b/ux/equipment_editor.go
@@ -81,6 +81,7 @@ func initEquipmentEditor(carried bool) func(e *editor[*gurps.Equipment, *gurps.E
 		addCheckBox(content, i18n.Text("Ignore weight for skills"), &e.editorData.WeightIgnoredForSkills)
 		addSwitchedOnCheckBox(content, &e.editorData.SwitchedOn)
 		addPreconfigurable(e, content)
+		addChoices(e, content, true)
 		resolvedMaxUses := func() int { return cloneEquipmentWithOverlay(e.target, e.editorData).ResolvedMaxUses() }
 		usesLabel := i18n.Text("Uses Left")
 		wrapper := addFlowWrapper(content, usesLabel, 5)

--- a/ux/template.go
+++ b/ux/template.go
@@ -802,9 +802,10 @@ func rawPoints[T gurps.Node[T]](child T) fxp.Int {
 	}
 	if child.Container() {
 		if pickable, ok := any(child).(gurps.TemplatePickerProvider); ok {
-			tp := pickable.TemplatePickerData()
-			if tp != nil && tp.Type == picker.Points && tp.Qualifier.Compare == criteria.EqualsNumber {
-				return tp.Qualifier.Qualifier
+			if _, tp := pickable.TemplatePickerData(); tp.Type == picker.Points {
+				if tp.Qualifier.Compare == criteria.EqualsNumber {
+					return tp.Qualifier.Qualifier
+				}
 			}
 		}
 	}

--- a/ux/template.go
+++ b/ux/template.go
@@ -382,6 +382,9 @@ func processTemplatePickers(rows *templateRows) bool {
 	if rows.spells, abort = processPickerRows(rows.spells); abort {
 		return false
 	}
+	if rows.equipment, abort = processPickerRows(rows.equipment); abort {
+		return false
+	}
 	return true
 }
 

--- a/ux/template_picker.go
+++ b/ux/template_picker.go
@@ -46,12 +46,13 @@ func processPickerRow[T gurps.Node[T]](row T) (revised []T, abort bool) {
 		return []T{row}, false
 	}
 	children := row.NodeChildren()
-	tpp, ok := any(row).(gurps.TemplatePickerProvider)
 	var tp *gurps.TemplatePicker
-	if ok {
-		_, tp = tpp.TemplatePickerData()
+	if tpp, ok := any(row).(gurps.TemplatePickerProvider); ok {
+		if ok {
+			_, tp = tpp.TemplatePickerData()
+		}
 	}
-	if !ok || tp.IsZero() {
+	if tp.IsZero() {
 		rowChildren := make([]T, 0, len(children))
 		for _, child := range children {
 			var result []T
@@ -104,6 +105,10 @@ func processPickerRow[T gurps.Node[T]](row T) (revised []T, abort bool) {
 					total += fxp.One
 				case picker.Points:
 					total += rawPoints(children[i])
+				case picker.Quantity, picker.Cost, picker.Weight:
+					if equipment, valid := any(children[i]).(*gurps.Equipment); valid {
+						total += equipmentPickerMeasure(equipment, tp.Type)
+					}
 				}
 			}
 		}
@@ -256,6 +261,9 @@ func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, pt picker.Type, 
 		}
 		pageRef = actual.PageRef
 		pageRefHighlight = actual.PageRefHighlight
+	case *gurps.Equipment:
+		pageRef = actual.PageRef
+		pageRefHighlight = actual.PageRefHighlight
 	}
 	if pageRef != "" {
 		if pageRefs := ExtractPageReferences(pageRef); len(pageRefs) > 0 {
@@ -310,10 +318,63 @@ func updatePickerCheckBoxTitle[T gurps.Node[T]](checkBox *unison.CheckBox, row T
 		}
 	case picker.Count:
 		// NOP
+	case picker.Quantity, picker.Cost, picker.Weight:
+		if equipment, ok := any(row).(*gurps.Equipment); ok {
+			title += equipmentPickerMeasureSuffix(equipment, pt)
+		}
 	default:
 		// NOP
 	}
 	checkBox.SetTitle(title)
+}
+
+// equipmentPickerMeasure returns the quantity that a piece of equipment contributes toward a Quantity, Cost, or
+// Weight picker's running total.
+func equipmentPickerMeasure(equipment *gurps.Equipment, pt picker.Type) fxp.Int {
+	switch pt {
+	case picker.Quantity:
+		return equipment.Quantity
+	case picker.Cost:
+		return equipment.ExtendedValue()
+	case picker.Weight:
+		units := gurps.SheetSettingsFor(gurps.EntityFromNode(equipment)).DefaultWeightUnits
+		return fxp.Int(equipment.ExtendedWeight(false, units))
+	default:
+		return 0
+	}
+}
+
+// equipmentPickerMeasureSuffix returns the "[...]" tag to append to a checkbox title showing the value that
+// contributes to the active picker's total, formatted appropriately for its type. Count and NotApplicable pickers
+// have nothing informative to add per-row, so they return an empty string.
+func equipmentPickerMeasureSuffix(equipment *gurps.Equipment, pt picker.Type) string {
+	switch pt {
+	case picker.Quantity:
+		qty := equipment.Quantity
+		if qty == 0 {
+			return ""
+		}
+		unitLabel := i18n.Text("units")
+		if qty == fxp.One {
+			unitLabel = i18n.Text("unit")
+		}
+		return fmt.Sprintf(" [%s %s]", qty.Comma(), unitLabel)
+	case picker.Cost:
+		cost := equipment.ExtendedValue()
+		if cost == 0 {
+			return ""
+		}
+		return fmt.Sprintf(" [%s]", cost.Comma())
+	case picker.Weight:
+		units := gurps.SheetSettingsFor(gurps.EntityFromNode(equipment)).DefaultWeightUnits
+		weight := equipment.ExtendedWeight(false, units)
+		if weight == 0 {
+			return ""
+		}
+		return fmt.Sprintf(" [%s]", units.Format(weight))
+	default:
+		return ""
+	}
 }
 
 func pickerRowLevelEditor(trait *gurps.Trait, checkBox *unison.CheckBox, pt picker.Type, callback func()) {

--- a/ux/template_picker.go
+++ b/ux/template_picker.go
@@ -47,7 +47,11 @@ func processPickerRow[T gurps.Node[T]](row T) (revised []T, abort bool) {
 	}
 	children := row.NodeChildren()
 	tpp, ok := any(row).(gurps.TemplatePickerProvider)
-	if !ok || tpp.TemplatePickerData().IsZero() {
+	var tp *gurps.TemplatePicker
+	if ok {
+		_, tp = tpp.TemplatePickerData()
+	}
+	if !ok || tp.IsZero() {
 		rowChildren := make([]T, 0, len(children))
 		for _, child := range children {
 			var result []T
@@ -61,7 +65,6 @@ func processPickerRow[T gurps.Node[T]](row T) (revised []T, abort bool) {
 		SetParents(rowChildren, row)
 		return []T{row}, false
 	}
-	tp := tpp.TemplatePickerData()
 
 	list := unison.NewPanel()
 	list.SetBorder(unison.NewEmptyBorder(geom.NewUniformInsets(unison.StdHSpacing)))
@@ -126,7 +129,7 @@ func processPickerRow[T gurps.Node[T]](row T) (revised []T, abort bool) {
 		}
 	}
 	for _, child := range children {
-		boxes = addPickerRow(list, child, callback, boxes)
+		boxes = addPickerRow(list, child, tp.Type, callback, boxes)
 	}
 
 	scroll := unison.NewScrollPanel()
@@ -219,7 +222,7 @@ func pickerMatchStateColor(matches bool) unison.Color {
 	return unison.ThemeError.GetColor()
 }
 
-func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, callback func(), boxes []*unison.CheckBox) []*unison.CheckBox {
+func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, pt picker.Type, callback func(), boxes []*unison.CheckBox) []*unison.CheckBox {
 	wrapper := unison.NewPanel()
 	wrapper.SetLayout(&unison.FlexLayout{
 		Columns:  2,
@@ -227,7 +230,7 @@ func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, callback func(),
 	})
 	parent.AddChild(wrapper)
 	checkBox := unison.NewCheckBox()
-	updatePickerCheckBoxTitle(checkBox, row)
+	updatePickerCheckBoxTitle(checkBox, row, pt)
 	checkBox.ClickCallback = callback
 	wrapper.AddChild(checkBox)
 	boxes = append(boxes, checkBox)
@@ -237,19 +240,19 @@ func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, callback func(),
 	switch actual := any(row).(type) {
 	case *gurps.Trait:
 		if actual.IsLeveled() {
-			onClick = func() { pickerRowLevelEditor(actual, checkBox, callback) }
+			onClick = func() { pickerRowLevelEditor(actual, checkBox, pt, callback) }
 		}
 		pageRef = actual.PageRef
 		pageRefHighlight = actual.PageRefHighlight
 	case *gurps.Skill:
 		if !actual.Container() {
-			onClick = func() { pickerRowPointEditor(actual, checkBox, callback) }
+			onClick = func() { pickerRowPointEditor(actual, checkBox, pt, callback) }
 		}
 		pageRef = actual.PageRef
 		pageRefHighlight = actual.PageRefHighlight
 	case *gurps.Spell:
 		if !actual.Container() {
-			onClick = func() { pickerRowPointEditor(actual, checkBox, callback) }
+			onClick = func() { pickerRowPointEditor(actual, checkBox, pt, callback) }
 		}
 		pageRef = actual.PageRef
 		pageRefHighlight = actual.PageRefHighlight
@@ -293,20 +296,27 @@ func addPickerRow[T gurps.Node[T]](parent *unison.Panel, row T, callback func(),
 	return boxes
 }
 
-func updatePickerCheckBoxTitle[T gurps.Node[T]](checkBox *unison.CheckBox, row T) {
+func updatePickerCheckBoxTitle[T gurps.Node[T]](checkBox *unison.CheckBox, row T, pt picker.Type) {
 	title := row.String()
-	points := rawPoints(row)
-	if points != 0 {
-		pointsLabel := i18n.Text("points")
-		if points == fxp.One {
-			pointsLabel = i18n.Text("point")
+	switch pt {
+	case picker.Points:
+		points := rawPoints(row)
+		if points != 0 {
+			pointsLabel := i18n.Text("points")
+			if points == fxp.One {
+				pointsLabel = i18n.Text("point")
+			}
+			title += fmt.Sprintf(" [%s %s]", points.Comma(), pointsLabel)
 		}
-		title += fmt.Sprintf(" [%s %s]", points.Comma(), pointsLabel)
+	case picker.Count:
+		// NOP
+	default:
+		// NOP
 	}
 	checkBox.SetTitle(title)
 }
 
-func pickerRowLevelEditor(trait *gurps.Trait, checkBox *unison.CheckBox, callback func()) {
+func pickerRowLevelEditor(trait *gurps.Trait, checkBox *unison.CheckBox, pt picker.Type, callback func()) {
 	levels := trait.Levels
 	maximum := trait.ResolvedMaxLevels()
 	fieldMax := fxp.MaxBasePoints
@@ -343,7 +353,7 @@ func pickerRowLevelEditor(trait *gurps.Trait, checkBox *unison.CheckBox, callbac
 		return
 	}
 	trait.Levels = levels
-	updatePickerCheckBoxTitle(checkBox, trait)
+	updatePickerCheckBoxTitle(checkBox, trait, pt)
 	callback()
 	checkBox.MarkForLayoutRecursivelyUpward()
 	checkBox.MarkForRedraw()
@@ -354,7 +364,7 @@ type pickerRowPointEditorTypes[T gurps.Node[T]] interface {
 	gurps.RawPointsAdjuster
 }
 
-func pickerRowPointEditor[T pickerRowPointEditorTypes[T]](node T, checkBox *unison.CheckBox, callback func()) {
+func pickerRowPointEditor[T pickerRowPointEditorTypes[T]](node T, checkBox *unison.CheckBox, pt picker.Type, callback func()) {
 	points := node.RawPoints()
 	panel := unison.NewPanel()
 	panel.SetLayout(&unison.FlexLayout{
@@ -381,7 +391,7 @@ func pickerRowPointEditor[T pickerRowPointEditorTypes[T]](node T, checkBox *unis
 		return
 	}
 	node.SetRawPoints(points)
-	updatePickerCheckBoxTitle(checkBox, node)
+	updatePickerCheckBoxTitle(checkBox, node, pt)
 	callback()
 	checkBox.MarkForLayoutRecursivelyUpward()
 	checkBox.MarkForRedraw()


### PR DESCRIPTION
Traits, Skills, and Spells already support template choices. This is adding the ability to set an equipment container to a template choice container. This means a user selects based on count, quantity, cost, or weight and then the selected items are added to the character sheet while the template choice group is not added.

This builds on PR (#1121)