### PR TITLE
Fixing regression on when dialog config triggered

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,3 +21,5 @@
   equipment modifiers already were.
 - The tooltip for a per-level weapon bonus attached to a trait modifier now reports the same amount the weapon actually
   receives, rather than an amount based on the trait's level.
+- Copying items from a template to a character is now correctly triggering modifier and nameable configuration. Applying
+  templates was not affected by this bug. (#1126)

--- a/ux/table.go
+++ b/ux/table.go
@@ -396,10 +396,8 @@ func copySelectionToTemplate[T gurps.Node[T]](table *unison.Table[*Node[T]]) {
 // then folding the points of rows that duplicate ones already present into those rows. Does nothing when the
 // destination isn't a character or loot sheet.
 func processCopiedRows[T gurps.Node[T]](source, target *unison.Table[*Node[T]]) {
-	if shouldProcessModifiersAndNameables(target) {
-		// Only process modifiers and nameables when copying from something besides a character or loot sheet; rows already
-		// on a sheet have had these resolved.
-		if !shouldProcessModifiersAndNameables(source) {
+	if shouldProcessModifiersAndNameablesTo(target) {
+		if shouldProcessModifiersAndNameablesFrom(source) {
 			// Answering the modifier prompt rebuilds the owner, and that rebuild can replace the table underneath us: only
 			// the modifiers that are enabled count toward a row having switchable features, so turning one on or off can
 			// add or take away the switch column, and a list can only change its columns by building a new table. An

--- a/ux/table_drop.go
+++ b/ux/table_drop.go
@@ -166,10 +166,8 @@ func didDropCallback[T gurps.Node[T]](undo *unison.UndoEdit[*TableDragUndoEditDa
 		from = liveTable(from)
 		to = liveTable(to)
 	}
-	if shouldProcessModifiersAndNameables(to) {
-		// Only process modifiers and nameables when the drop comes from something besides a character, loot sheet
-		// or template; rows already on one of those have had these resolved.
-		if !shouldProcessModifiersAndNameables(from) {
+	if shouldProcessModifiersAndNameablesTo(to) {
+		if shouldProcessModifiersAndNameablesFrom(from) {
 			// Answering the modifier prompt rebuilds the owner all over again, and that rebuild can replace the tables
 			// just as the one above did: only the modifiers that are enabled count toward a row having switchable
 			// features, so turning one on or off can add or take away the switch column, and a list can only change its
@@ -223,7 +221,21 @@ func dropRebuilder(table unison.Paneler) Rebuildable {
 	return unison.Ancestor[Rebuildable](table)
 }
 
-func shouldProcessModifiersAndNameables(panel unison.Paneler) bool {
+// shouldProcessModifiersAndNameablesFrom checks if the copy source should process modifiers and nameables
+func shouldProcessModifiersAndNameablesFrom(panel unison.Paneler) bool {
+	if xreflect.IsNil(panel) {
+		return false
+	}
+	switch unison.AncestorOrSelf[unison.Dockable](panel).(type) {
+	case *Sheet, *LootSheet:
+		return false
+	default:
+		return true
+	}
+}
+
+// shouldProcessModifiersAndNameablesFrom checks if the copy destination should process modifiers and nameables
+func shouldProcessModifiersAndNameablesTo(panel unison.Paneler) bool {
 	if xreflect.IsNil(panel) {
 		return false
 	}

--- a/ux/table_drop_test.go
+++ b/ux/table_drop_test.go
@@ -190,6 +190,28 @@ func TestAltDropNotifiesTheTable(t *testing.T) {
 	c.Equal(1, notified, "a declined drop must not notify the table")
 }
 
+// TestShouldProcessModifiersAndNameables verifies that a copy is prompted for modifiers and nameables when it lands on
+// a sheet, loot sheet or template and comes from anywhere except a sheet or loot sheet -- including a template, which
+// a prior refactor collapsed into a single predicate shared by both the source and destination checks. That shared
+// predicate answered true for a template on either side, so a copy from a template onto a sheet was mistaken for one
+// arriving from a sheet and silently skipped its prompts.
+func TestShouldProcessModifiersAndNameables(t *testing.T) {
+	c := check.New(t)
+	sheet := newTestSheetForTemplate(t)
+	loot := newTestLootSheet(t)
+	template := newTestTemplateWithBodyType("")
+
+	c.False(shouldProcessModifiersAndNameablesFrom(sheet.Traits.Table), "copying from a sheet")
+	c.False(shouldProcessModifiersAndNameablesFrom(loot.Equipment.Table), "copying from a loot sheet")
+	c.True(shouldProcessModifiersAndNameablesFrom(template.Traits.Table), "copying from a template")
+	c.True(shouldProcessModifiersAndNameablesFrom(newLibraryStyleTraitsTable()), "copying from a library list")
+
+	c.True(shouldProcessModifiersAndNameablesTo(sheet.Traits.Table), "copying to a sheet")
+	c.True(shouldProcessModifiersAndNameablesTo(loot.Equipment.Table), "copying to a loot sheet")
+	c.True(shouldProcessModifiersAndNameablesTo(template.Traits.Table), "copying to a template")
+	c.False(shouldProcessModifiersAndNameablesTo(newLibraryStyleTraitsTable()), "copying to a library list")
+}
+
 // TestDropWithinASheetSurvivesTheSourceTableBeingReplaced verifies that a drag from one list on a sheet to another is
 // still recognized as coming from that sheet after the rebuild the drop triggers. Moving the only switchable item out
 // of the carried equipment list takes the switch column away from it, and a list can only change its columns by being


### PR DESCRIPTION
The modifier and nameables config dialog is meant to trigger when copying *from* anywhere except Sheet/Loot and *to* Sheet/Loot/Template. This regressed recently and this is resolving the regression.