### PR TITLE
Adding missing criteria functions

### DIFF
--- a/model/criteria/numeric_comparison.go
+++ b/model/criteria/numeric_comparison.go
@@ -99,6 +99,12 @@ func (n NumericComparison) DescribeWith(qualifier string) string {
 
 // AltDescribe returns an alternate description of this NumericCompareType using a qualifier.
 func (n NumericComparison) AltDescribe(qualifier fxp.Int) string {
+	return n.AltDescribeWith(qualifier.String())
+}
+
+// AltDescribeWith returns an alternate description of this NumericCompareType using an already-formatted qualifier.
+// Use this for a qualifier that carries more than a bare number, such as a weight with its units.
+func (n NumericComparison) AltDescribeWith(qualifier string) string {
 	v := n.EnsureValid()
 	result := v.AltString()
 	if v == AnyNumber {
@@ -107,7 +113,7 @@ func (n NumericComparison) AltDescribe(qualifier fxp.Int) string {
 	if result != "" {
 		result += " "
 	}
-	return result + qualifier.String()
+	return result + qualifier
 }
 
 // Matches performs a comparison and returns true if the data matches.

--- a/model/criteria/weight.go
+++ b/model/criteria/weight.go
@@ -50,10 +50,22 @@ func (w Weight) String() string {
 	return w.Describe(fxp.Pound)
 }
 
+// AltString returns the alternate description.
+func (w Weight) AltString() string {
+	return w.AltDescribe(fxp.Pound)
+}
+
 // Describe returns a description of the criteria, with the qualifier expressed in the given units. Note that the
 // qualifier must be described as a weight rather than as a bare number, since the units are part of its meaning.
 func (w Weight) Describe(units fxp.WeightUnit) string {
 	return w.Compare.DescribeWith(units.Format(w.Qualifier))
+}
+
+// AltDescribe returns an alternate description of the criteria, with the qualifier expressed in the given units.
+// Note that the qualifier must be described as a weight rather than as a bare number, since the units are part
+// of its meaning.
+func (w Weight) AltDescribe(units fxp.WeightUnit) string {
+	return w.Compare.AltDescribeWith(units.Format(w.Qualifier))
 }
 
 // Hash writes this object's contents into the hasher.

--- a/model/criteria/weight_test.go
+++ b/model/criteria/weight_test.go
@@ -33,12 +33,18 @@ func TestWeightDescriptionHasUnits(t *testing.T) {
 	c.Equal("is at least 5 lb", weight(criteria.AtLeastNumber, fivePounds).String())
 	c.Equal("is 5 lb", weight(criteria.EqualsNumber, fivePounds).String())
 	c.Equal("is not 5 lb", weight(criteria.NotEqualsNumber, fivePounds).String())
+	c.Equal("at most 5 lb", weight(criteria.AtMostNumber, fivePounds).AltString())
+	c.Equal("at least 5 lb", weight(criteria.AtLeastNumber, fivePounds).AltString())
+	c.Equal("5 lb", weight(criteria.EqualsNumber, fivePounds).AltString())
+	c.Equal("not 5 lb", weight(criteria.NotEqualsNumber, fivePounds).AltString())
 
 	// "is anything" has no qualifier to describe, so no units appear.
 	c.Equal("is anything", weight(criteria.AnyNumber, fivePounds).String())
+	c.Equal("anything", weight(criteria.AnyNumber, fivePounds).AltString())
 
 	// An invalid comparison is treated as "any", just as it is when matching.
 	c.Equal("is anything", weight(criteria.NumericComparison("bogus"), fivePounds).String())
+	c.Equal("anything", weight(criteria.NumericComparison("bogus"), fivePounds).AltString())
 }
 
 // TestWeightDescriptionUsesRequestedUnits verifies that a weight criteria can be described in the units the user has
@@ -49,11 +55,16 @@ func TestWeightDescriptionUsesRequestedUnits(t *testing.T) {
 	c.Equal("is at most 5 lb", crit.Describe(fxp.Pound))
 	c.Equal("is at most 2.5 kg", crit.Describe(fxp.Kilogram))
 	c.Equal("is at most 80 oz", crit.Describe(fxp.Ounce))
+	c.Equal("at most 5 lb", crit.AltDescribe(fxp.Pound))
+	c.Equal("at most 2.5 kg", crit.AltDescribe(fxp.Kilogram))
+	c.Equal("at most 80 oz", crit.AltDescribe(fxp.Ounce))
 
 	// The units are those asked for, not those the qualifier was created with.
 	metric := weight(criteria.AtLeastNumber, fxp.WeightFromInteger(2, fxp.Kilogram))
 	c.Equal("is at least 2 kg", metric.Describe(fxp.Kilogram))
 	c.Equal("is at least 4 lb", metric.Describe(fxp.Pound))
+	c.Equal("at least 2 kg", metric.AltDescribe(fxp.Kilogram))
+	c.Equal("at least 4 lb", metric.AltDescribe(fxp.Pound))
 }
 
 // TestWeightHashIgnoresQualifierWhenAny verifies that a weight criteria whose comparison is "is anything" hashes the


### PR DESCRIPTION
- Added `AltDescribeWith` function to the `NumericComparison` type. 
- Added `AltString` function to the `Weight` type.
- Added `AltDescribe` function to the `Weight` type. 
- Added extra tests for `Weight` type.