### PR TITLE
Adding Alternative Ability Slots

### DIFF
--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -10,6 +10,7 @@
 package gurps
 
 import (
+	"cmp"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"fmt"
@@ -134,9 +135,10 @@ type TraitNonContainerSyncData struct {
 
 // TraitContainerSyncData holds the Trait sync data that is only applicable to traits that are containers.
 type TraitContainerSyncData struct {
-	Ancestry       string         `json:"ancestry,omitzero"`
-	TemplatePicker TemplatePicker `json:"template_picker,omitzero"`
-	ContainerType  container.Type `json:"container_type,omitzero"`
+	Ancestry         string         `json:"ancestry,omitzero"`
+	TemplatePicker   TemplatePicker `json:"template_picker,omitzero"`
+	ContainerType    container.Type `json:"container_type,omitzero"`
+	AlternativeSlots int            `json:"alternative_slots,omitzero"`
 }
 
 type traitListData struct {
@@ -439,7 +441,11 @@ func (t *Trait) CellData(columnID int, data *CellData) {
 		if t.Container() {
 			switch t.ContainerType {
 			case container.AlternativeAbilities:
-				data.InlineTag = i18n.Text("Alternate")
+				if slots := t.ResolvedAlternativeSlots(); slots > 1 {
+					data.InlineTag = fmt.Sprintf(i18n.Text("Alternate x%d"), slots)
+				} else {
+					data.InlineTag = i18n.Text("Alternate")
+				}
 			case container.Ancestry:
 				data.InlineTag = i18n.Text("Ancestry")
 			case container.Attributes:
@@ -638,18 +644,11 @@ func (t *Trait) AdjustedPoints() fxp.Int {
 		for i, one := range t.Children {
 			values[i] = one.AdjustedPoints()
 		}
-		if len(values) != 0 {
-			// The most expensive child is billed at full cost and the rest at 20%, so the running total starts at the
-			// largest child's cost. It must come from the values themselves rather than from zero, since a set of
-			// children that all cost negative points has no member matching a zero maximum, which would leave every
-			// one of them billed at 20%.
-			points = slices.Max(values)
-		}
-		maximum := points
-		found := false
-		for _, v := range values {
-			if !found && maximum == v {
-				found = true
+		slices.SortFunc(values, func(a, b fxp.Int) int { return cmp.Compare(b, a) })
+		slots := min(t.ResolvedAlternativeSlots(), len(values))
+		for i, v := range values {
+			if i < slots {
+				points += v
 			} else {
 				points += fxp.ApplyRounding(v.Mul(fxp.Twenty).Div(fxp.Hundred), t.RoundCostDown)
 			}
@@ -1057,6 +1056,12 @@ func (t *Trait) Kind() string {
 func (t *Trait) ClearUnusedFieldsForType() {
 	if t.Container() {
 		t.TraitNonContainerOnlyEditData = TraitNonContainerOnlyEditData{}
+		if t.ContainerType != container.Ancestry {
+			t.Ancestry = ""
+		}
+		if t.ContainerType != container.AlternativeAbilities {
+			t.AlternativeSlots = 0
+		}
 	} else {
 		t.TraitContainerSyncData = TraitContainerSyncData{}
 		t.Children = nil
@@ -1139,9 +1144,20 @@ func (t *TraitNonContainerSyncData) hash(h hash.Hash) {
 }
 
 func (t *TraitContainerSyncData) hash(h hash.Hash) {
-	xhash.StringWithLen(h, t.Ancestry)
 	t.TemplatePicker.Hash(h)
 	xhash.Num8(h, t.ContainerType)
+	switch t.ContainerType {
+	case container.Ancestry:
+		xhash.StringWithLen(h, t.Ancestry)
+	case container.AlternativeAbilities:
+		xhash.Num64(h, t.AlternativeSlots)
+	}
+}
+
+// ResolvedAlternativeSlots returns the number of children that should be billed at full price when this is
+// an Alternative Abilities container, i.e. the number of alternative abilities that can be active simultaneously.
+func (t *TraitContainerSyncData) ResolvedAlternativeSlots() int {
+	return max(t.AlternativeSlots, 1)
 }
 
 // CopyFrom implements node.EditorData.

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -1061,6 +1061,8 @@ func (t *Trait) ClearUnusedFieldsForType() {
 		}
 		if t.ContainerType != container.AlternativeAbilities {
 			t.AlternativeSlots = 0
+		} else {
+			t.AlternativeSlots = max(t.AlternativeSlots, 1)
 		}
 	} else {
 		t.TraitContainerSyncData = TraitContainerSyncData{}

--- a/model/gurps/trait_test.go
+++ b/model/gurps/trait_test.go
@@ -220,6 +220,36 @@ func TestAlternativeAbilitiesCost(t *testing.T) {
 		"mixed children bill the most expensive one at full cost")
 }
 
+// TestAlternativeAbilitiesMultipleSlots verifies that setting AlternativeSlots > 1 bills that many of the
+// most expensive children at full cost and the rest at 20%.
+func TestAlternativeAbilitiesMultipleSlots(t *testing.T) {
+	c := check.New(t)
+
+	newAltContainer := func(slots int, childPoints ...int) *Trait {
+		parent := NewTrait(nil, nil, true)
+		parent.ContainerType = container.AlternativeAbilities
+		parent.AlternativeSlots = slots
+		for _, points := range childPoints {
+			child := NewTrait(nil, parent, false)
+			child.BasePoints = fxp.FromInteger(points)
+			parent.Children = append(parent.Children, child)
+		}
+		return parent
+	}
+
+	// A stored value of 0 means "unset" and behaves like a single slot: 20 + 2.
+	c.Equal(fxp.FromInteger(22), newAltContainer(0, 20, 10).AdjustedPoints(),
+		"an unset slot count resolves to a single slot")
+
+	// With 2 slots, the two most expensive children (20 and 10) are billed in full and the rest at 20%: 20 + 10 + 1.
+	c.Equal(fxp.FromInteger(31), newAltContainer(2, 20, 10, 5).AdjustedPoints(),
+		"two slots bill the two most expensive children at full cost")
+
+	// A slot count larger than the number of children bills every child in full: 20 + 10 + 5.
+	c.Equal(fxp.FromInteger(35), newAltContainer(5, 20, 10, 5).AdjustedPoints(),
+		"a slot count exceeding the child count bills every child at full cost")
+}
+
 // TestInheritedModifiersAreNotRepointed verifies that computing a child's points costs an inherited modifier against
 // that child without re-pointing the modifier at it, leaving the container's own display of the modifier intact.
 func TestInheritedModifiersAreNotRepointed(t *testing.T) {

--- a/ux/trait_editor.go
+++ b/ux/trait_editor.go
@@ -10,6 +10,8 @@
 package ux
 
 import (
+	"strconv"
+
 	"github.com/richardwilkes/gcs/v5/model/fxp"
 	"github.com/richardwilkes/gcs/v5/model/gurps"
 	"github.com/richardwilkes/gcs/v5/model/gurps/enums/container"
@@ -112,6 +114,7 @@ func initTraitEditor(e *editor[*gurps.Trait, *gurps.TraitEditData], content *uni
 	}
 	addLabelAndPopup(content, i18n.Text("Frequency of Appearance"), "", frequency.Rolls, &e.editorData.Frequency)
 	var ancestryPopup *unison.PopupMenu[string]
+	var slotsField *IntegerField
 	if e.target.Container() {
 		addLabelAndPopup(content, i18n.Text("Container Type"), "", container.Types,
 			&e.editorData.ContainerType)
@@ -123,6 +126,10 @@ func initTraitEditor(e *editor[*gurps.Trait, *gurps.TraitEditData], content *uni
 		}
 		ancestryPopup = addLabelAndPopup(content, i18n.Text("Ancestry"), "", choices, &e.editorData.Ancestry)
 		adjustPopupBlank(ancestryPopup, e.editorData.ContainerType != container.Ancestry)
+		slotsField = addLabelAndIntegerField(content, nil, "", i18n.Text("Alternative Slots"),
+			i18n.Text("How many of this container's children may be active at once; that many of the most expensive children are billed at full cost and the rest at 20%"),
+			&e.editorData.AlternativeSlots, 1, 20)
+		adjustFieldBlank(slotsField, e.editorData.ContainerType != container.AlternativeAbilities)
 	}
 	addChoices(e, content, true)
 	addPageRefLabelAndField(content, &e.editorData.PageRef)
@@ -172,6 +179,19 @@ func initTraitEditor(e *editor[*gurps.Trait, *gurps.TraitEditData], content *uni
 				}
 			} else {
 				adjustPopupBlank(ancestryPopup, true)
+			}
+		}
+		if slotsField != nil {
+			if e.editorData.ContainerType == container.AlternativeAbilities {
+				if !slotsField.Enabled() {
+					adjustFieldBlank(slotsField, false)
+					if e.editorData.AlternativeSlots < 1 {
+						e.editorData.AlternativeSlots = 1
+					}
+					slotsField.SetText(strconv.Itoa(e.editorData.AlternativeSlots))
+				}
+			} else {
+				adjustFieldBlank(slotsField, true)
 			}
 		}
 	}


### PR DESCRIPTION
The trait alternative ability container only supports a single alternative ability "slot" currently. The rules mention that you can have multiple slots. This adds a slot configuration, adjusts the table to indicate the slot count, and adjusts the point calculations for the container.