### PR TITLE
Refactoring Modifier Nodes

### DIFF
--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -42,6 +42,7 @@ import (
 var (
 	_ = assertNode[*Equipment]
 	_ = assertEditorData[*EquipmentEditData]
+	_ = assertModifiable[*EquipmentEditData]
 
 	_ WeaponOwner       = &Equipment{}
 	_ LeveledOwner      = &Equipment{}
@@ -89,14 +90,18 @@ type EquipmentData struct {
 // EquipmentEditData holds the Equipment data that can be edited by the UI detail editor.
 type EquipmentEditData struct {
 	EquipmentSyncData
-	VTTNotes     string               `json:"vtt_notes,omitzero"`
-	Replacements map[string]string    `json:"replacements,omitempty"`
-	Modifiers    []*EquipmentModifier `json:"modifiers,omitempty"`
-	RatedST      fxp.Int              `json:"rated_strength,omitzero"`
-	Quantity     fxp.Int              `json:"quantity"`
-	Level        fxp.Int              `json:"level,omitzero"`
-	Uses         int                  `json:"uses,omitzero"`
-	Equipped     bool                 `json:"equipped,omitzero"`
+	VTTNotes     string            `json:"vtt_notes,omitzero"`
+	Replacements map[string]string `json:"replacements,omitempty"`
+
+	// Leverage a default generic implementation of the Modifiable constraint that makes this a ModifiableNode
+	modifiable[*EquipmentModifier, *Equipment]
+
+	RatedST  fxp.Int `json:"rated_strength,omitzero"`
+	Quantity fxp.Int `json:"quantity"`
+	Level    fxp.Int `json:"level,omitzero"`
+	Uses     int     `json:"uses,omitzero"`
+	Equipped bool    `json:"equipped,omitzero"`
+
 	ItemSwitch
 	preconfigurable
 }
@@ -623,7 +628,7 @@ func (e *Equipment) SetDataOwner(owner DataOwner) {
 		}
 	}
 	for _, m := range e.Modifiers {
-		m.setEquipment(e)
+		m.SetTargetNode(e)
 		m.SetDataOwner(owner)
 	}
 }
@@ -883,7 +888,7 @@ func ContainedWeightAdjustedForModifiers(equipment *Equipment, defUnits fxp.Weig
 		}
 	}
 	Traverse(func(mod *EquipmentModifier) bool {
-		mod.setEquipment(equipment)
+		mod.SetTargetNode(equipment)
 		for _, f := range mod.Features.Active(switchedOn) {
 			if cwr, ok := f.(*ContainedWeightReduction); ok {
 				if cwr.IsPercentageReduction() {
@@ -1225,10 +1230,10 @@ func (e *EquipmentEditData) copyFrom(equipment *Equipment, other *EquipmentEditD
 			// Point the copy at the equipment it belongs to, so that its nameable placeholders can be resolved with
 			// that equipment's replacements. Without this, the copies held in an editor show their raw placeholders
 			// (e.g. "@Material@"), since the accessors fall back to the unsubstituted text when there is no equipment.
-			cloned.setEquipment(equipment)
+			cloned.SetTargetNode(equipment)
 			e.Modifiers = append(e.Modifiers, cloned)
 		}
-		// setEquipment() migrates a modifier's legacy replacements into the equipment it was pointed at, which isn't
+		// SetTargetNode() migrates a modifier's legacy replacements into the equipment it was pointed at, which isn't
 		// the holder of this data when an editor is being populated, so pick up anything it added. This is a no-op
 		// when this data is the equipment's own, since both maps are then the same one.
 		for k, v := range equipment.Replacements {

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -41,8 +41,8 @@ import (
 
 var (
 	_ = assertNode[*Equipment]
+	_ = assertModifiableNode[*Equipment]
 	_ = assertEditorData[*EquipmentEditData]
-	_ = assertModifiable[*EquipmentEditData]
 
 	_ WeaponOwner       = &Equipment{}
 	_ LeveledOwner      = &Equipment{}
@@ -94,7 +94,7 @@ type EquipmentEditData struct {
 	Replacements map[string]string `json:"replacements,omitempty"`
 
 	// Leverage a default generic implementation of the Modifiable constraint
-	modifiable[*EquipmentModifier, *Equipment]
+	modifiable[*Equipment, *EquipmentModifier]
 
 	RatedST  fxp.Int `json:"rated_strength,omitzero"`
 	Quantity fxp.Int `json:"quantity"`
@@ -628,7 +628,7 @@ func (e *Equipment) SetDataOwner(owner DataOwner) {
 		}
 	}
 	for _, m := range e.Modifiers {
-		m.SetTargetNode(e)
+		m.SetTarget(e)
 		m.SetDataOwner(owner)
 	}
 }
@@ -888,7 +888,7 @@ func ContainedWeightAdjustedForModifiers(equipment *Equipment, defUnits fxp.Weig
 		}
 	}
 	Traverse(func(mod *EquipmentModifier) bool {
-		mod.SetTargetNode(equipment)
+		mod.SetTarget(equipment)
 		for _, f := range mod.Features.Active(switchedOn) {
 			if cwr, ok := f.(*ContainedWeightReduction); ok {
 				if cwr.IsPercentageReduction() {
@@ -1230,10 +1230,10 @@ func (e *EquipmentEditData) copyFrom(equipment *Equipment, other *EquipmentEditD
 			// Point the copy at the equipment it belongs to, so that its nameable placeholders can be resolved with
 			// that equipment's replacements. Without this, the copies held in an editor show their raw placeholders
 			// (e.g. "@Material@"), since the accessors fall back to the unsubstituted text when there is no equipment.
-			cloned.SetTargetNode(equipment)
+			cloned.SetTarget(equipment)
 			e.Modifiers = append(e.Modifiers, cloned)
 		}
-		// SetTargetNode() migrates a modifier's legacy replacements into the equipment it was pointed at, which isn't
+		// SetTarget() migrates a modifier's legacy replacements into the equipment it was pointed at, which isn't
 		// the holder of this data when an editor is being populated, so pick up anything it added. This is a no-op
 		// when this data is the equipment's own, since both maps are then the same one.
 		for k, v := range equipment.Replacements {

--- a/model/gurps/equipment.go
+++ b/model/gurps/equipment.go
@@ -93,7 +93,7 @@ type EquipmentEditData struct {
 	VTTNotes     string            `json:"vtt_notes,omitzero"`
 	Replacements map[string]string `json:"replacements,omitempty"`
 
-	// Leverage a default generic implementation of the Modifiable constraint that makes this a ModifiableNode
+	// Leverage a default generic implementation of the Modifiable constraint
 	modifiable[*EquipmentModifier, *Equipment]
 
 	RatedST  fxp.Int `json:"rated_strength,omitzero"`

--- a/model/gurps/equipment_modifier.go
+++ b/model/gurps/equipment_modifier.go
@@ -389,7 +389,7 @@ func (e *EquipmentModifier) DataOwner() DataOwner {
 }
 
 // SetTarget sets the equipment being targeted for modification and configures any sub-components as needed
-func (e *EquipmentModifier) SetTarget(target *Equipment) {
+func (e *EquipmentModifier) SetTarget(target *Equipment) *EquipmentModifier {
 	// Set the target node for this modifier
 	e.equipment = target
 
@@ -405,6 +405,8 @@ func (e *EquipmentModifier) SetTarget(target *Equipment) {
 			child.SetTarget(target)
 		}
 	}
+
+	return e
 }
 
 // SetDataOwner sets the data owner and configures any sub-components as needed.

--- a/model/gurps/equipment_modifier.go
+++ b/model/gurps/equipment_modifier.go
@@ -378,8 +378,8 @@ func (e *EquipmentModifier) Depth() int {
 	return count
 }
 
-// TargetNode returns the equipment being targeted for modification
-func (e *EquipmentModifier) TargetNode() *Equipment {
+// Target returns the equipment being targeted for modification
+func (e *EquipmentModifier) Target() *Equipment {
 	return e.equipment
 }
 
@@ -388,8 +388,8 @@ func (e *EquipmentModifier) DataOwner() DataOwner {
 	return e.owner
 }
 
-// SetTargetNode sets the equipment being targeted for modification and configures any sub-components as needed
-func (e *EquipmentModifier) SetTargetNode(target *Equipment) {
+// SetTarget sets the equipment being targeted for modification and configures any sub-components as needed
+func (e *EquipmentModifier) SetTarget(target *Equipment) {
 	// Set the target node for this modifier
 	e.equipment = target
 
@@ -402,7 +402,7 @@ func (e *EquipmentModifier) SetTargetNode(target *Equipment) {
 	// Cascade the operation
 	if e.Container() {
 		for _, child := range e.Children {
-			child.SetTargetNode(target)
+			child.SetTarget(target)
 		}
 	}
 }

--- a/model/gurps/equipment_modifier.go
+++ b/model/gurps/equipment_modifier.go
@@ -37,6 +37,7 @@ import (
 
 var (
 	_ = assertNode[*EquipmentModifier]
+	_ = assertModifierNode[*EquipmentModifier]
 	_ = assertEditorData[*EquipmentModifierEditData]
 
 	_ GeneralModifier = &EquipmentModifier{}
@@ -377,8 +378,8 @@ func (e *EquipmentModifier) Depth() int {
 	return count
 }
 
-// OwningEquipment returns the owning equipment.
-func (e *EquipmentModifier) OwningEquipment() *Equipment {
+// TargetNode returns the equipment being targeted for modification
+func (e *EquipmentModifier) TargetNode() *Equipment {
 	return e.equipment
 }
 
@@ -387,15 +388,21 @@ func (e *EquipmentModifier) DataOwner() DataOwner {
 	return e.owner
 }
 
-func (e *EquipmentModifier) setEquipment(equipment *Equipment) {
-	e.equipment = equipment
-	if equipment != nil && len(e.Replacements) != 0 {
-		equipment.Replacements = mergeReplacements(equipment.Replacements, e.Replacements)
+// SetTargetNode sets the equipment being targeted for modification and configures any sub-components as needed
+func (e *EquipmentModifier) SetTargetNode(target *Equipment) {
+	// Set the target node for this modifier
+	e.equipment = target
+
+	// COMPAT: Promote replacements from this node up to the target node
+	if target != nil && len(e.Replacements) != 0 {
+		target.Replacements = mergeReplacements(target.Replacements, e.Replacements)
 		e.Replacements = nil
 	}
+
+	// Cascade the operation
 	if e.Container() {
 		for _, child := range e.Children {
-			child.setEquipment(equipment)
+			child.SetTargetNode(target)
 		}
 	}
 }

--- a/model/gurps/equipment_modifier_test.go
+++ b/model/gurps/equipment_modifier_test.go
@@ -48,7 +48,7 @@ func TestEquipmentModifierSyncHashIncludesPerLevelAndPerPoundFlags(t *testing.T)
 }
 
 // TestEquipmentModifierCloneDoesNotShareReplacements verifies that a copy of a modifier still carrying the legacy
-// replacements map gets its own map. setEquipment() installs a modifier's replacements directly into the equipment it
+// replacements map gets its own map. SetTargetNode() installs a modifier's replacements directly into the equipment it
 // is attached to when that equipment has none of its own, so sharing the map let a later merge into the equipment's map
 // write into the library row the copy came from.
 func TestEquipmentModifierCloneDoesNotShareReplacements(t *testing.T) {

--- a/model/gurps/equipment_modifier_test.go
+++ b/model/gurps/equipment_modifier_test.go
@@ -65,15 +65,15 @@ func TestEquipmentModifierCloneDoesNotShareReplacements(t *testing.T) {
 
 	// ...and the next attachment pass migrates the copy's map into the equipment, which has none of its own.
 	equipment := NewEquipment(nil, nil, false)
-	dup.setEquipment(equipment)
+	dup.SetTargetNode(equipment)
 	c.Nil(dup.Replacements, "the copy hands its map off to the equipment")
 	c.Equal(map[string]string{"Material": "Steel"}, equipment.Replacements, "the equipment picks up the replacements")
 
-	// A second modifier attaching to the same equipment takes setEquipment's merge branch, writing into the map the
+	// A second modifier attaching to the same equipment takes SetTargetNode's merge branch, writing into the map the
 	// equipment now holds. That must not reach back into the library row.
 	second := NewEquipmentModifier(nil, nil, false)
 	second.Replacements = map[string]string{"Finish": "Blued"}
-	second.setEquipment(equipment)
+	second.SetTargetNode(equipment)
 	c.Equal(map[string]string{"Material": "Steel", "Finish": "Blued"}, equipment.Replacements,
 		"the equipment merges in the second modifier's replacements")
 	c.Equal(map[string]string{"Material": "Steel"}, library.Replacements, "the library row is left untouched")

--- a/model/gurps/equipment_modifier_test.go
+++ b/model/gurps/equipment_modifier_test.go
@@ -48,7 +48,7 @@ func TestEquipmentModifierSyncHashIncludesPerLevelAndPerPoundFlags(t *testing.T)
 }
 
 // TestEquipmentModifierCloneDoesNotShareReplacements verifies that a copy of a modifier still carrying the legacy
-// replacements map gets its own map. SetTargetNode() installs a modifier's replacements directly into the equipment it
+// replacements map gets its own map. SetTarget() installs a modifier's replacements directly into the equipment it
 // is attached to when that equipment has none of its own, so sharing the map let a later merge into the equipment's map
 // write into the library row the copy came from.
 func TestEquipmentModifierCloneDoesNotShareReplacements(t *testing.T) {
@@ -65,15 +65,15 @@ func TestEquipmentModifierCloneDoesNotShareReplacements(t *testing.T) {
 
 	// ...and the next attachment pass migrates the copy's map into the equipment, which has none of its own.
 	equipment := NewEquipment(nil, nil, false)
-	dup.SetTargetNode(equipment)
+	dup.SetTarget(equipment)
 	c.Nil(dup.Replacements, "the copy hands its map off to the equipment")
 	c.Equal(map[string]string{"Material": "Steel"}, equipment.Replacements, "the equipment picks up the replacements")
 
-	// A second modifier attaching to the same equipment takes SetTargetNode's merge branch, writing into the map the
+	// A second modifier attaching to the same equipment takes SetTarget's merge branch, writing into the map the
 	// equipment now holds. That must not reach back into the library row.
 	second := NewEquipmentModifier(nil, nil, false)
 	second.Replacements = map[string]string{"Finish": "Blued"}
-	second.SetTargetNode(equipment)
+	second.SetTarget(equipment)
 	c.Equal(map[string]string{"Material": "Steel", "Finish": "Blued"}, equipment.Replacements,
 		"the equipment merges in the second modifier's replacements")
 	c.Equal(map[string]string{"Material": "Steel"}, library.Replacements, "the library row is left untouched")

--- a/model/gurps/equipment_test.go
+++ b/model/gurps/equipment_test.go
@@ -86,7 +86,7 @@ func TestEquipmentEditDataResolvesModifierNameables(t *testing.T) {
 	var edit EquipmentEditData
 	edit.CopyFrom(eqp)
 	c.Equal(1, len(edit.Modifiers))
-	c.True(eqp == edit.Modifiers[0].TargetNode(), "the copy points at the equipment being edited")
+	c.True(eqp == edit.Modifiers[0].Target(), "the copy points at the equipment being edited")
 	c.Equal("Steel plating", edit.Modifiers[0].NameWithReplacements())
 	c.Equal("Forged from Steel", edit.Modifiers[0].LocalNotesWithReplacements())
 
@@ -98,7 +98,7 @@ func TestEquipmentEditDataResolvesModifierNameables(t *testing.T) {
 	target := NewEquipment(entity, nil, false)
 	edit.ApplyTo(target)
 	c.Equal(1, len(target.Modifiers))
-	c.True(target == target.Modifiers[0].TargetNode(), "the applied copy points at the equipment it was applied to")
+	c.True(target == target.Modifiers[0].Target(), "the applied copy points at the equipment it was applied to")
 	c.Equal("Steel mesh", target.Modifiers[0].NameWithReplacements())
 }
 
@@ -125,8 +125,8 @@ func TestEquipmentCloneAttachesModifiersToTheClone(t *testing.T) {
 	if len(clone.Modifiers) != 1 || len(clone.Modifiers[0].Children) != 1 {
 		return
 	}
-	c.True(clone == clone.Modifiers[0].TargetNode(), "the clone's modifier points at the clone")
-	c.True(clone == clone.Modifiers[0].Children[0].TargetNode(), "the clone's child modifier points at the clone")
+	c.True(clone == clone.Modifiers[0].Target(), "the clone's modifier points at the clone")
+	c.True(clone == clone.Modifiers[0].Children[0].Target(), "the clone's child modifier points at the clone")
 
 	// Diverging the clone's replacements must move the clone's modifiers only.
 	clone.Replacements["Material"] = "Bronze"

--- a/model/gurps/equipment_test.go
+++ b/model/gurps/equipment_test.go
@@ -86,7 +86,7 @@ func TestEquipmentEditDataResolvesModifierNameables(t *testing.T) {
 	var edit EquipmentEditData
 	edit.CopyFrom(eqp)
 	c.Equal(1, len(edit.Modifiers))
-	c.True(eqp == edit.Modifiers[0].OwningEquipment(), "the copy points at the equipment being edited")
+	c.True(eqp == edit.Modifiers[0].TargetNode(), "the copy points at the equipment being edited")
 	c.Equal("Steel plating", edit.Modifiers[0].NameWithReplacements())
 	c.Equal("Forged from Steel", edit.Modifiers[0].LocalNotesWithReplacements())
 
@@ -98,7 +98,7 @@ func TestEquipmentEditDataResolvesModifierNameables(t *testing.T) {
 	target := NewEquipment(entity, nil, false)
 	edit.ApplyTo(target)
 	c.Equal(1, len(target.Modifiers))
-	c.True(target == target.Modifiers[0].OwningEquipment(), "the applied copy points at the equipment it was applied to")
+	c.True(target == target.Modifiers[0].TargetNode(), "the applied copy points at the equipment it was applied to")
 	c.Equal("Steel mesh", target.Modifiers[0].NameWithReplacements())
 }
 
@@ -125,8 +125,8 @@ func TestEquipmentCloneAttachesModifiersToTheClone(t *testing.T) {
 	if len(clone.Modifiers) != 1 || len(clone.Modifiers[0].Children) != 1 {
 		return
 	}
-	c.True(clone == clone.Modifiers[0].OwningEquipment(), "the clone's modifier points at the clone")
-	c.True(clone == clone.Modifiers[0].Children[0].OwningEquipment(), "the clone's child modifier points at the clone")
+	c.True(clone == clone.Modifiers[0].TargetNode(), "the clone's modifier points at the clone")
+	c.True(clone == clone.Modifiers[0].Children[0].TargetNode(), "the clone's child modifier points at the clone")
 
 	// Diverging the clone's replacements must move the clone's modifiers only.
 	clone.Replacements["Material"] = "Bronze"

--- a/model/gurps/modifier.go
+++ b/model/gurps/modifier.go
@@ -16,6 +16,66 @@ import (
 	"github.com/richardwilkes/toolbox/v2/xreflect"
 )
 
+// assertModifiable is used at compile time to check a *constraint*
+func assertModifiable[N Modifiable[MN, TN], MN ModifierNode[MN, TN], TN Node[TN]]() {}
+
+// Modifiable represents an interface for an object that accepts modifier nodes
+type Modifiable[T ModifierNode[T, TN], TN Node[TN]] interface {
+	ModifierList() []T
+	SetModifiers([]T)
+	AddModifier(T)
+}
+
+// GeneralModifier is used for common access to modifiers.
+type GeneralModifier interface {
+	Container() bool
+	Depth() int
+	FullDescription() string
+	FullCostDescription() string
+	Enabled() bool
+	SetEnabled(enabled bool)
+}
+
+// assertModifierNode is used at compile time to check a *constraint*
+func assertModifierNode[T ModifierNode[T, TN], TN Node[TN]]() {}
+
+// ModifierNode is a narrowed constraint for a Node
+// The narrowed constraint enforces that TargetNode and SetTargetNode functions are satisfied.
+// The narrowed constraint enforces the GeneralModifier interface is satisfied.
+type ModifierNode[N Node[N], TN Node[TN]] interface {
+	Node[N]
+	TargetNode() TN
+	SetTargetNode(TN)
+	GeneralModifier
+}
+
+// modifiable is a default implementation that satisfies the Modifiable constraint
+type modifiable[T ModifierNode[T, TN], TN Node[TN]] struct {
+	Modifiers []T `json:"modifiers,omitempty"`
+}
+
+// ModifierList returns the list of modifiers
+func (m *modifiable[T, TN]) ModifierList() []T {
+	return m.Modifiers
+}
+
+// SetModifiers sets the list of modifiers
+func (m *modifiable[T, TN]) SetModifiers(all []T) {
+	m.Modifiers = all
+}
+
+// AddModifier adds a modifier to the list
+func (m *modifiable[T, TN]) AddModifier(mod T) {
+	m.Modifiers = append(m.Modifiers, mod)
+}
+
+// SetTargetNode calls SetTargetNode on each modifier.
+func (m *modifiable[T, TN]) SetTargetNode(target TN) {
+	for _, one := range m.Modifiers {
+		one.SetTargetNode(target)
+	}
+}
+
 // mergeReplacements folds src into dst, keeping whatever value dst already holds for a key, and returns the result. A
 // nil dst simply takes src.
 func mergeReplacements(dst, src map[string]string) map[string]string {

--- a/model/gurps/modifier.go
+++ b/model/gurps/modifier.go
@@ -49,7 +49,7 @@ func assertModifierNode[M ModifierNode[M, T], T ModifiableNode[T, M]]() {}
 type ModifierNode[M ModifierNode[M, T], T ModifiableNode[T, M]] interface {
 	Node[M]
 	Target() T
-	SetTarget(T)
+	SetTarget(T) M
 	GeneralModifier
 }
 

--- a/model/gurps/modifier.go
+++ b/model/gurps/modifier.go
@@ -16,14 +16,17 @@ import (
 	"github.com/richardwilkes/toolbox/v2/xreflect"
 )
 
-// assertModifiable is used at compile time to check a *constraint*
-func assertModifiable[N Modifiable[MN, TN], MN ModifierNode[MN, TN], TN Node[TN]]() {}
+// assertModifiableNode is used at compile time to check a *constraint*
+func assertModifiableNode[T ModifiableNode[T, M], M ModifierNode[M, T]]() {}
 
-// Modifiable represents an interface for an object that accepts modifier nodes
-type Modifiable[T ModifierNode[T, TN], TN Node[TN]] interface {
-	ModifierList() []T
-	SetModifiers([]T)
-	AddModifier(T)
+// ModifiableNode is a narrowed constraint for a Node
+// The narrowed constraint enforces the Node[T] constraint is satisfied.
+// The narrowed constraint enforces that ModifierList, SetModifiers, and AddModifier functions are satisfied.
+type ModifiableNode[T ModifiableNode[T, M], M ModifierNode[M, T]] interface {
+	Node[T]
+	ModifierList() []M
+	SetModifiers([]M)
+	AddModifier(M)
 }
 
 // GeneralModifier is used for common access to modifiers.
@@ -37,42 +40,43 @@ type GeneralModifier interface {
 }
 
 // assertModifierNode is used at compile time to check a *constraint*
-func assertModifierNode[T ModifierNode[T, TN], TN Node[TN]]() {}
+func assertModifierNode[M ModifierNode[M, T], T ModifiableNode[T, M]]() {}
 
 // ModifierNode is a narrowed constraint for a Node
-// The narrowed constraint enforces that TargetNode and SetTargetNode functions are satisfied.
+// The narrowed constraint enforces the Node[M] constraint is satisfied.
+// The narrowed constraint enforces that Target and SetTarget functions are satisfied.
 // The narrowed constraint enforces the GeneralModifier interface is satisfied.
-type ModifierNode[N Node[N], TN Node[TN]] interface {
-	Node[N]
-	TargetNode() TN
-	SetTargetNode(TN)
+type ModifierNode[M ModifierNode[M, T], T ModifiableNode[T, M]] interface {
+	Node[M]
+	Target() T
+	SetTarget(T)
 	GeneralModifier
 }
 
 // modifiable is a default implementation that satisfies the Modifiable constraint
-type modifiable[T ModifierNode[T, TN], TN Node[TN]] struct {
-	Modifiers []T `json:"modifiers,omitempty"`
+type modifiable[T ModifiableNode[T, M], M ModifierNode[M, T]] struct {
+	Modifiers []M `json:"modifiers,omitempty"`
 }
 
 // ModifierList returns the list of modifiers
-func (m *modifiable[T, TN]) ModifierList() []T {
+func (m *modifiable[T, M]) ModifierList() []M {
 	return m.Modifiers
 }
 
 // SetModifiers sets the list of modifiers
-func (m *modifiable[T, TN]) SetModifiers(all []T) {
+func (m *modifiable[T, M]) SetModifiers(all []M) {
 	m.Modifiers = all
 }
 
 // AddModifier adds a modifier to the list
-func (m *modifiable[T, TN]) AddModifier(mod T) {
+func (m *modifiable[T, M]) AddModifier(mod M) {
 	m.Modifiers = append(m.Modifiers, mod)
 }
 
-// SetModifiersTargetNode calls SetTargetNode on each modifier.
-func (m *modifiable[T, TN]) SetModifiersTargetNode(target TN) {
+// SetModifiersTarget calls SetTarget on each modifier.
+func (m *modifiable[T, M]) SetModifiersTarget(target T) {
 	for _, one := range m.Modifiers {
-		one.SetTargetNode(target)
+		one.SetTarget(target)
 	}
 }
 

--- a/model/gurps/modifier.go
+++ b/model/gurps/modifier.go
@@ -69,8 +69,8 @@ func (m *modifiable[T, TN]) AddModifier(mod T) {
 	m.Modifiers = append(m.Modifiers, mod)
 }
 
-// SetTargetNode calls SetTargetNode on each modifier.
-func (m *modifiable[T, TN]) SetTargetNode(target TN) {
+// SetModifiersTargetNode calls SetTargetNode on each modifier.
+func (m *modifiable[T, TN]) SetModifiersTargetNode(target TN) {
 	for _, one := range m.Modifiers {
 		one.SetTargetNode(target)
 	}

--- a/model/gurps/modifier_test.go
+++ b/model/gurps/modifier_test.go
@@ -55,14 +55,14 @@ func TestModifierWithoutOwnerKeepsMarkersIntact(t *testing.T) {
 
 	// Once attached, the owner's replacements are applied and anything still unresolved is shown in compact form.
 	trait := NewTrait(nil, nil, false)
-	tm.setTrait(trait)
+	tm.SetTargetNode(trait)
 	c.Equal("A @Element@ spell", tm.NameWithReplacements(), "an owner without replacements yields the compact form")
 	trait.Replacements = map[string]string{"Element|Fire|Water": "Fire"}
 	c.Equal("A Fire spell", tm.NameWithReplacements())
 	c.Equal("A Fire spell", tm.LocalNotesWithReplacements())
 
 	equipment := NewEquipment(nil, nil, false)
-	em.setEquipment(equipment)
+	em.SetTargetNode(equipment)
 	c.Equal("A @Element@ spell", em.NameWithReplacements(), "an owner without replacements yields the compact form")
 	equipment.Replacements = map[string]string{"Element|Fire|Water": "Water"}
 	c.Equal("A Water spell", em.NameWithReplacements())

--- a/model/gurps/modifier_test.go
+++ b/model/gurps/modifier_test.go
@@ -55,14 +55,14 @@ func TestModifierWithoutOwnerKeepsMarkersIntact(t *testing.T) {
 
 	// Once attached, the owner's replacements are applied and anything still unresolved is shown in compact form.
 	trait := NewTrait(nil, nil, false)
-	tm.SetTargetNode(trait)
+	tm.SetTarget(trait)
 	c.Equal("A @Element@ spell", tm.NameWithReplacements(), "an owner without replacements yields the compact form")
 	trait.Replacements = map[string]string{"Element|Fire|Water": "Fire"}
 	c.Equal("A Fire spell", tm.NameWithReplacements())
 	c.Equal("A Fire spell", tm.LocalNotesWithReplacements())
 
 	equipment := NewEquipment(nil, nil, false)
-	em.SetTargetNode(equipment)
+	em.SetTarget(equipment)
 	c.Equal("A @Element@ spell", em.NameWithReplacements(), "an owner without replacements yields the compact form")
 	equipment.Replacements = map[string]string{"Element|Fire|Water": "Water"}
 	c.Equal("A Water spell", em.NameWithReplacements())

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -95,7 +95,7 @@ type TraitEditData struct {
 	UserDesc     string            `json:"userdesc,omitzero"`
 	Replacements map[string]string `json:"replacements,omitempty"`
 
-	// Leverage a default generic implementation of the Modifiable constraint that makes this a ModifiableNode
+	// Leverage a default generic implementation of the Modifiable constraint
 	modifiable[*TraitModifier, *Trait]
 
 	SelfControl selfctrl.Roll  `json:"cr,omitzero"`

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -48,8 +48,8 @@ import (
 
 var (
 	_ = assertNode[*Trait]
+	_ = assertModifiableNode[*Trait]
 	_ = assertEditorData[*TraitEditData]
-	_ = assertModifiable[*TraitEditData]
 
 	_ WeaponOwner            = &Trait{}
 	_ TemplatePickerProvider = &Trait{}
@@ -96,7 +96,7 @@ type TraitEditData struct {
 	Replacements map[string]string `json:"replacements,omitempty"`
 
 	// Leverage a default generic implementation of the Modifiable constraint
-	modifiable[*TraitModifier, *Trait]
+	modifiable[*Trait, *TraitModifier]
 
 	SelfControl selfctrl.Roll  `json:"cr,omitzero"`
 	Frequency   frequency.Roll `json:"frequency,omitzero"`
@@ -532,7 +532,7 @@ func (t *Trait) SetDataOwner(owner DataOwner) {
 		}
 	}
 	for _, m := range t.Modifiers {
-		m.SetTargetNode(t)
+		m.SetTarget(t)
 		m.SetDataOwner(owner)
 	}
 }
@@ -1205,7 +1205,7 @@ func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply boo
 			// Point the copy at the trait it belongs to, so that a "use level from owner" modifier can resolve its
 			// level. Prior to this, the copies held in an editor only acquired their trait as a side effect of a point
 			// cost computation.
-			cloned.SetTargetNode(trait)
+			cloned.SetTarget(trait)
 			t.Modifiers = append(t.Modifiers, cloned)
 		}
 	}

--- a/model/gurps/trait.go
+++ b/model/gurps/trait.go
@@ -49,6 +49,7 @@ import (
 var (
 	_ = assertNode[*Trait]
 	_ = assertEditorData[*TraitEditData]
+	_ = assertModifiable[*TraitEditData]
 
 	_ WeaponOwner            = &Trait{}
 	_ TemplatePickerProvider = &Trait{}
@@ -93,10 +94,14 @@ type TraitEditData struct {
 	VTTNotes     string            `json:"vtt_notes,omitzero"`
 	UserDesc     string            `json:"userdesc,omitzero"`
 	Replacements map[string]string `json:"replacements,omitempty"`
-	Modifiers    []*TraitModifier  `json:"modifiers,omitempty"`
-	SelfControl  selfctrl.Roll     `json:"cr,omitzero"`
-	Frequency    frequency.Roll    `json:"frequency,omitzero"`
-	Disabled     bool              `json:"disabled,omitzero"`
+
+	// Leverage a default generic implementation of the Modifiable constraint that makes this a ModifiableNode
+	modifiable[*TraitModifier, *Trait]
+
+	SelfControl selfctrl.Roll  `json:"cr,omitzero"`
+	Frequency   frequency.Roll `json:"frequency,omitzero"`
+	Disabled    bool           `json:"disabled,omitzero"`
+
 	ItemSwitch
 	preconfigurable
 	TraitNonContainerOnlyEditData
@@ -527,7 +532,7 @@ func (t *Trait) SetDataOwner(owner DataOwner) {
 		}
 	}
 	for _, m := range t.Modifiers {
-		m.setTrait(t)
+		m.SetTargetNode(t)
 		m.SetDataOwner(owner)
 	}
 }
@@ -1200,7 +1205,7 @@ func (t *TraitEditData) copyFrom(trait *Trait, other *TraitEditData, isApply boo
 			// Point the copy at the trait it belongs to, so that a "use level from owner" modifier can resolve its
 			// level. Prior to this, the copies held in an editor only acquired their trait as a side effect of a point
 			// cost computation.
-			cloned.setTrait(trait)
+			cloned.SetTargetNode(trait)
 			t.Modifiers = append(t.Modifiers, cloned)
 		}
 	}

--- a/model/gurps/trait_modifier.go
+++ b/model/gurps/trait_modifier.go
@@ -371,8 +371,8 @@ func (t *TraitModifier) Depth() int {
 	return count
 }
 
-// TargetNode returns the trait being targeted for modification
-func (t *TraitModifier) TargetNode() *Trait {
+// Target returns the trait being targeted for modification
+func (t *TraitModifier) Target() *Trait {
 	return t.trait
 }
 
@@ -381,8 +381,8 @@ func (t *TraitModifier) DataOwner() DataOwner {
 	return t.owner
 }
 
-// SetTargetNode sets the trait being targeted for modification and configures any sub-components as needed.
-func (t *TraitModifier) SetTargetNode(target *Trait) {
+// SetTarget sets the trait being targeted for modification and configures any sub-components as needed.
+func (t *TraitModifier) SetTarget(target *Trait) {
 	// Set the target node for this modifier
 	t.trait = target
 
@@ -395,7 +395,7 @@ func (t *TraitModifier) SetTargetNode(target *Trait) {
 	// Cascade the operation
 	if t.Container() {
 		for _, child := range t.Children {
-			child.SetTargetNode(target)
+			child.SetTarget(target)
 		}
 	}
 }

--- a/model/gurps/trait_modifier.go
+++ b/model/gurps/trait_modifier.go
@@ -382,7 +382,7 @@ func (t *TraitModifier) DataOwner() DataOwner {
 }
 
 // SetTarget sets the trait being targeted for modification and configures any sub-components as needed.
-func (t *TraitModifier) SetTarget(target *Trait) {
+func (t *TraitModifier) SetTarget(target *Trait) *TraitModifier {
 	// Set the target node for this modifier
 	t.trait = target
 
@@ -398,6 +398,8 @@ func (t *TraitModifier) SetTarget(target *Trait) {
 			child.SetTarget(target)
 		}
 	}
+
+	return t
 }
 
 // SetDataOwner sets the data owner and configures any sub-components as needed.

--- a/model/gurps/trait_modifier.go
+++ b/model/gurps/trait_modifier.go
@@ -37,6 +37,7 @@ import (
 
 var (
 	_ = assertNode[*TraitModifier]
+	_ = assertModifierNode[*TraitModifier]
 	_ = assertEditorData[*TraitModifierEditData]
 
 	_ GeneralModifier = &TraitModifier{}
@@ -52,16 +53,6 @@ const (
 	TraitModifierReferenceColumn
 	TraitModifierLibSrcColumn
 )
-
-// GeneralModifier is used for common access to modifiers.
-type GeneralModifier interface {
-	Container() bool
-	Depth() int
-	FullDescription() string
-	FullCostDescription() string
-	Enabled() bool
-	SetEnabled(enabled bool)
-}
 
 // TraitModifier holds a modifier to an Trait.
 type TraitModifier struct {
@@ -380,8 +371,8 @@ func (t *TraitModifier) Depth() int {
 	return count
 }
 
-// OwningTrait returns the owning trait.
-func (t *TraitModifier) OwningTrait() *Trait {
+// TargetNode returns the trait being targeted for modification
+func (t *TraitModifier) TargetNode() *Trait {
 	return t.trait
 }
 
@@ -390,15 +381,21 @@ func (t *TraitModifier) DataOwner() DataOwner {
 	return t.owner
 }
 
-func (t *TraitModifier) setTrait(trait *Trait) {
-	t.trait = trait
-	if trait != nil && len(t.Replacements) != 0 {
-		trait.Replacements = mergeReplacements(trait.Replacements, t.Replacements)
+// SetTargetNode sets the trait being targeted for modification and configures any sub-components as needed.
+func (t *TraitModifier) SetTargetNode(target *Trait) {
+	// Set the target node for this modifier
+	t.trait = target
+
+	// COMPAT: Promote replacements from this node up to the target node
+	if target != nil && len(t.Replacements) != 0 {
+		target.Replacements = mergeReplacements(target.Replacements, t.Replacements)
 		t.Replacements = nil
 	}
+
+	// Cascade the operation
 	if t.Container() {
 		for _, child := range t.Children {
-			child.setTrait(trait)
+			child.SetTargetNode(target)
 		}
 	}
 }

--- a/model/gurps/trait_modifier_test.go
+++ b/model/gurps/trait_modifier_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // TestTraitModifierCloneDoesNotShareReplacements verifies that a copy of a modifier still carrying the legacy
-// replacements map gets its own map. setTrait() installs a modifier's replacements directly into the trait it is
+// replacements map gets its own map. SetTargetNode() installs a modifier's replacements directly into the trait it is
 // attached to when that trait has none of its own, so sharing the map let a later merge into the trait's map write into
 // the library row the copy came from.
 func TestTraitModifierCloneDoesNotShareReplacements(t *testing.T) {

--- a/model/gurps/trait_modifier_test.go
+++ b/model/gurps/trait_modifier_test.go
@@ -36,15 +36,15 @@ func TestTraitModifierCloneDoesNotShareReplacements(t *testing.T) {
 
 	// ...and the next attachment pass migrates the copy's map into the trait, which has none of its own.
 	trait := NewTrait(nil, nil, false)
-	dup.setTrait(trait)
+	dup.SetTargetNode(trait)
 	c.Nil(dup.Replacements, "the copy hands its map off to the trait")
 	c.Equal(map[string]string{"Element": "Fire"}, trait.Replacements, "the trait picks up the replacements")
 
-	// A second modifier attaching to the same trait takes setTrait's merge branch, writing into the map the trait now
+	// A second modifier attaching to the same trait takes SetTargetNode's merge branch, writing into the map the trait now
 	// holds. That must not reach back into the library row.
 	second := NewTraitModifier(nil, nil, false)
 	second.Replacements = map[string]string{"Aspect": "Heat"}
-	second.setTrait(trait)
+	second.SetTargetNode(trait)
 	c.Equal(map[string]string{"Element": "Fire", "Aspect": "Heat"}, trait.Replacements,
 		"the trait merges in the second modifier's replacements")
 	c.Equal(map[string]string{"Element": "Fire"}, library.Replacements, "the library row is left untouched")

--- a/model/gurps/trait_modifier_test.go
+++ b/model/gurps/trait_modifier_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // TestTraitModifierCloneDoesNotShareReplacements verifies that a copy of a modifier still carrying the legacy
-// replacements map gets its own map. SetTargetNode() installs a modifier's replacements directly into the trait it is
+// replacements map gets its own map. SetTarget() installs a modifier's replacements directly into the trait it is
 // attached to when that trait has none of its own, so sharing the map let a later merge into the trait's map write into
 // the library row the copy came from.
 func TestTraitModifierCloneDoesNotShareReplacements(t *testing.T) {
@@ -36,15 +36,15 @@ func TestTraitModifierCloneDoesNotShareReplacements(t *testing.T) {
 
 	// ...and the next attachment pass migrates the copy's map into the trait, which has none of its own.
 	trait := NewTrait(nil, nil, false)
-	dup.SetTargetNode(trait)
+	dup.SetTarget(trait)
 	c.Nil(dup.Replacements, "the copy hands its map off to the trait")
 	c.Equal(map[string]string{"Element": "Fire"}, trait.Replacements, "the trait picks up the replacements")
 
-	// A second modifier attaching to the same trait takes SetTargetNode's merge branch, writing into the map the trait now
+	// A second modifier attaching to the same trait takes SetTarget's merge branch, writing into the map the trait now
 	// holds. That must not reach back into the library row.
 	second := NewTraitModifier(nil, nil, false)
 	second.Replacements = map[string]string{"Aspect": "Heat"}
-	second.SetTargetNode(trait)
+	second.SetTarget(trait)
 	c.Equal(map[string]string{"Element": "Fire", "Aspect": "Heat"}, trait.Replacements,
 		"the trait merges in the second modifier's replacements")
 	c.Equal(map[string]string{"Element": "Fire"}, library.Replacements, "the library row is left untouched")

--- a/model/gurps/trait_test.go
+++ b/model/gurps/trait_test.go
@@ -284,7 +284,7 @@ func TestInheritedModifiersAreNotRepointed(t *testing.T) {
 	c.Equal(fxp.FromInteger(16), first.AdjustedPoints(), "the first child's cost is unaffected by the second's")
 
 	// The container's modifier still belongs to the container, so the container's display of it is unchanged.
-	c.Equal(parent, mod.OwningTrait(), "the inherited modifier still belongs to the container")
+	c.Equal(parent, mod.TargetNode(), "the inherited modifier still belongs to the container")
 	c.Equal("Fire Attack", mod.NameWithReplacements(),
 		"the inherited modifier still resolves against the container's replacements")
 }
@@ -308,7 +308,7 @@ func TestTraitEditDataCopyLinksModifiers(t *testing.T) {
 	var data TraitEditData
 	data.CopyFrom(trait)
 	c.Equal(1, len(data.Modifiers), "the modifier was copied")
-	c.Equal(trait, data.Modifiers[0].OwningTrait(), "the copied modifier knows its trait")
+	c.Equal(trait, data.Modifiers[0].TargetNode(), "the copied modifier knows its trait")
 	c.Equal(fxp.Three, data.Modifiers[0].CurrentLevel(), "the copied modifier resolves its level from the trait")
 	c.Equal(fxp.FromInteger(16), AdjustedPoints(nil, trait, data.CanLevel, data.BasePoints, data.Levels,
 		data.PointsPerLevel, data.SelfControl, data.Frequency, data.Modifiers, data.RoundCostDown), "10 + 2*3")
@@ -339,8 +339,8 @@ func TestTraitCloneModifiersBelongToTheClone(t *testing.T) {
 	clone := source.Clone(LibraryFile{}, nil, nil, Reference)
 	c.Equal(1, len(clone.Modifiers), "the modifier was copied")
 	// Compared as pointers: the two traits are equal by value at this point, so only identity distinguishes them.
-	c.True(clone.Modifiers[0].OwningTrait() == clone, "the copy belongs to the clone, not the trait cloned from")
-	c.True(mod.OwningTrait() == source, "the original's modifier still belongs to the original")
+	c.True(clone.Modifiers[0].TargetNode() == clone, "the copy belongs to the clone, not the trait cloned from")
+	c.True(mod.TargetNode() == source, "the original's modifier still belongs to the original")
 
 	// Diverging the clone must not be read through the original, and vice versa.
 	clone.Replacements["element"] = "Ice"
@@ -362,5 +362,5 @@ func TestTraitCloneModifiersBelongToTheClone(t *testing.T) {
 	clonedContainer := parent.Clone(LibraryFile{}, nil, nil, Reference)
 	c.Equal(1, len(clonedContainer.Children), "the child was cloned")
 	clonedChild := clonedContainer.Children[0]
-	c.True(clonedChild.Modifiers[0].OwningTrait() == clonedChild, "a cloned child's modifier belongs to that child")
+	c.True(clonedChild.Modifiers[0].TargetNode() == clonedChild, "a cloned child's modifier belongs to that child")
 }

--- a/model/gurps/trait_test.go
+++ b/model/gurps/trait_test.go
@@ -284,7 +284,7 @@ func TestInheritedModifiersAreNotRepointed(t *testing.T) {
 	c.Equal(fxp.FromInteger(16), first.AdjustedPoints(), "the first child's cost is unaffected by the second's")
 
 	// The container's modifier still belongs to the container, so the container's display of it is unchanged.
-	c.Equal(parent, mod.TargetNode(), "the inherited modifier still belongs to the container")
+	c.Equal(parent, mod.Target(), "the inherited modifier still belongs to the container")
 	c.Equal("Fire Attack", mod.NameWithReplacements(),
 		"the inherited modifier still resolves against the container's replacements")
 }
@@ -308,7 +308,7 @@ func TestTraitEditDataCopyLinksModifiers(t *testing.T) {
 	var data TraitEditData
 	data.CopyFrom(trait)
 	c.Equal(1, len(data.Modifiers), "the modifier was copied")
-	c.Equal(trait, data.Modifiers[0].TargetNode(), "the copied modifier knows its trait")
+	c.Equal(trait, data.Modifiers[0].Target(), "the copied modifier knows its trait")
 	c.Equal(fxp.Three, data.Modifiers[0].CurrentLevel(), "the copied modifier resolves its level from the trait")
 	c.Equal(fxp.FromInteger(16), AdjustedPoints(nil, trait, data.CanLevel, data.BasePoints, data.Levels,
 		data.PointsPerLevel, data.SelfControl, data.Frequency, data.Modifiers, data.RoundCostDown), "10 + 2*3")
@@ -339,8 +339,8 @@ func TestTraitCloneModifiersBelongToTheClone(t *testing.T) {
 	clone := source.Clone(LibraryFile{}, nil, nil, Reference)
 	c.Equal(1, len(clone.Modifiers), "the modifier was copied")
 	// Compared as pointers: the two traits are equal by value at this point, so only identity distinguishes them.
-	c.True(clone.Modifiers[0].TargetNode() == clone, "the copy belongs to the clone, not the trait cloned from")
-	c.True(mod.TargetNode() == source, "the original's modifier still belongs to the original")
+	c.True(clone.Modifiers[0].Target() == clone, "the copy belongs to the clone, not the trait cloned from")
+	c.True(mod.Target() == source, "the original's modifier still belongs to the original")
 
 	// Diverging the clone must not be read through the original, and vice versa.
 	clone.Replacements["element"] = "Ice"
@@ -362,5 +362,5 @@ func TestTraitCloneModifiersBelongToTheClone(t *testing.T) {
 	clonedContainer := parent.Clone(LibraryFile{}, nil, nil, Reference)
 	c.Equal(1, len(clonedContainer.Children), "the child was cloned")
 	clonedChild := clonedContainer.Children[0]
-	c.True(clonedChild.Modifiers[0].TargetNode() == clonedChild, "a cloned child's modifier belongs to that child")
+	c.True(clonedChild.Modifiers[0].Target() == clonedChild, "a cloned child's modifier belongs to that child")
 }

--- a/ux/trait_modifier_editor.go
+++ b/ux/trait_modifier_editor.go
@@ -103,7 +103,7 @@ func traitModifierWithOverlay(t *gurps.TraitModifier, overlay *gurps.TraitModifi
 // that trait's own editor, the trait is returned as it currently stands in that editor, so that a level change which
 // has not yet been applied is still reflected in the modifier's cost.
 func owningTraitWithPendingEdits(owner Rebuildable, modifier *gurps.TraitModifier) *gurps.Trait {
-	trait := modifier.OwningTrait()
+	trait := modifier.TargetNode()
 	if trait == nil {
 		return nil
 	}

--- a/ux/trait_modifier_editor.go
+++ b/ux/trait_modifier_editor.go
@@ -103,7 +103,7 @@ func traitModifierWithOverlay(t *gurps.TraitModifier, overlay *gurps.TraitModifi
 // that trait's own editor, the trait is returned as it currently stands in that editor, so that a level change which
 // has not yet been applied is still reflected in the modifier's cost.
 func owningTraitWithPendingEdits(owner Rebuildable, modifier *gurps.TraitModifier) *gurps.Trait {
-	trait := modifier.TargetNode()
+	trait := modifier.Target()
 	if trait == nil {
 		return nil
 	}


### PR DESCRIPTION
The current code around modifiers for traits and equipment is very similar and we can start unifying this code by good use of generics.

I have added a new `modifiers.go` file in the `gurps` package to hold interfaces, constraints, and any common code. That involvde migrating the existing `GeneralModifer` interface from `trait.go` where it was initially created. I added two new constraint and matching "assert" helpers to verify compliance to the constraints at compile time. There's also a shared 'modifiable' implementation that uses generics to work with both equipment and traits.

Future work will cover further identification and refactoring of code that's identical between equipment and trait modifiers.