### PR TITLE
Adding a few values to the scripting entity

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,6 +48,7 @@
   and removed together. Sample names from the current definition are shown as you edit. Saving, opening from your
   libraries, having several open at once, and undo work as in the ancestry editor, and each name generator row in the
   ancestry editor has a button that opens that generator for editing. (#607)
+- Added three new fields to the `entity` object in scripting. The `otherEquipment` field is an array of equipment not currently carried. The `wealthCarried` and wealthNotCarried` fields are currency sums for the two groups of equipment.
 
 ## Bug Fixes
 

--- a/model/gurps/scripting_entity.go
+++ b/model/gurps/scripting_entity.go
@@ -54,6 +54,15 @@ func newScriptEntity(r *goja.Runtime, entity *Entity) *goja.Object {
 		m["equipment"] = func() goja.Value {
 			return scriptObjects(r, entity.CarriedEquipment, hasQuantity, newScriptEquipment)
 		}
+		m["otherEquipment"] = func() goja.Value {
+			return scriptObjects(r, entity.OtherEquipment, hasQuantity, newScriptEquipment)
+		}
+		m["wealthCarried"] = func() goja.Value {
+			return r.ToValue(entity.WealthCarried().AsFloat[float64]())
+		}
+		m["wealthNotCarried"] = func() goja.Value {
+			return r.ToValue(entity.WealthNotCarried().AsFloat[float64]())
+		}
 		m["notes"] = func() goja.Value { return scriptObjects(r, entity.Notes, nil, newScriptNote) }
 		m["skills"] = func() goja.Value { return scriptObjects(r, entity.Skills, nil, newScriptSkill) }
 		m["spells"] = func() goja.Value { return scriptObjects(r, entity.Spells, nil, newScriptSpell) }

--- a/model/gurps/scripting_entity_test.go
+++ b/model/gurps/scripting_entity_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 1998-2026 by Richard A. Wilkes. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, version 2.0. If a copy of the MPL was not distributed with
+// this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, version 2.0.
+
+package gurps
+
+import (
+	"testing"
+
+	"github.com/richardwilkes/gcs/v5/model/fxp"
+	"github.com/richardwilkes/toolbox/v2/check"
+)
+
+// entity.wealthCarried and entity.wealthNotCarried sum the extended value of the carried and other equipment lists,
+// respectively, matching Entity.WealthCarried and Entity.WealthNotCarried.
+func TestScriptEntityWealth(t *testing.T) {
+	c := check.New(t)
+	e := NewEntity()
+
+	carried := NewEquipment(e, nil, false)
+	carried.Name = "Sword"
+	carried.BaseValue = "10"
+	carried.Quantity = fxp.Two
+	e.CarriedEquipment = []*Equipment{carried}
+
+	other := NewEquipment(e, nil, false)
+	other.Name = "Spare Armor"
+	other.BaseValue = "50"
+	other.Quantity = fxp.One
+	e.OtherEquipment = []*Equipment{other}
+	e.Recalculate()
+
+	resolve := func(expr string) string { return ResolveScript(e, ScriptSelfProvider{}, expr) }
+	c.Equal("20", resolve("entity.wealthCarried.toString()"))
+	c.Equal("50", resolve("entity.wealthNotCarried.toString()"))
+	c.Equal(fxp.FromFloat[float64](20), e.WealthCarried())
+	c.Equal(fxp.FromFloat[float64](50), e.WealthNotCarried())
+}

--- a/model/gurps/scripting_equipment_test.go
+++ b/model/gurps/scripting_equipment_test.go
@@ -180,3 +180,23 @@ func TestScriptEquipmentWithoutQuantityIsHidden(t *testing.T) {
 	c.Equal("Coin", names(`entity.findEquipment("Bag", "")[0].children`))
 	c.Equal("Coin", names(`entity.findEquipment("Bag", "")[0].find("", "")`))
 }
+
+// entity.otherEquipment exposes the non-carried equipment list, the same way entity.equipment (covered by
+// TestScriptEquipmentWithoutQuantityIsHidden) exposes the carried one, and it filters out items with a
+// non-positive quantity too.
+func TestScriptEntityOtherEquipment(t *testing.T) {
+	c := check.New(t)
+	e := NewEntity()
+
+	other := NewEquipment(e, nil, false)
+	other.Name = "Spare Armor"
+	zeroQty := NewEquipment(e, nil, false)
+	zeroQty.Name = "Sold Off"
+	zeroQty.Quantity = 0
+	e.OtherEquipment = []*Equipment{other, zeroQty}
+	e.Recalculate()
+
+	resolve := func(expr string) string { return ResolveScript(e, ScriptSelfProvider{}, expr) }
+	c.Equal("1", resolve("entity.otherEquipment.length"))
+	c.Equal("Spare Armor", resolve("entity.otherEquipment[0].name"))
+}


### PR DESCRIPTION
- Added `otherEquipment` to expose non-carried equipment. 
- Added `wealthCarried` to give an extended value sum of all carried equipment. 
- Added `wealthNotCarried` to give an extended value sum of all non-carried equipment.

Resolves #1128