### PR TITLE
Adding Headless API Run Mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/richardwilkes/pdfview v0.8.1
 	github.com/richardwilkes/rpgtools v1.14.0
 	github.com/richardwilkes/toolbox/v2 v2.20.0
-	github.com/richardwilkes/unison v0.103.2-0.20260910183622-3eb48a86be1a
+	github.com/richardwilkes/unison v0.103.2-0.20260910213427-ae8ed6f98ec4
 	github.com/rjeczalik/notify v0.9.3
 	github.com/yookoala/realpath v1.0.0
 	github.com/yuin/goldmark v1.8.6

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/richardwilkes/pdfview v0.8.1
 	github.com/richardwilkes/rpgtools v1.14.0
 	github.com/richardwilkes/toolbox/v2 v2.20.0
-	github.com/richardwilkes/unison v0.103.1
+	github.com/richardwilkes/unison v0.103.2-0.20260910183622-3eb48a86be1a
 	github.com/rjeczalik/notify v0.9.3
 	github.com/yookoala/realpath v1.0.0
 	github.com/yuin/goldmark v1.8.6

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/image v0.45.0
 	golang.org/x/sys v0.48.0
 	golang.org/x/text v0.42.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -46,5 +47,4 @@ require (
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.23.0 // indirect
 	golang.org/x/term v0.46.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/richardwilkes/rpgtools v1.14.0 h1:wTUTokRzF6eScPIiko6X5c7QA3clTNLHiOX
 github.com/richardwilkes/rpgtools v1.14.0/go.mod h1:XUrkoraM3YiXeS9FRhOIBlWP7/SVY3YvEgytWIQm4CQ=
 github.com/richardwilkes/toolbox/v2 v2.20.0 h1:PeVucrk0nzChcJ+FKfL6bu1g/aNhHZ6uSt+iszkefP4=
 github.com/richardwilkes/toolbox/v2 v2.20.0/go.mod h1:7UgBxfqnGbzSo+Wdkf+RRKM/1YOBilwol6jvjLhwvYE=
-github.com/richardwilkes/unison v0.103.2-0.20260910183622-3eb48a86be1a h1:/ZDw9smPiT/DvMFfknmi6KL+ONPWg4gigwXLrpYDKuc=
-github.com/richardwilkes/unison v0.103.2-0.20260910183622-3eb48a86be1a/go.mod h1:H0YL9RuXBkwAKTRV2jwJ0Dweud5VGlBhB3V2+UiNGRs=
+github.com/richardwilkes/unison v0.103.2-0.20260910213427-ae8ed6f98ec4 h1:/GRG2mDa7SKXTz5d3SLHQ9+9MoGUw7QMQD0f9RFBu2M=
+github.com/richardwilkes/unison v0.103.2-0.20260910213427-ae8ed6f98ec4/go.mod h1:H0YL9RuXBkwAKTRV2jwJ0Dweud5VGlBhB3V2+UiNGRs=
 github.com/rjeczalik/notify v0.9.3 h1:6rJAzHTGKXGj76sbRgDiDcYj/HniypXmSJo1SWakZeY=
 github.com/rjeczalik/notify v0.9.3/go.mod h1:gF3zSOrafR9DQEWSE8TjfI9NkooDxbyT4UgRGKZA0lc=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/richardwilkes/rpgtools v1.14.0 h1:wTUTokRzF6eScPIiko6X5c7QA3clTNLHiOX
 github.com/richardwilkes/rpgtools v1.14.0/go.mod h1:XUrkoraM3YiXeS9FRhOIBlWP7/SVY3YvEgytWIQm4CQ=
 github.com/richardwilkes/toolbox/v2 v2.20.0 h1:PeVucrk0nzChcJ+FKfL6bu1g/aNhHZ6uSt+iszkefP4=
 github.com/richardwilkes/toolbox/v2 v2.20.0/go.mod h1:7UgBxfqnGbzSo+Wdkf+RRKM/1YOBilwol6jvjLhwvYE=
-github.com/richardwilkes/unison v0.103.1 h1:pnBRgHI4x4p4BJKKh146jpaRJasmrX2HkXstRzgOAtQ=
-github.com/richardwilkes/unison v0.103.1/go.mod h1:H0YL9RuXBkwAKTRV2jwJ0Dweud5VGlBhB3V2+UiNGRs=
+github.com/richardwilkes/unison v0.103.2-0.20260910183622-3eb48a86be1a h1:/ZDw9smPiT/DvMFfknmi6KL+ONPWg4gigwXLrpYDKuc=
+github.com/richardwilkes/unison v0.103.2-0.20260910183622-3eb48a86be1a/go.mod h1:H0YL9RuXBkwAKTRV2jwJ0Dweud5VGlBhB3V2+UiNGRs=
 github.com/rjeczalik/notify v0.9.3 h1:6rJAzHTGKXGj76sbRgDiDcYj/HniypXmSJo1SWakZeY=
 github.com/rjeczalik/notify v0.9.3/go.mod h1:gF3zSOrafR9DQEWSE8TjfI9NkooDxbyT4UgRGKZA0lc=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/main.go
+++ b/main.go
@@ -17,9 +17,8 @@ import (
 
 	"github.com/richardwilkes/gcs/v5/early"
 	"github.com/richardwilkes/gcs/v5/model/gurps"
-	"github.com/richardwilkes/gcs/v5/updater"
+	"github.com/richardwilkes/gcs/v5/runmode"
 	"github.com/richardwilkes/gcs/v5/ux"
-	"github.com/richardwilkes/toolbox/v2/errs"
 	"github.com/richardwilkes/toolbox/v2/i18n"
 	"github.com/richardwilkes/toolbox/v2/xflag"
 	"github.com/richardwilkes/toolbox/v2/xos"
@@ -32,7 +31,16 @@ func main() {
 	early.Configure()
 	ux.LoadLanguageSetting()
 	unison.AttachConsole()
-	xflag.SetUsage(nil, ux.AppDescription(), i18n.Text("[file]..."), updater.FinishFlag)
+	// Run each registered runmode.Factory now, ahead of flag parsing, since each one registers its own flags as a
+	// side effect of being called (see runmode.Factories). Which modes exist, if any beyond the ones this repo
+	// itself registers, is entirely up to what got compiled into this build.
+	runModes := make([]runmode.Mode, len(runmode.Factories))
+	var hiddenFlags []string
+	for i, newRunMode := range runmode.Factories {
+		runModes[i] = newRunMode(nil)
+		hiddenFlags = append(hiddenFlags, runModes[i].HiddenFlagNames...)
+	}
+	xflag.SetUsage(nil, ux.AppDescription(), i18n.Text("[file]..."), hiddenFlags...)
 	savedUsage := flag.CommandLine.Usage
 	flag.CommandLine.Usage = func() {
 		savedUsage()
@@ -61,17 +69,6 @@ func main() {
 	}
 	flag.StringVar(&gurps.SettingsPath, "settings", gurps.SettingsPath, i18n.Text("The `file` to load settings from and store them into"))
 
-	textTmplPath := flag.String("text", "", i18n.Text("Export sheets using the specified text template `file`"))
-
-	convertFiles := flag.Bool("convert", false, i18n.Text("Convert all files specified on the command line to the current data format. If a directory is specified, it will be traversed recursively and all files found will be converted. After all files have been processed, GCS will exit"))
-
-	syncToLibraryData := flag.Bool("sync", false, fmt.Sprintf(i18n.Text("Syncs all character sheet (%s), template (%s), and loot (%s) files specified on the command line with their library sources. If a directory is specified, it will be traversed recursively and all files found will be converted. After all files have been processed, GCS will exit"), gurps.SheetExt, gurps.TemplatesExt, gurps.LootExt))
-
-	// Not meant to be typed by anyone. A copy of GCS is started this way to finish applying an update once the copy
-	// that prepared it has exited, since replacing a running application from within itself is not something any of
-	// the supported systems allow.
-	finishUpdate := flag.String(updater.FinishFlag, "", i18n.Text("Internal use only. Finish applying a previously prepared update, using the state in the specified `file`"))
-
 	var logCfg xslog.Config
 	logCfg.AddFlags()
 
@@ -86,57 +83,29 @@ func main() {
 	ux.RegisterKnownFileTypes()
 	gurps.GlobalSettings() // Here to force early initialization
 
-	if msg := exclusiveModeMsg(*convertFiles, *syncToLibraryData, *textTmplPath, *finishUpdate); msg != "" {
+	var requestedRunMode *runmode.Mode
+	var requestedRunModeNames []string
+	for i := range runModes {
+		if runModes[i].Requested() {
+			requestedRunMode = &runModes[i]
+			requestedRunModeNames = append(requestedRunModeNames, runModes[i].Name)
+		}
+	}
+	if msg := exclusiveModeMsg(requestedRunModeNames); msg != "" {
 		xos.ExitWithMsg(msg)
 	}
 
-	switch {
-	case *finishUpdate != "":
-		// This must stay ahead of anything that could reach ux.Start: the helper's whole job is to wait for the
-		// single-instance service to let go of its port, so it must never try to join that protocol itself.
-		if err := updater.Finish(*finishUpdate); err != nil {
-			errs.Log(err)
-			xos.Exit(1)
-		}
-	case *convertFiles:
-		if err := gurps.Convert(fileList...); err != nil {
-			xos.ExitWithMsg(err.Error())
-		}
-	case *syncToLibraryData:
-		if err := gurps.SyncToLibraryData(fileList...); err != nil {
-			xos.ExitWithMsg(err.Error())
-		}
-	case *textTmplPath != "":
-		if len(fileList) == 0 {
-			xos.ExitWithMsg(i18n.Text("No files to process."))
-		}
-		if err := gurps.ExportSheets(*textTmplPath, fileList); err != nil {
-			xos.ExitWithMsg(err.Error())
-		}
-	default:
-		ux.Start(fileList) // Never returns
+	if requestedRunMode != nil {
+		requestedRunMode.Start(fileList) // Never returns
 	}
-	xos.Exit(0)
+	ux.Start(fileList) // Never returns
 }
 
-// exclusiveModeMsg returns a non-empty error message if more than one of --convert, --sync, --text and --finish-update
-// was specified. Each of these modes takes over the process and exits, so only one may be requested at a time.
-func exclusiveModeMsg(convert, sync bool, textTmplPath, finishUpdatePath string) string {
-	var modes []string
-	if convert {
-		modes = append(modes, "--convert")
-	}
-	if sync {
-		modes = append(modes, "--sync")
-	}
-	if textTmplPath != "" {
-		modes = append(modes, "--text")
-	}
-	if finishUpdatePath != "" {
-		modes = append(modes, "--finish-update")
-	}
-	if len(modes) > 1 {
-		return fmt.Sprintf(i18n.Text("Cannot specify more than one of %s"), strings.Join(modes, ", "))
+// exclusiveModeMsg returns a non-empty error message if more than one of the requested run mode names was specified.
+// Each run mode takes over the process and exits, so only one may be requested at a time.
+func exclusiveModeMsg(requestedModeNames []string) string {
+	if len(requestedModeNames) > 1 {
+		return fmt.Sprintf(i18n.Text("Cannot specify more than one of -%s"), strings.Join(requestedModeNames, ", -"))
 	}
 	return ""
 }

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 	runModes := make([]runmode.Mode, len(runmode.Factories))
 	var hiddenFlags []string
 	for i, newRunMode := range runmode.Factories {
-		runModes[i] = newRunMode(nil)
+		runModes[i] = newRunMode(flag.CommandLine)
 		hiddenFlags = append(hiddenFlags, runModes[i].HiddenFlagNames...)
 	}
 	xflag.SetUsage(nil, ux.AppDescription(), i18n.Text("[file]..."), hiddenFlags...)

--- a/main_test.go
+++ b/main_test.go
@@ -10,8 +10,11 @@
 package main
 
 import (
+	"flag"
+	"io"
 	"testing"
 
+	"github.com/richardwilkes/gcs/v5/runmode"
 	"github.com/richardwilkes/toolbox/v2/check"
 )
 
@@ -59,4 +62,44 @@ func TestExclusiveModeMsg(t *testing.T) {
 			c.Equal("", msg, tc.name)
 		}
 	}
+}
+
+// TestRunModeFactories checks the wiring every registered runmode.Factory is expected to provide: it registers a flag
+// named after the Mode it returns, that Mode is not requested until that flag is given, and it is requested once it
+// is. Each factory is called with its own flag set, so this exercises exactly what main does with flag.CommandLine
+// without disturbing it. Which modes take part depends on what got compiled into this build (see runmode.Factories).
+func TestRunModeFactories(t *testing.T) {
+	c := check.New(t)
+	c.NotEqual(0, len(runmode.Factories))
+	seen := make(map[string]bool, len(runmode.Factories))
+	for _, factory := range runmode.Factories {
+		flagSet := flag.NewFlagSet("gcs", flag.ContinueOnError)
+		flagSet.SetOutput(io.Discard)
+		m := factory(flagSet)
+		c.NotEqual("", m.Name)
+		c.False(seen[m.Name], m.Name)
+		seen[m.Name] = true
+		c.NotNil(m.Requested, m.Name)
+		c.NotNil(m.Start, m.Name)
+		f := flagSet.Lookup(m.Name)
+		c.NotNil(f, m.Name)
+		if f == nil {
+			continue
+		}
+		for _, hidden := range m.HiddenFlagNames {
+			c.NotNil(flagSet.Lookup(hidden), m.Name, hidden)
+		}
+		c.False(m.Requested(), m.Name)
+		c.NoError(flagSet.Parse([]string{"-" + m.Name + "=" + requestValueFor(f)}), m.Name)
+		c.True(m.Requested(), m.Name)
+	}
+}
+
+// requestValueFor returns a value for f that asks for the run mode it belongs to: bool flags are simply turned on,
+// while the rest -- the ones that name a file or an address -- are considered requested when they are non-empty.
+func requestValueFor(f *flag.Flag) string {
+	if b, ok := f.Value.(interface{ IsBoolFlag() bool }); ok && b.IsBoolFlag() {
+		return "true"
+	}
+	return "requested"
 }

--- a/main_test.go
+++ b/main_test.go
@@ -18,28 +18,18 @@ import (
 func TestExclusiveModeMsg(t *testing.T) {
 	c := check.New(t)
 	for _, tc := range []struct {
-		name             string
-		textTmplPath     string
-		finishUpdatePath string
-		wantContains     []string
-		convert          bool
-		sync             bool
-		wantErr          bool
+		name         string
+		modes        []string
+		wantContains []string
+		wantErr      bool
 	}{
 		{name: "none specified"},
-		{name: "convert only", convert: true},
-		{name: "sync only", sync: true},
-		{name: "text only", textTmplPath: "tmpl"},
-		{name: "finish-update only", finishUpdatePath: "state.json"},
-		{name: "convert and sync", convert: true, sync: true, wantErr: true, wantContains: []string{"--convert", "--sync"}},
-		{name: "convert and text", convert: true, textTmplPath: "tmpl", wantErr: true, wantContains: []string{"--convert", "--text"}},
-		{name: "sync and text", sync: true, textTmplPath: "tmpl", wantErr: true, wantContains: []string{"--sync", "--text"}},
-		{name: "finish-update and convert", convert: true, finishUpdatePath: "state.json", wantErr: true, wantContains: []string{"--convert", "--finish-update"}},
-		{name: "finish-update and text", textTmplPath: "tmpl", finishUpdatePath: "state.json", wantErr: true, wantContains: []string{"--text", "--finish-update"}},
-		{name: "all three", convert: true, sync: true, textTmplPath: "tmpl", wantErr: true, wantContains: []string{"--convert", "--sync", "--text"}},
-		{name: "all four", convert: true, sync: true, textTmplPath: "tmpl", finishUpdatePath: "state.json", wantErr: true, wantContains: []string{"--convert", "--sync", "--text", "--finish-update"}},
+		{name: "one mode", modes: []string{"--convert"}},
+		{name: "two modes", modes: []string{"--convert", "--sync"}, wantErr: true, wantContains: []string{"--convert", "--sync"}},
+		{name: "four modes", modes: []string{"--convert", "--sync", "--text", "--finish-update"}, wantErr: true, wantContains: []string{"--convert", "--sync", "--text", "--finish-update"}},
+		{name: "five modes", modes: []string{"--convert", "--sync", "--text", "--finish-update", "--headless-api"}, wantErr: true, wantContains: []string{"--convert", "--sync", "--text", "--finish-update", "--headless-api"}},
 	} {
-		msg := exclusiveModeMsg(tc.convert, tc.sync, tc.textTmplPath, tc.finishUpdatePath)
+		msg := exclusiveModeMsg(tc.modes)
 		if tc.wantErr {
 			c.NotEqual("", msg, tc.name)
 			for _, want := range tc.wantContains {

--- a/main_test.go
+++ b/main_test.go
@@ -23,11 +23,31 @@ func TestExclusiveModeMsg(t *testing.T) {
 		wantContains []string
 		wantErr      bool
 	}{
-		{name: "none specified"},
-		{name: "one mode", modes: []string{"--convert"}},
-		{name: "two modes", modes: []string{"--convert", "--sync"}, wantErr: true, wantContains: []string{"--convert", "--sync"}},
-		{name: "four modes", modes: []string{"--convert", "--sync", "--text", "--finish-update"}, wantErr: true, wantContains: []string{"--convert", "--sync", "--text", "--finish-update"}},
-		{name: "five modes", modes: []string{"--convert", "--sync", "--text", "--finish-update", "--headless-api"}, wantErr: true, wantContains: []string{"--convert", "--sync", "--text", "--finish-update", "--headless-api"}},
+		{
+			name: "none specified",
+		},
+		{
+			name:  "one mode",
+			modes: []string{"convert"},
+		},
+		{
+			name:         "two modes",
+			modes:        []string{"convert", "sync"},
+			wantErr:      true,
+			wantContains: []string{"-convert", "-sync"},
+		},
+		{
+			name:         "four modes",
+			modes:        []string{"convert", "sync", "text", "finish-update"},
+			wantErr:      true,
+			wantContains: []string{"-convert", "-sync", "-text", "-finish-update"},
+		},
+		{
+			name:         "five modes",
+			modes:        []string{"convert", "sync", "text", "finish-update", "headless-api"},
+			wantErr:      true,
+			wantContains: []string{"-convert", "-sync", "-text", "-finish-update", "-headless-api"},
+		},
 	} {
 		msg := exclusiveModeMsg(tc.modes)
 		if tc.wantErr {

--- a/model/gurps/run_modes.go
+++ b/model/gurps/run_modes.go
@@ -1,0 +1,83 @@
+// Copyright (c) 1998-2026 by Richard A. Wilkes. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, version 2.0. If a copy of the MPL was not distributed with
+// this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, version 2.0.
+
+package gurps
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/richardwilkes/gcs/v5/runmode"
+	"github.com/richardwilkes/toolbox/v2/i18n"
+	"github.com/richardwilkes/toolbox/v2/xos"
+)
+
+func init() {
+	runmode.Factories = append(runmode.Factories, newConvertRunMode, newSyncRunMode, newExportSheetsRunMode)
+}
+
+// newConvertRunMode registers 'convert' on flag.CommandLine as a side effect of being called, and returns the
+// runmode.Mode that converts the files given on the command line to the current file format.
+func newConvertRunMode(flagSet *flag.FlagSet) runmode.Mode {
+	if flagSet == nil {
+		flagSet = flag.CommandLine
+	}
+	convert := flagSet.Bool("convert", false, i18n.Text("Convert all files specified on the command line to the current data format. If a directory is specified, it will be traversed recursively and all files found will be converted. After all files have been processed, GCS will exit"))
+	return runmode.Mode{
+		Name:      "convert",
+		Requested: func() bool { return *convert },
+		Start: func(files []string) {
+			if err := Convert(files...); err != nil {
+				xos.ExitWithMsg(err.Error())
+			}
+			xos.Exit(0)
+		},
+	}
+}
+
+// newSyncRunMode registers 'sync' on flag.CommandLine as a side effect of being called, and returns the runmode.Mode
+// that syncs the files given on the command line with their library sources.
+func newSyncRunMode(flagSet *flag.FlagSet) runmode.Mode {
+	if flagSet == nil {
+		flagSet = flag.CommandLine
+	}
+	sync := flagSet.Bool("sync", false, fmt.Sprintf(i18n.Text("Syncs all character sheet (%s), template (%s), and loot (%s) files specified on the command line with their library sources. If a directory is specified, it will be traversed recursively and all files found will be converted. After all files have been processed, GCS will exit"), SheetExt, TemplatesExt, LootExt))
+	return runmode.Mode{
+		Name:      "sync",
+		Requested: func() bool { return *sync },
+		Start: func(files []string) {
+			if err := SyncToLibraryData(files...); err != nil {
+				xos.ExitWithMsg(err.Error())
+			}
+			xos.Exit(0)
+		},
+	}
+}
+
+// newExportSheetsRunMode registers 'text' on flag.CommandLine as a side effect of being called, and returns the
+// runmode.Mode that exports the sheets given on the command line using the specified text template.
+func newExportSheetsRunMode(flagSet *flag.FlagSet) runmode.Mode {
+	if flagSet == nil {
+		flagSet = flag.CommandLine
+	}
+	textTmplPath := flagSet.String("text", "", i18n.Text("Export sheets using the specified text template `file`"))
+	return runmode.Mode{
+		Name:      "text",
+		Requested: func() bool { return *textTmplPath != "" },
+		Start: func(files []string) {
+			if len(files) == 0 {
+				xos.ExitWithMsg(i18n.Text("No files to process."))
+			}
+			if err := ExportSheets(*textTmplPath, files); err != nil {
+				xos.ExitWithMsg(err.Error())
+			}
+			xos.Exit(0)
+		},
+	}
+}

--- a/model/gurps/run_modes.go
+++ b/model/gurps/run_modes.go
@@ -22,7 +22,7 @@ func init() {
 	runmode.Factories = append(runmode.Factories, newConvertRunMode, newSyncRunMode, newExportSheetsRunMode)
 }
 
-// newConvertRunMode registers 'convert' on flag.CommandLine as a side effect of being called, and returns the
+// newConvertRunMode registers 'convert' on flagSet as a side effect of being called, and returns the
 // runmode.Mode that converts the files given on the command line to the current file format.
 func newConvertRunMode(flagSet *flag.FlagSet) runmode.Mode {
 	if flagSet == nil {
@@ -41,7 +41,7 @@ func newConvertRunMode(flagSet *flag.FlagSet) runmode.Mode {
 	}
 }
 
-// newSyncRunMode registers 'sync' on flag.CommandLine as a side effect of being called, and returns the runmode.Mode
+// newSyncRunMode registers 'sync' on flagSet as a side effect of being called, and returns the runmode.Mode
 // that syncs the files given on the command line with their library sources.
 func newSyncRunMode(flagSet *flag.FlagSet) runmode.Mode {
 	if flagSet == nil {
@@ -60,7 +60,7 @@ func newSyncRunMode(flagSet *flag.FlagSet) runmode.Mode {
 	}
 }
 
-// newExportSheetsRunMode registers 'text' on flag.CommandLine as a side effect of being called, and returns the
+// newExportSheetsRunMode registers 'text' on flagSet as a side effect of being called, and returns the
 // runmode.Mode that exports the sheets given on the command line using the specified text template.
 func newExportSheetsRunMode(flagSet *flag.FlagSet) runmode.Mode {
 	if flagSet == nil {

--- a/runmode/runmode.go
+++ b/runmode/runmode.go
@@ -15,7 +15,8 @@ import "flag"
 
 // Mode describes one alternate run mode.
 type Mode struct {
-	// Name identifies this mode in the "cannot combine modes" error.
+	// Name identifies this mode in the "cannot combine modes" error, where it is shown as a flag. It is therefore
+	// also the name of the flag that requests this mode.
 	Name string
 	// HiddenFlagNames lists the flags that xflag.SetUsage should hide.
 	HiddenFlagNames []string
@@ -25,8 +26,9 @@ type Mode struct {
 	Start func(files []string)
 }
 
-// Factory registers a run mode's command line flags as a side effect of being called, and returns the Mode
-// describing it. main calls every factory in Factories ahead of flag.Parse, exactly once each.
+// Factory registers a run mode's command line flags on the given flag set as a side effect of being called, and
+// returns the Mode describing it. main calls every factory in Factories with flag.CommandLine ahead of flag.Parse,
+// exactly once each.
 type Factory func(*flag.FlagSet) Mode
 
 // Factories holds the run mode factories registered by init functions elsewhere, typically one per package that

--- a/runmode/runmode.go
+++ b/runmode/runmode.go
@@ -1,0 +1,35 @@
+// Copyright (c) 1998-2026 by Richard A. Wilkes. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, version 2.0. If a copy of the MPL was not distributed with
+// this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, version 2.0.
+
+// Package runmode lets any package register an alternate mode main() can dispatch to instead of the normal UI --
+// something that takes over the process and exits, the way -convert, -sync and -text already do.
+package runmode
+
+import "flag"
+
+// Mode describes one alternate run mode.
+type Mode struct {
+	// Name identifies this mode in the "cannot combine modes" error.
+	Name string
+	// HiddenFlagNames lists the flags that xflag.SetUsage should hide.
+	HiddenFlagNames []string
+	// Requested reports whether this mode has been requested. Only meaningful after flag.Parse.
+	Requested func() bool
+	// Start starts the mode with the file list from the command line. Never returns.
+	Start func(files []string)
+}
+
+// Factory registers a run mode's command line flags as a side effect of being called, and returns the Mode
+// describing it. main calls every factory in Factories ahead of flag.Parse, exactly once each.
+type Factory func(*flag.FlagSet) Mode
+
+// Factories holds the run mode factories registered by init functions elsewhere, typically one per package that
+// wants to offer an alternate mode. main iterates this slice rather than referring to any specific mode by name, so
+// which alternate modes exist, if any, is entirely up to what got compiled into this build.
+var Factories []Factory

--- a/updater/run_modes.go
+++ b/updater/run_modes.go
@@ -22,7 +22,7 @@ func init() {
 	runmode.Factories = append(runmode.Factories, newFinishRunMode)
 }
 
-// newFinishRunMode registers the hidden -finish-update flag on flag.CommandLine as a side effect of being called,
+// newFinishRunMode registers the hidden -finish-update flag on flagSet as a side effect of being called,
 // and returns the runmode.Mode that finishes applying a staged update. Not meant to be typed by anyone: a copy of
 // GCS is started this way to finish applying an update once the copy that prepared it has exited, since replacing a
 // running application from within itself is not something any of the supported systems allow. Its Start must never

--- a/updater/run_modes.go
+++ b/updater/run_modes.go
@@ -1,0 +1,48 @@
+// Copyright (c) 1998-2026 by Richard A. Wilkes. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, version 2.0. If a copy of the MPL was not distributed with
+// this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, version 2.0.
+
+package updater
+
+import (
+	"flag"
+
+	"github.com/richardwilkes/gcs/v5/runmode"
+	"github.com/richardwilkes/toolbox/v2/errs"
+	"github.com/richardwilkes/toolbox/v2/i18n"
+	"github.com/richardwilkes/toolbox/v2/xos"
+)
+
+func init() {
+	runmode.Factories = append(runmode.Factories, newFinishRunMode)
+}
+
+// newFinishRunMode registers the hidden -finish-update flag on flag.CommandLine as a side effect of being called,
+// and returns the runmode.Mode that finishes applying a staged update. Not meant to be typed by anyone: a copy of
+// GCS is started this way to finish applying an update once the copy that prepared it has exited, since replacing a
+// running application from within itself is not something any of the supported systems allow. Its Start must never
+// reach ux.Start's single-instance handoff protocol. Waiting for that protocol's port to be released is this mode's
+// whole job. Running as its own runmode.Mode, mutually exclusive with every other mode, guarantees this outcome.
+func newFinishRunMode(flagSet *flag.FlagSet) runmode.Mode {
+	if flagSet == nil {
+		flagSet = flag.CommandLine
+	}
+	statePath := flagSet.String(FinishFlag, "", i18n.Text("Internal use only. Finish applying a previously prepared update, using the state in the specified `file`"))
+	return runmode.Mode{
+		Name:            FinishFlag,
+		HiddenFlagNames: []string{FinishFlag},
+		Requested:       func() bool { return *statePath != "" },
+		Start: func(_ []string) {
+			if err := Finish(*statePath); err != nil {
+				errs.Log(err)
+				xos.Exit(1)
+			}
+			xos.Exit(0)
+		},
+	}
+}

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -258,20 +258,7 @@ func (s *headlessAPIServer) handleInput(w http.ResponseWriter, r *http.Request) 
 func parseMods(names []string) mod.Modifiers {
 	var m mod.Modifiers
 	for _, n := range names {
-		switch strings.ToLower(n) {
-		case "shift":
-			m |= mod.Shift
-		case "control", "ctrl":
-			m |= mod.Control
-		case "option", "alt":
-			m |= mod.Option
-		case "command", "cmd", "meta":
-			m |= mod.Command
-		case "capslock":
-			m |= mod.CapsLock
-		case "numlock":
-			m |= mod.NumLock
-		}
+		m |= mod.FromKey(n)
 	}
 	return m
 }

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -68,7 +68,8 @@ func newHeadlessAPIRunMode(flagSet *flag.FlagSet) runmode.Mode {
 // StartHeadlessAPI starts GCS headless -- no real window ever appears -- with a debug HTTP server listening on addr
 // that lets automated tooling drive and inspect the running app:
 //
-//   - POST /input      inject a click, double-click, drag, wheel, key press or typed text
+//   - POST /input       inject a click, double-click, drag, wheel, key press or typed text
+//   - GET  /input       the canonical key and modifier names POST /input recognizes
 //   - GET  /inspect     the widget at a point: type, absolute bounding rect, tooltip, enabled state, text
 //   - GET  /inspect/focus  the same, for whatever currently holds keyboard focus (e.g. an open error dialog)
 //   - GET  /screenshot  a PNG of the whole virtual screen, or of an absolute rectangle within it
@@ -118,6 +119,7 @@ func StartHeadlessAPI(addr string, width, height float32, files []string) {
 	xos.RunAtExit(screen.Stop)
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /input", server.handleInputVocabulary)
 	mux.HandleFunc("POST /input", server.handleInput)
 	mux.HandleFunc("GET /inspect", server.handleInspect)
 	mux.HandleFunc("GET /inspect/focus", server.handleInspectFocus)
@@ -281,6 +283,29 @@ func resolveKeyCode(name string, code int) (unison.KeyCode, bool) {
 	}
 	keyCode := unison.KeyCodeFromKey(name)
 	return keyCode, keyCode != unison.KeyNone
+}
+
+// handleInputVocabulary reports the canonical name -- unison.KeyCode.Key() and mod.Modifiers.Key(), respectively --
+// of every key and modifier POST /input recognizes, so a caller can discover the exact vocabulary rather than
+// guessing at it. resolveKeyCode and parseMods also tolerate other forms of these names -- any casing for keys, and
+// a handful of longer aliases plus "+"-joined combinations for modifiers.
+func (s *headlessAPIServer) handleInputVocabulary(w http.ResponseWriter, _ *http.Request) {
+	keyCodeList := unison.KeyCodeList()
+	keys := make([]string, len(keyCodeList))
+	for i, k := range keyCodeList {
+		keys[i] = k.Key()
+	}
+
+	modList := mod.List()
+	mods := make([]string, len(modList))
+	for i, m := range modList {
+		mods[i] = m.Key()
+	}
+
+	writeJSON(w, struct {
+		Keys      []string `json:"keys"`
+		Modifiers []string `json:"modifiers"`
+	}{Keys: keys, Modifiers: mods})
 }
 
 // --- /inspect and /inspect/focus -------------------------------------------

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -1,0 +1,620 @@
+// Copyright (c) 1998-2026 by Richard A. Wilkes. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, version 2.0. If a copy of the MPL was not distributed with
+// this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, version 2.0.
+
+//go:build headlessapi
+
+package ux
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"image"
+	"image/png"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/richardwilkes/gcs/v5/model/colors"
+	"github.com/richardwilkes/gcs/v5/model/gurps"
+	"github.com/richardwilkes/gcs/v5/runmode"
+	"github.com/richardwilkes/toolbox/v2/errs"
+	"github.com/richardwilkes/toolbox/v2/geom"
+	"github.com/richardwilkes/toolbox/v2/i18n"
+	"github.com/richardwilkes/toolbox/v2/xos"
+	"github.com/richardwilkes/unison"
+	"github.com/richardwilkes/unison/enums/mod"
+)
+
+// init registers the headless debug API as a runmode.Mode, which is how main learns about -headless-api at all: a
+// build compiled without the headlessapi tag never runs this file, so runmode.Factories stays empty and main has no
+// trace of any of it -- no flags, no help text, no mode name, nothing.
+func init() {
+	runmode.Factories = append(runmode.Factories, newHeadlessAPIRunMode)
+}
+
+// newHeadlessAPIRunMode registers -headless-api, -headless-api-width and -headless-api-height on flag.CommandLine as
+// a side effect of being called, and returns the runmode.Mode that starts the headless debug API those flags
+// configure.
+func newHeadlessAPIRunMode(flagSet *flag.FlagSet) runmode.Mode {
+	if flagSet == nil {
+		flagSet = flag.CommandLine
+	}
+	addr := flagSet.String("headless-api", "", i18n.Text("Internal use only. Start the headless debug API on the given `address` (e.g. \"127.0.0.1:8642\") instead of the normal UI"))
+	width := flagSet.Float64("headless-api-width", 1400, i18n.Text("Internal use only. Logical width of the virtual screen the headless debug API renders to"))
+	height := flagSet.Float64("headless-api-height", 900, i18n.Text("Internal use only. Logical height of the virtual screen the headless debug API renders to"))
+	return runmode.Mode{
+		Name:            "headless-api",
+		HiddenFlagNames: []string{"headless-api", "headless-api-width", "headless-api-height"},
+		Requested:       func() bool { return *addr != "" },
+		Start: func(files []string) {
+			StartHeadlessAPI(*addr, float32(*width), float32(*height), files)
+		},
+	}
+}
+
+// StartHeadlessAPI starts GCS headless -- no real window ever appears -- with a debug HTTP server listening on addr
+// that lets automated tooling drive and inspect the running app:
+//
+//   - POST /input      inject a click, double-click, drag, wheel, key press or typed text
+//   - GET  /inspect     the widget at a point: type, absolute bounding rect, tooltip, enabled state, text
+//   - GET  /inspect/focus  the same, for whatever currently holds keyboard focus (e.g. an open error dialog)
+//   - GET  /screenshot  a PNG of the whole virtual screen, or of an absolute rectangle within it
+//   - GET  /console     log output and session errors recorded since a given sequence number
+//
+// Coordinates everywhere in the protocol -- input points, inspected rects, screenshot rects -- are in the same
+// logical, screen-absolute space: the one /inspect and /inspect/focus report a widget's rect in is exactly the one a
+// screenshot rect or an input point should be given in, and windows other than the main one (such as a modal error
+// dialog) are positioned within it, not at their own private origin.
+//
+// The virtual screen's size is fixed for the life of the session; there is no live resize.
+//
+// It never returns.
+func StartHeadlessAPI(addr string, width, height float32, files []string) {
+	console := &consoleBuffer{}
+	slog.SetDefault(slog.New(&teeLogHandler{orig: slog.Default().Handler(), buf: console}))
+
+	if width <= 0 {
+		width = 1400
+	}
+	if height <= 0 {
+		height = 900
+	}
+
+	server := &headlessAPIServer{console: console}
+	screen, err := unison.StartHeadless(unison.HeadlessConfig{Width: width, Height: height},
+		unison.StartupFinishedCallback(func() {
+			unison.DefaultTableColumnHeaderTheme.OnBackgroundInk = colors.OnHeader
+			unison.DefaultMarkdownTheme.LinkHandler = HandleLink
+			unison.DefaultMarkdownTheme.WorkingDirProvider = WorkingDirProvider
+			unison.DefaultMarkdownTheme.AltLinkPrefixes = []string{"md:"}
+			wnd, wndErr := unison.NewWindow(xos.AppName)
+			if wndErr != nil {
+				errs.Log(wndErr)
+				xos.Exit(1)
+			}
+			server.wnd = wnd
+			registerWindowDragTypes(server.wnd)
+			SetupMenuBar(server.wnd)
+			InitWorkspace(server.wnd)
+			OpenFiles(files)
+		}),
+	)
+	if err != nil {
+		xos.ExitWithMsg(fmt.Sprintf("unable to start the headless session: %v", err))
+	}
+	server.screen = screen
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /input", server.handleInput)
+	mux.HandleFunc("GET /inspect", server.handleInspect)
+	mux.HandleFunc("GET /inspect/focus", server.handleInspectFocus)
+	mux.HandleFunc("GET /screenshot", server.handleScreenshot)
+	mux.HandleFunc("GET /console", server.handleConsole)
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		xos.ExitWithMsg(fmt.Sprintf("unable to listen on %s: %v", addr, err))
+	}
+	slog.Info("headless debug API listening", "addr", listener.Addr().String())
+	httpServer := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+
+	// The workspace's own settings-saving close handler (workspaceWillClose, in workspace.go) only ever runs when the
+	// main window is closed the normal way, and nothing here ever closes it -- the process just runs until killed.
+	// Without this, everything settings-backed (page reference mappings, recent files, window layout, and so on) that
+	// a session here changes is silently lost the moment the container stops, however it stops. A periodic autosave
+	// covers an unclean stop (SIGKILL, OOM, a crash); the signal handler below covers a clean one (SIGINT/SIGTERM,
+	// which is what "podman stop"/"docker stop" send, and Ctrl-C) by saving once more and only then letting the
+	// process exit, so the common case loses nothing at all.
+	stopAutosave := make(chan struct{})
+	go autosaveSettings(screen, stopAutosave)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		close(stopAutosave)
+		saveSettings(screen)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if shutdownErr := httpServer.Shutdown(shutdownCtx); shutdownErr != nil {
+			errs.Log(shutdownErr)
+		}
+	}()
+
+	if err = httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		errs.Log(err)
+	}
+	screen.Stop()
+	xos.Exit(0)
+}
+
+// autosaveSettings saves the global settings every minute until stop is closed, as a safety net for a container stop
+// that never reaches the signal handler in StartHeadlessAPI (SIGKILL, an OOM kill, a crash).
+func autosaveSettings(screen *unison.HeadlessScreen, stop <-chan struct{}) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			saveSettings(screen)
+		case <-stop:
+			return
+		}
+	}
+}
+
+// saveSettings saves the global settings on the UI thread, the same way workspaceWillClose (workspace.go) does on a
+// normal window close, logging rather than reporting through Workspace.ErrorHandler: nobody is here to see a dialog,
+// and by the time this runs from the shutdown signal handler, the caller wants the process to exit either way.
+func saveSettings(screen *unison.HeadlessScreen) {
+	screen.Do(func() {
+		if err := gurps.GlobalSettings().Save(); err != nil {
+			errs.Log(err)
+		}
+	})
+}
+
+type headlessAPIServer struct {
+	screen *unison.HeadlessScreen
+	wnd    *unison.Window
+
+	console  *consoleBuffer
+	errMu    sync.Mutex
+	errCount int
+}
+
+// drainSessionErrors copies whatever HeadlessScreen.Errors() has recorded since the last drain -- recovered panics and
+// requests the session itself refused -- into the console buffer, tagged distinctly from ordinary log output.
+func (s *headlessAPIServer) drainSessionErrors() {
+	s.errMu.Lock()
+	defer s.errMu.Unlock()
+	all := s.screen.Errors()
+	for _, e := range all[s.errCount:] {
+		s.console.add("session", "error", e.Error())
+	}
+	s.errCount = len(all)
+}
+
+// --- /input ---------------------------------------------------------------
+
+type inputRequest struct {
+	Op     string   `json:"op"`
+	X      float32  `json:"x"`
+	Y      float32  `json:"y"`
+	ToX    float32  `json:"toX"`
+	ToY    float32  `json:"toY"`
+	DeltaX float32  `json:"deltaX"`
+	DeltaY float32  `json:"deltaY"`
+	Steps  int      `json:"steps"`
+	Button string   `json:"button"`
+	Mods   []string `json:"mods"`
+	Text   string   `json:"text"`
+	Key    string   `json:"key"`
+	Code   int      `json:"code"`
+}
+
+func (s *headlessAPIServer) handleInput(w http.ResponseWriter, r *http.Request) {
+	var req inputRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	mods := parseMods(req.Mods)
+	switch req.Op {
+	case "click":
+		s.screen.ClickWith(geom.NewPoint(req.X, req.Y), parseButton(req.Button), mods)
+	case "doubleclick":
+		s.screen.DoubleClick(geom.NewPoint(req.X, req.Y))
+	case "drag":
+		s.screen.Drag(geom.NewPoint(req.X, req.Y), geom.NewPoint(req.ToX, req.ToY), max(req.Steps, 1))
+	case "wheel":
+		s.screen.Wheel(geom.NewPoint(req.X, req.Y), geom.NewPoint(req.DeltaX, req.DeltaY), mods)
+	case "type":
+		s.screen.Type(req.Text)
+	case "key":
+		code, ok := resolveKeyCode(req.Key, req.Code)
+		if !ok {
+			http.Error(w, "unknown key: give a recognized 'key' name or a numeric 'code'", http.StatusBadRequest)
+			return
+		}
+		s.screen.KeyPress(code, mods)
+	default:
+		http.Error(w, "unknown op: "+req.Op, http.StatusBadRequest)
+		return
+	}
+	s.drainSessionErrors()
+	writeJSON(w, struct {
+		OK bool `json:"ok"`
+	}{OK: true})
+}
+
+func parseMods(names []string) mod.Modifiers {
+	var m mod.Modifiers
+	for _, n := range names {
+		switch strings.ToLower(n) {
+		case "shift":
+			m |= mod.Shift
+		case "control", "ctrl":
+			m |= mod.Control
+		case "option", "alt":
+			m |= mod.Option
+		case "command", "cmd", "meta":
+			m |= mod.Command
+		case "capslock":
+			m |= mod.CapsLock
+		case "numlock":
+			m |= mod.NumLock
+		}
+	}
+	return m
+}
+
+func parseButton(name string) int {
+	switch strings.ToLower(name) {
+	case "right":
+		return unison.ButtonRight
+	case "middle":
+		return unison.ButtonMiddle
+	default:
+		return unison.ButtonLeft
+	}
+}
+
+var namedKeys = map[string]unison.KeyCode{
+	"return": unison.KeyReturn, "enter": unison.KeyReturn,
+	"tab":       unison.KeyTab,
+	"escape":    unison.KeyEscape,
+	"esc":       unison.KeyEscape,
+	"backspace": unison.KeyBackspace,
+	"delete":    unison.KeyDelete,
+	"insert":    unison.KeyInsert,
+	"up":        unison.KeyUp,
+	"down":      unison.KeyDown,
+	"left":      unison.KeyLeft,
+	"right":     unison.KeyRight,
+	"home":      unison.KeyHome,
+	"end":       unison.KeyEnd,
+	"pageup":    unison.KeyPageUp,
+	"pagedown":  unison.KeyPageDown,
+	"space":     unison.KeySpace,
+	"f1":        unison.KeyF1,
+	"f2":        unison.KeyF2,
+	"f3":        unison.KeyF3,
+	"f4":        unison.KeyF4,
+	"f5":        unison.KeyF5,
+	"f6":        unison.KeyF6,
+	"f7":        unison.KeyF7,
+	"f8":        unison.KeyF8,
+	"f9":        unison.KeyF9,
+	"f10":       unison.KeyF10,
+	"f11":       unison.KeyF11,
+	"f12":       unison.KeyF12,
+}
+
+// resolveKeyCode resolves a "key" op's target key: an explicit numeric code takes precedence, then a name from
+// namedKeys, then a single ASCII letter or digit.
+func resolveKeyCode(name string, code int) (unison.KeyCode, bool) {
+	if code != 0 {
+		return unison.KeyCode(code), true
+	}
+	if kc, ok := namedKeys[strings.ToLower(name)]; ok {
+		return kc, true
+	}
+	if len(name) == 1 {
+		switch ch := name[0]; {
+		case ch >= 'a' && ch <= 'z':
+			return unison.KeyA + unison.KeyCode(ch-'a'), true
+		case ch >= 'A' && ch <= 'Z':
+			return unison.KeyA + unison.KeyCode(ch-'A'), true
+		case ch >= '0' && ch <= '9':
+			return unison.Key0 + unison.KeyCode(ch-'0'), true
+		}
+	}
+	return 0, false
+}
+
+// --- /inspect and /inspect/focus -------------------------------------------
+
+type rectDTO struct {
+	X float32 `json:"x"`
+	Y float32 `json:"y"`
+	W float32 `json:"w"`
+	H float32 `json:"h"`
+}
+
+func rectFromGeom(r geom.Rect) rectDTO {
+	return rectDTO{X: r.X, Y: r.Y, W: r.Width, H: r.Height}
+}
+
+type panelDTO struct {
+	Type    string  `json:"type"`
+	Rect    rectDTO `json:"rect"`
+	Tooltip string  `json:"tooltip,omitempty"`
+	Enabled bool    `json:"enabled"`
+	Text    string  `json:"text,omitempty"`
+}
+
+type windowDTO struct {
+	Title string  `json:"title"`
+	Rect  rectDTO `json:"rect"`
+}
+
+type inspectResult struct {
+	Window    windowDTO  `json:"window"`
+	Panel     *panelDTO  `json:"panel,omitempty"`
+	Ancestors []panelDTO `json:"ancestors,omitempty"`
+}
+
+func (s *headlessAPIServer) handleInspect(w http.ResponseWriter, r *http.Request) {
+	x, errX := strconv.ParseFloat(r.URL.Query().Get("x"), 32)
+	y, errY := strconv.ParseFloat(r.URL.Query().Get("y"), 32)
+	if errX != nil || errY != nil {
+		http.Error(w, "x and y are required numbers", http.StatusBadRequest)
+		return
+	}
+	pt := geom.NewPoint(float32(x), float32(y))
+	var result inspectResult
+	var ok bool
+	s.screen.Do(func() {
+		wnd := s.screen.WindowAt(pt)
+		if wnd == nil {
+			return
+		}
+		ok = true
+		local := pt.Sub(wnd.ContentRect().Point)
+		result = describeWindowAndPanel(wnd, wnd.Content().PanelAt(local))
+	})
+	if !ok {
+		http.Error(w, "no window at that point", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, result)
+}
+
+func (s *headlessAPIServer) handleInspectFocus(w http.ResponseWriter, _ *http.Request) {
+	var result inspectResult
+	var ok bool
+	s.screen.Do(func() {
+		wnd := s.screen.FocusedWindow()
+		if wnd == nil {
+			return
+		}
+		ok = true
+		result = describeWindowAndPanel(wnd, wnd.Focus())
+	})
+	if !ok {
+		http.Error(w, "nothing is focused", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, result)
+}
+
+// describeWindowAndPanel must be called on the UI thread. It reports leaf's rect, and every ancestor's, translated by
+// wnd's position on the shared virtual screen -- the same absolute space /screenshot and /input use -- rather than in
+// wnd's own window-local space.
+func describeWindowAndPanel(wnd *unison.Window, leaf *unison.Panel) inspectResult {
+	origin := wnd.ContentRect().Point
+	result := inspectResult{Window: windowDTO{Title: wnd.Title(), Rect: rectFromGeom(wnd.ContentRect())}}
+	if leaf == nil {
+		return result
+	}
+	d := describePanel(leaf, origin)
+	result.Panel = &d
+	for anc := leaf.Parent(); anc != nil; anc = anc.Parent() {
+		result.Ancestors = append(result.Ancestors, describePanel(anc, origin))
+	}
+	return result
+}
+
+func describePanel(p *unison.Panel, origin geom.Point) panelDTO {
+	rect := p.RectToRoot(p.ContentRect(false))
+	rect.Point = rect.Point.Add(origin)
+	d := panelDTO{
+		Type:    fmt.Sprintf("%T", p.Self),
+		Rect:    rectFromGeom(rect),
+		Enabled: p.Enabled(),
+	}
+	if p.Tooltip != nil {
+		d.Tooltip = tooltipOf(p.Tooltip)
+	}
+	switch v := p.Self.(type) {
+	case interface{ Text() string }:
+		d.Text = v.Text()
+	case fmt.Stringer:
+		d.Text = v.String()
+	}
+	return d
+}
+
+// tooltipOf returns the text of a tooltip panel built the way this app's tooltips are: one label per line.
+func tooltipOf(tip *unison.Panel) string {
+	var lines []string
+	for _, child := range tip.Children() {
+		if label, ok := child.Self.(*unison.Label); ok {
+			lines = append(lines, label.String())
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// --- /screenshot -------------------------------------------------------------
+
+func (s *headlessAPIServer) handleScreenshot(w http.ResponseWriter, r *http.Request) {
+	s.screen.Sync()
+	img := s.screen.Capture()
+	if img == nil {
+		http.Error(w, "the screen has never been drawn", http.StatusInternalServerError)
+		return
+	}
+	q := r.URL.Query()
+	if q.Has("x") || q.Has("y") || q.Has("w") || q.Has("h") {
+		x, errX := strconv.ParseFloat(q.Get("x"), 32)
+		y, errY := strconv.ParseFloat(q.Get("y"), 32)
+		width, errW := strconv.ParseFloat(q.Get("w"), 32)
+		height, errH := strconv.ParseFloat(q.Get("h"), 32)
+		if errX != nil || errY != nil || errW != nil || errH != nil {
+			http.Error(w, "x, y, w and h must all be given together, as numbers", http.StatusBadRequest)
+			return
+		}
+		// The query rect is in the same logical, screen-absolute space as every other coordinate in the protocol;
+		// Capture() is in device pixels, so it is scaled up to match.
+		scale := float64(s.screen.Scale())
+		rect := image.Rect(
+			int(scale*x), int(scale*y),
+			int(scale*(x+width)), int(scale*(y+height)),
+		).Intersect(img.Bounds())
+		if rect.Empty() {
+			http.Error(w, "the requested rectangle does not intersect the screen", http.StatusBadRequest)
+			return
+		}
+		writeScreenshotPNG(w, img.SubImage(rect))
+		return
+	}
+	writeScreenshotPNG(w, img)
+}
+
+func writeScreenshotPNG(w http.ResponseWriter, img image.Image) {
+	w.Header().Set("Content-Type", "image/png")
+	if err := png.Encode(w, img); err != nil {
+		errs.Log(err)
+	}
+}
+
+// --- /console ----------------------------------------------------------------
+
+type consoleEntry struct {
+	Seq     int64  `json:"seq"`
+	Time    string `json:"time"`
+	Source  string `json:"source"` // "log" for slog/errs.Log output, "session" for HeadlessScreen.Errors()
+	Level   string `json:"level,omitempty"`
+	Message string `json:"message"`
+}
+
+// consoleBuffer is a bounded, timestamped log of everything StartHeadlessAPI wants an agent driving the app to be
+// able to see without a real console attached: slog output (including errs.Log, wherever it lands) and whatever
+// HeadlessScreen.Errors() has recorded. It deliberately does not intercept Workspace.ErrorHandler: an app-level error
+// after startup still pops the same modal dialog a real user would see, findable through /inspect/focus and
+// /screenshot like any other UI state, rather than being diverted here.
+type consoleBuffer struct {
+	mu      sync.Mutex
+	entries []consoleEntry
+	nextSeq int64
+}
+
+const consoleBufferLimit = 5000
+
+func (b *consoleBuffer) add(source, level, message string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.nextSeq++
+	b.entries = append(b.entries, consoleEntry{
+		Seq:     b.nextSeq,
+		Time:    time.Now().UTC().Format(time.RFC3339Nano),
+		Source:  source,
+		Level:   level,
+		Message: message,
+	})
+	if len(b.entries) > consoleBufferLimit {
+		b.entries = b.entries[len(b.entries)-consoleBufferLimit:]
+	}
+}
+
+func (b *consoleBuffer) since(seq int64) []consoleEntry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var out []consoleEntry
+	for _, e := range b.entries {
+		if e.Seq > seq {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func (s *headlessAPIServer) handleConsole(w http.ResponseWriter, r *http.Request) {
+	s.drainSessionErrors()
+	since := int64(0)
+	if v := r.URL.Query().Get("since"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			http.Error(w, "since must be an integer", http.StatusBadRequest)
+			return
+		}
+		since = n
+	}
+	writeJSON(w, struct {
+		Entries []consoleEntry `json:"entries"`
+	}{Entries: s.console.since(since)})
+}
+
+// teeLogHandler wraps whatever slog.Handler main.go's xslog.Config installed -- normally a rotating log file, plus
+// stdout only when -console was passed -- so that everything logged through it, including errs.Log, also lands in the
+// console buffer regardless of those flags. It changes nothing about where the original handler sends its own output.
+type teeLogHandler struct {
+	orig slog.Handler
+	buf  *consoleBuffer
+}
+
+func (h *teeLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.orig.Enabled(ctx, level)
+}
+
+func (h *teeLogHandler) Handle(ctx context.Context, record slog.Record) error { //nolint:gocritic // signature fixed by slog.Handler
+	msg := record.Message
+	record.Attrs(func(a slog.Attr) bool {
+		msg += " " + a.String()
+		return true
+	})
+	h.buf.add("log", record.Level.String(), msg)
+	return h.orig.Handle(ctx, record)
+}
+
+func (h *teeLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &teeLogHandler{orig: h.orig.WithAttrs(attrs), buf: h.buf}
+}
+
+func (h *teeLogHandler) WithGroup(name string) slog.Handler {
+	return &teeLogHandler{orig: h.orig.WithGroup(name), buf: h.buf}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		errs.Log(err)
+	}
+}

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -162,7 +162,7 @@ func newHeadlessAPIRunMode(flagSet *flag.FlagSet) runmode.Mode {
 //   - GET  /           this documentation, or this API's specification (see headless_api.md, headless_api.yaml)
 //   - POST /input       inject a click, double-click, drag, wheel, key press or typed text
 //   - GET  /input       the canonical key and modifier names POST /input recognizes
-//   - GET  /inspect     the widget at a point: type, absolute bounding rect, tooltip, enabled state, text
+//   - GET  /inspect     the widget at a point: type, absolute bounding and visible rects, tooltip, enabled, text
 //   - GET  /inspect/focus  the same, for whatever currently holds keyboard focus (e.g. an open error dialog)
 //   - GET  /screenshot  a PNG of the whole virtual screen, or of an absolute rectangle within it
 //   - GET  /console     log output and session errors recorded since a given sequence number
@@ -415,11 +415,12 @@ func rectFromGeom(r geom.Rect) rectDTO {
 }
 
 type panelDTO struct {
-	Type    string  `json:"type"`
-	Rect    rectDTO `json:"rect"`
-	Tooltip string  `json:"tooltip,omitempty"`
-	Enabled bool    `json:"enabled"`
-	Text    string  `json:"text,omitempty"`
+	Type    string   `json:"type"`
+	Rect    rectDTO  `json:"rect"`
+	Visible *rectDTO `json:"visible,omitempty"`
+	Tooltip string   `json:"tooltip,omitempty"`
+	Enabled bool     `json:"enabled"`
+	Text    string   `json:"text,omitempty"`
 }
 
 type windowDTO struct {
@@ -479,7 +480,8 @@ func (s *headlessAPIServer) handleInspectFocus(w http.ResponseWriter, _ *http.Re
 
 // describeWindowAndPanel must be called on the UI thread. It reports leaf's rect, and every ancestor's, translated by
 // wnd's position on the shared virtual screen -- the same absolute space /screenshot and /input use -- rather than in
-// wnd's own window-local space.
+// wnd's own window-local space. Alongside each full rect it reports the visible part of it, which is the one to aim
+// input at; see clipToVisible.
 func describeWindowAndPanel(wnd *unison.Window, leaf *unison.Panel) inspectResult {
 	origin := wnd.ContentRect().Point
 	result := inspectResult{Window: windowDTO{Title: wnd.Title(), Rect: rectFromGeom(wnd.ContentRect())}}
@@ -496,11 +498,17 @@ func describeWindowAndPanel(wnd *unison.Window, leaf *unison.Panel) inspectResul
 
 func describePanel(p *unison.Panel, origin geom.Point) panelDTO {
 	rect := p.RectToRoot(p.ContentRect(false))
+	visible := clipToVisible(p, rect)
 	rect.Point = rect.Point.Add(origin)
 	d := panelDTO{
 		Type:    fmt.Sprintf("%T", p.Self),
 		Rect:    rectFromGeom(rect),
 		Enabled: p.Enabled(),
+	}
+	if !visible.Empty() {
+		visible.Point = visible.Point.Add(origin)
+		v := rectFromGeom(visible)
+		d.Visible = &v
 	}
 	if p.Tooltip != nil {
 		d.Tooltip = tooltipOf(p.Tooltip)
@@ -512,6 +520,29 @@ func describePanel(p *unison.Panel, origin geom.Point) panelDTO {
 		d.Text = v.String()
 	}
 	return d
+}
+
+// clipToVisible returns the part of rect -- p's own rect, in root coordinates -- that is actually on screen. A panel's
+// rect is its whole extent, which inside a scroll panel can be far larger than the window, or scrolled entirely out
+// of sight; only what survives being clipped by every ancestor in turn, exactly as drawing clips it, can be seen or
+// aimed at. An empty result means none of the panel is showing, which is also what a hidden panel, or one below a
+// hidden ancestor, gets. Must be called on the UI thread.
+func clipToVisible(p *unison.Panel, rect geom.Rect) geom.Rect {
+	if p.Hidden {
+		return geom.Rect{}
+	}
+	for anc := p.Parent(); anc != nil; anc = anc.Parent() {
+		if anc.Hidden {
+			return geom.Rect{}
+		}
+		// The border is included because that is what clips: drawing hands a child the intersection of its frame with
+		// whatever the parent itself was given, and a parent's border is inside its frame, not outside it.
+		rect = rect.Intersect(anc.RectToRoot(anc.ContentRect(true)))
+		if rect.Empty() {
+			return geom.Rect{}
+		}
+	}
+	return rect
 }
 
 // tooltipOf returns the text of a tooltip panel built the way this app's tooltips are: one label per line.

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -108,10 +108,9 @@ func StartHeadlessAPI(addr string, width, height float32, files []string) {
 				errs.Log(wndErr)
 				xos.Exit(1)
 			}
-			server.wnd = wnd
-			registerWindowDragTypes(server.wnd)
-			SetupMenuBar(server.wnd)
-			InitWorkspace(server.wnd)
+			registerWindowDragTypes(wnd)
+			SetupMenuBar(wnd)
+			InitWorkspace(wnd)
 			OpenFiles(files)
 		}),
 	)
@@ -190,9 +189,7 @@ func saveSettings(screen *unison.HeadlessScreen) {
 }
 
 type headlessAPIServer struct {
-	screen *unison.HeadlessScreen
-	wnd    *unison.Window
-
+	screen   *unison.HeadlessScreen
 	console  *consoleBuffer
 	errMu    sync.Mutex
 	errCount int

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -22,12 +22,9 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"os"
-	"os/signal"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/richardwilkes/gcs/v5/model/colors"
@@ -142,10 +139,7 @@ func StartHeadlessAPI(addr string, width, height float32, files []string) {
 	// process exit, so the common case loses nothing at all.
 	stopAutosave := make(chan struct{})
 	go autosaveSettings(screen, stopAutosave)
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-sigCh
+	xos.RunAtExit(func() {
 		close(stopAutosave)
 		saveSettings(screen)
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -153,7 +147,7 @@ func StartHeadlessAPI(addr string, width, height float32, files []string) {
 		if shutdownErr := httpServer.Shutdown(shutdownCtx); shutdownErr != nil {
 			errs.Log(shutdownErr)
 		}
-	}()
+	})
 
 	if err = httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		errs.Log(err)

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -380,8 +380,8 @@ func resolveKeyCode(name string, code int) (unison.KeyCode, bool) {
 
 // handleInputVocabulary reports the canonical name -- unison.KeyCode.Key() and mod.Modifiers.Key(), respectively --
 // of every key and modifier POST /input recognizes, so a caller can discover the exact vocabulary rather than
-// guessing at it. resolveKeyCode and parseMods also tolerate other forms of these names -- any casing for keys, and
-// a handful of longer aliases plus "+"-joined combinations for modifiers.
+// guessing at it. resolveKeyCode also tolerates any casing of these names for keys, and a "mods" entry may be a
+// "+"-joined combination of these names, e.g. "ctrl+shift".
 func (s *headlessAPIServer) handleInputVocabulary(w http.ResponseWriter, _ *http.Request) {
 	keyCodeList := unison.KeyCodeList()
 	keys := make([]string, len(keyCodeList))

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -27,6 +27,10 @@ import (
 	"sync"
 	"time"
 
+	_ "embed"
+
+	"gopkg.in/yaml.v3"
+
 	"github.com/richardwilkes/gcs/v5/model/colors"
 	"github.com/richardwilkes/gcs/v5/model/gurps"
 	"github.com/richardwilkes/gcs/v5/runmode"
@@ -37,6 +41,93 @@ import (
 	"github.com/richardwilkes/unison"
 	"github.com/richardwilkes/unison/enums/mod"
 )
+
+//go:embed headless_api.md
+var apiDocsMD string
+
+//go:embed headless_api.yaml
+var apiSpecYAML string
+
+// handleAPIDocs serves this API's documentation at the session's root, so a caller that only knows the address can
+// find out what it can do: the prose in headless_api.md by default, or this API's specification (headless_api.yaml)
+// itself, as YAML or as JSON converted from it on the fly, according to the request's Accept header.
+func handleAPIDocs(w http.ResponseWriter, r *http.Request) {
+	switch negotiateDocFormat(r.Header.Get("Accept")) {
+	case docFormatJSON:
+		var spec any
+		if err := yaml.Unmarshal([]byte(apiSpecYAML), &spec); err != nil {
+			errs.Log(err)
+			http.Error(w, "unable to convert the API specification to JSON", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(spec); err != nil {
+			errs.Log(err)
+		}
+	case docFormatYAML:
+		w.Header().Set("Content-Type", "application/yaml")
+		if _, err := w.Write([]byte(apiSpecYAML)); err != nil {
+			errs.Log(err)
+		}
+	default:
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		if _, err := w.Write([]byte(apiDocsMD)); err != nil {
+			errs.Log(err)
+		}
+	}
+}
+
+// docFormat is which representation of the API documentation GET / should serve.
+type docFormat int
+
+const (
+	docFormatMD docFormat = iota
+	docFormatYAML
+	docFormatJSON
+)
+
+// negotiateDocFormat picks a docFormat from the value of an Accept header: docFormatJSON for application/json,
+// docFormatYAML for application/yaml or application/x-yaml, and docFormatMD -- the default -- for anything else,
+// including an empty or missing header, "*/*", or text/markdown itself. Ties (equal, and equal to the highest,
+// "q" value) are broken by whichever the header lists first.
+func negotiateDocFormat(accept string) docFormat {
+	best := docFormatMD
+	bestQ := -1.0
+	for entry := range strings.SplitSeq(accept, ",") {
+		mediaType, q := parseAcceptEntry(entry)
+		var format docFormat
+		switch mediaType {
+		case "application/json":
+			format = docFormatJSON
+		case "application/yaml", "application/x-yaml":
+			format = docFormatYAML
+		case "text/markdown":
+			format = docFormatMD
+		default:
+			continue
+		}
+		if q > bestQ {
+			best, bestQ = format, q
+		}
+	}
+	return best
+}
+
+// parseAcceptEntry parses one comma-separated entry of an Accept header, such as "application/json;q=0.9", into its
+// media type and "q" value (1, when absent).
+func parseAcceptEntry(entry string) (mediaType string, q float64) {
+	q = 1
+	fields := strings.Split(entry, ";")
+	mediaType = strings.TrimSpace(fields[0])
+	for _, param := range fields[1:] {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(param), "q="); ok {
+			if parsed, err := strconv.ParseFloat(v, 64); err == nil {
+				q = parsed
+			}
+		}
+	}
+	return mediaType, q
+}
 
 // init registers the headless debug API as a runmode.Mode, which is how main learns about -headless-api at all: a
 // build compiled without the headlessapi tag never runs this file, so runmode.Factories stays empty and main has no
@@ -68,6 +159,7 @@ func newHeadlessAPIRunMode(flagSet *flag.FlagSet) runmode.Mode {
 // StartHeadlessAPI starts GCS headless -- no real window ever appears -- with a debug HTTP server listening on addr
 // that lets automated tooling drive and inspect the running app:
 //
+//   - GET  /           this documentation, or this API's specification (see headless_api.md, headless_api.yaml)
 //   - POST /input       inject a click, double-click, drag, wheel, key press or typed text
 //   - GET  /input       the canonical key and modifier names POST /input recognizes
 //   - GET  /inspect     the widget at a point: type, absolute bounding rect, tooltip, enabled state, text
@@ -119,6 +211,7 @@ func StartHeadlessAPI(addr string, width, height float32, files []string) {
 	xos.RunAtExit(screen.Stop)
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /{$}", handleAPIDocs)
 	mux.HandleFunc("GET /input", server.handleInputVocabulary)
 	mux.HandleFunc("POST /input", server.handleInput)
 	mux.HandleFunc("GET /inspect", server.handleInspect)

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -274,57 +274,13 @@ func parseButton(name string) int {
 	}
 }
 
-var namedKeys = map[string]unison.KeyCode{
-	"return": unison.KeyReturn, "enter": unison.KeyReturn,
-	"tab":       unison.KeyTab,
-	"escape":    unison.KeyEscape,
-	"esc":       unison.KeyEscape,
-	"backspace": unison.KeyBackspace,
-	"delete":    unison.KeyDelete,
-	"insert":    unison.KeyInsert,
-	"up":        unison.KeyUp,
-	"down":      unison.KeyDown,
-	"left":      unison.KeyLeft,
-	"right":     unison.KeyRight,
-	"home":      unison.KeyHome,
-	"end":       unison.KeyEnd,
-	"pageup":    unison.KeyPageUp,
-	"pagedown":  unison.KeyPageDown,
-	"space":     unison.KeySpace,
-	"f1":        unison.KeyF1,
-	"f2":        unison.KeyF2,
-	"f3":        unison.KeyF3,
-	"f4":        unison.KeyF4,
-	"f5":        unison.KeyF5,
-	"f6":        unison.KeyF6,
-	"f7":        unison.KeyF7,
-	"f8":        unison.KeyF8,
-	"f9":        unison.KeyF9,
-	"f10":       unison.KeyF10,
-	"f11":       unison.KeyF11,
-	"f12":       unison.KeyF12,
-}
-
-// resolveKeyCode resolves a "key" op's target key: an explicit numeric code takes precedence, then a name from
-// namedKeys, then a single ASCII letter or digit.
+// resolveKeyCode resolves a "key" op's target key: an explicit numeric code takes precedence, then unison.KeyCodeFromKey
 func resolveKeyCode(name string, code int) (unison.KeyCode, bool) {
 	if code != 0 {
 		return unison.KeyCode(code), true
 	}
-	if kc, ok := namedKeys[strings.ToLower(name)]; ok {
-		return kc, true
-	}
-	if len(name) == 1 {
-		switch ch := name[0]; {
-		case ch >= 'a' && ch <= 'z':
-			return unison.KeyA + unison.KeyCode(ch-'a'), true
-		case ch >= 'A' && ch <= 'Z':
-			return unison.KeyA + unison.KeyCode(ch-'A'), true
-		case ch >= '0' && ch <= '9':
-			return unison.Key0 + unison.KeyCode(ch-'0'), true
-		}
-	}
-	return 0, false
+	keyCode := unison.KeyCodeFromKey(name)
+	return keyCode, keyCode != unison.KeyNone
 }
 
 // --- /inspect and /inspect/focus -------------------------------------------

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -332,7 +332,7 @@ func (s *headlessAPIServer) handleInspect(w http.ResponseWriter, r *http.Request
 		}
 		ok = true
 		local := pt.Sub(wnd.ContentRect().Point)
-		result = describeWindowAndPanel(wnd, wnd.Content().PanelAt(local))
+		result = describeWindowAndPanel(wnd, wnd.Content().Parent().PanelAt(local))
 	})
 	if !ok {
 		http.Error(w, "no window at that point", http.StatusNotFound)

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -460,6 +460,10 @@ func (s *headlessAPIServer) handleInspect(w http.ResponseWriter, r *http.Request
 	writeJSON(w, result)
 }
 
+// handleInspectFocus reports the focused panel of the focused window. It uses unison.Window.CurrentFocus rather than
+// Window.Focus because the latter assigns the focus to the window's first focusable panel when nothing holds it yet,
+// which is not something an "inspect" endpoint should be doing. A window that nothing in has been focused into
+// therefore reports no panel rather than acquiring one.
 func (s *headlessAPIServer) handleInspectFocus(w http.ResponseWriter, _ *http.Request) {
 	var result inspectResult
 	var ok bool
@@ -469,10 +473,10 @@ func (s *headlessAPIServer) handleInspectFocus(w http.ResponseWriter, _ *http.Re
 			return
 		}
 		ok = true
-		result = describeWindowAndPanel(wnd, wnd.Focus())
+		result = describeWindowAndPanel(wnd, wnd.CurrentFocus())
 	})
 	if !ok {
-		http.Error(w, "nothing is focused", http.StatusNotFound)
+		http.Error(w, "no window is focused", http.StatusNotFound)
 		return
 	}
 	writeJSON(w, result)

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -152,6 +152,7 @@ func StartHeadlessAPI(addr string, width, height float32, files []string) {
 
 	if err = httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		errs.Log(err)
+		xos.Exit(1)
 	}
 	xos.Exit(0)
 }

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -136,9 +136,8 @@ func init() {
 	runmode.Factories = append(runmode.Factories, newHeadlessAPIRunMode)
 }
 
-// newHeadlessAPIRunMode registers -headless-api, -headless-api-width and -headless-api-height on flag.CommandLine as
-// a side effect of being called, and returns the runmode.Mode that starts the headless debug API those flags
-// configure.
+// newHeadlessAPIRunMode registers -headless-api, -headless-api-width and -headless-api-height on flagSet as a side
+// effect of being called, and returns the runmode.Mode that starts the headless debug API those flags configure.
 func newHeadlessAPIRunMode(flagSet *flag.FlagSet) runmode.Mode {
 	if flagSet == nil {
 		flagSet = flag.CommandLine

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -227,12 +227,12 @@ func StartHeadlessAPI(addr string, width, height float32, files []string) {
 	httpServer := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 
 	// The workspace's own settings-saving close handler (workspaceWillClose, in workspace.go) only ever runs when the
-	// main window is closed the normal way, and nothing here ever closes it -- the process just runs until killed.
-	// Without this, everything settings-backed (page reference mappings, recent files, window layout, and so on) that
-	// a session here changes is silently lost the moment the container stops, however it stops. A periodic autosave
-	// covers an unclean stop (SIGKILL, OOM, a crash); the signal handler below covers a clean one (SIGINT/SIGTERM,
-	// which is what "podman stop"/"docker stop" send, and Ctrl-C) by saving once more and only then letting the
-	// process exit, so the common case loses nothing at all.
+	// main window is closed the normal way, which a session driven purely through this API never does -- it just runs
+	// until stopped from outside. Without this, everything settings-backed (page reference mappings, recent files,
+	// window layout, and so on) that a session here changes is silently lost the moment the container stops, however
+	// it stops. A periodic autosave covers an unclean stop (SIGKILL, OOM, a crash); the signal handler below covers a
+	// clean one (SIGINT/SIGTERM, which is what "podman stop"/"docker stop" send, and Ctrl-C) by saving once more and
+	// only then letting the process exit, so the common case loses nothing at all.
 	stopAutosave := make(chan struct{})
 	go autosaveSettings(screen, stopAutosave)
 	xos.RunAtExit(func() {
@@ -245,9 +245,19 @@ func StartHeadlessAPI(addr string, width, height float32, files []string) {
 		}
 	})
 
-	if err = httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		errs.Log(err)
-		xos.Exit(1)
+	// The session can end without the server noticing: a quit driven through the app itself -- the Quit menu item, or
+	// a POST /input that reaches it -- ends it while Serve is still blocked on the listener, which would otherwise
+	// leave the server, and the process, running with no UI behind it. Waiting on the screen being done alongside
+	// Serve covers that; the exit handlers registered above shut the server down either way.
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- httpServer.Serve(listener) }()
+	select {
+	case <-screen.Done():
+	case err = <-serveErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errs.Log(err)
+			xos.Exit(1)
+		}
 	}
 	xos.Exit(0)
 }

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -89,10 +89,11 @@ const (
 // negotiateDocFormat picks a docFormat from the value of an Accept header: docFormatJSON for application/json,
 // docFormatYAML for application/yaml or application/x-yaml, and docFormatMD -- the default -- for anything else,
 // including an empty or missing header, "*/*", or text/markdown itself. Ties (equal, and equal to the highest,
-// "q" value) are broken by whichever the header lists first.
+// "q" value) are broken by whichever the header lists first. A "q" of 0 means "not acceptable", so a format is
+// never chosen because it was the only one listed if the caller said it cannot handle it.
 func negotiateDocFormat(accept string) docFormat {
 	best := docFormatMD
-	bestQ := -1.0
+	bestQ := 0.0
 	for entry := range strings.SplitSeq(accept, ",") {
 		mediaType, q := parseAcceptEntry(entry)
 		var format docFormat

--- a/ux/headless_api.go
+++ b/ux/headless_api.go
@@ -115,6 +115,7 @@ func StartHeadlessAPI(addr string, width, height float32, files []string) {
 		xos.ExitWithMsg(fmt.Sprintf("unable to start the headless session: %v", err))
 	}
 	server.screen = screen
+	xos.RunAtExit(screen.Stop)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /input", server.handleInput)
@@ -152,7 +153,6 @@ func StartHeadlessAPI(addr string, width, height float32, files []string) {
 	if err = httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		errs.Log(err)
 	}
-	screen.Stop()
 	xos.Exit(0)
 }
 

--- a/ux/headless_api.md
+++ b/ux/headless_api.md
@@ -69,10 +69,16 @@ for every ancestor up to the window's root. `404` if there is no window at that 
 ```json
 {
   "window": {"title": "GCS", "rect": {"x": 0, "y": 0, "w": 1400, "h": 900}},
-  "panel": {"type": "*unison.Label", "rect": {"x": 8, "y": 28, "w": 115, "h": 17}, "enabled": true, "text": "..."},
-  "ancestors": [{"type": "...", "rect": {...}, "enabled": true}, ...]
+  "panel": {"type": "*unison.Label", "rect": {"x": 8, "y": 28, "w": 115, "h": 17},
+            "visible": {"x": 8, "y": 28, "w": 115, "h": 17}, "enabled": true, "text": "..."},
+  "ancestors": [{"type": "...", "rect": {...}, "visible": {...}, "enabled": true}, ...]
 }
 ```
+
+`rect` is the widget's whole extent; `visible` is the part of it that is actually on screen, after every ancestor has
+clipped it. Inside a scroll panel the two differ, and a widget scrolled out of sight has no `visible` at all. **Aim
+input at `visible`**, not at `rect`: the center of a `rect` that is mostly clipped away lands on whatever is drawn
+over that spot instead, or outside the window entirely.
 
 ## GET /inspect/focus
 

--- a/ux/headless_api.md
+++ b/ux/headless_api.md
@@ -1,0 +1,112 @@
+# GCS headless debug API
+
+This is a headless GCS session: no real window is visible anywhere, but the full UI is running and can be driven and
+inspected over this HTTP API. It only exists in builds compiled with the `headlessapi` build tag, via the hidden
+`-headless-api` command line flag.
+
+Coordinates everywhere in this API -- input points, inspected rects, screenshot rects -- are in the same logical,
+screen-absolute space: the one `/inspect` and `/inspect/focus` report a widget's rect in is exactly the one a
+screenshot rect or an input point should be given in. Windows other than the main one (such as a modal error dialog)
+are positioned within this same space, not at their own private origin. The virtual screen's size is fixed for the
+life of the session; there is no live resize.
+
+## GET /
+
+This document. Content-negotiated via the `Accept` header: Markdown (`text/markdown`) by default, or this API's
+full [OpenAPI](https://www.openapis.org/) specification as YAML (`application/yaml` or `application/x-yaml`) or JSON
+(`application/json`) if that's what `Accept` asks for.
+
+## GET /input
+
+The vocabulary `POST /input`'s `key` and `mods` fields recognize, straight from unison's own names (so this list
+tracks whatever GCS is built against, rather than being maintained by hand):
+
+```json
+{"keys": ["A", "B", ..., "return", "escape", ...], "modifiers": ["ctrl", "alt", "shift", "caps", "num", "cmd"]}
+```
+
+`key` also tolerates other casings of these names (`"a"` and `"A"` both work; `"f1"` and `"F1"` both work). `mods`
+also tolerates a handful of longer aliases (`"control"`, `"option"`, `"command"`, `"capslock"`, `"numlock"`) and
+`"+"`-joined combinations of any of these names in one entry.
+
+## POST /input
+
+Injects one input event. JSON body:
+
+```json
+{ "op": "click", "x": 0, "y": 0 }
+```
+
+Fields, all optional except `op`:
+
+| Field              | Type        | Used by                                                                                                                     |
+| ------------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `op`               | string      | always -- one of the ops below                                                                                              |
+| `x`, `y`           | number      | `click`, `doubleclick`, `drag` (from), `wheel`                                                                              |
+| `toX`, `toY`       | number      | `drag` (to)                                                                                                                 |
+| `deltaX`, `deltaY` | number      | `wheel`                                                                                                                     |
+| `steps`            | int         | `drag` -- number of intermediate move steps (default 1)                                                                     |
+| `button`           | string      | `click` -- `"left"` (default), `"right"`, or `"middle"`                                                                     |
+| `mods`             | string[]    | `click`, `wheel`, `key` -- see `GET /input` for the recognized names; entries may also be `"+"`-joined, e.g. `"ctrl+shift"` |
+| `text`             | string      | `type` -- typed one rune at a time, the way a person at a keyboard would                                                    |
+| `key`, `code`      | string, int | `key` -- see `GET /input`; `code` is a raw numeric key code and takes precedence over `key` if both are given               |
+
+Ops:
+
+- `click` -- press and release `button` at `(x, y)`
+- `doubleclick` -- click twice at `(x, y)` with a click count of two
+- `drag` -- press at `(x, y)`, move to `(toX, toY)` over `steps` steps, release
+- `wheel` -- rotate the mouse wheel by `(deltaX, deltaY)` at `(x, y)`
+- `type` -- type `text`
+- `key` -- press and release `key` (or `code`) with `mods` held
+
+Response: `{"ok": true}`, or a `4xx` with a plain-text error.
+
+## GET /inspect?x=&y=
+
+Reports the widget at a point: its type, absolute bounding rect, tooltip, enabled state and text, along with the same
+for every ancestor up to the window's root. `404` if there is no window at that point.
+
+```json
+{
+  "window": {"title": "GCS", "rect": {"x": 0, "y": 0, "w": 1400, "h": 900}},
+  "panel": {"type": "*unison.Label", "rect": {"x": 8, "y": 28, "w": 115, "h": 17}, "enabled": true, "text": "..."},
+  "ancestors": [{"type": "...", "rect": {...}, "enabled": true}, ...]
+}
+```
+
+## GET /inspect/focus
+
+The same shape as `GET /inspect`, but for whatever panel currently holds keyboard focus -- in whichever window
+currently has it, which may be a modal dialog (such as an error dialog a normal user would see and dismiss) rather
+than the main window. `404` if nothing is focused.
+
+## GET /screenshot
+
+A PNG (`Content-Type: image/png`) of the whole virtual screen. With `x`, `y`, `w` and `h` all given, a PNG cropped to
+that absolute rectangle instead.
+
+## GET /console?since=
+
+Log output and session errors recorded since sequence number `since` (default 0 -- everything), for polling
+incrementally:
+
+```json
+{
+    "entries": [
+        {
+            "seq": 1,
+            "time": "2026-01-01T00:00:00Z",
+            "source": "log",
+            "level": "INFO",
+            "message": "..."
+        }
+    ]
+}
+```
+
+`source` is `"log"` for slog output (including anything logged via `errs.Log`, wherever its handler sends it) or
+`"session"` for a recovered panic or a request the headless session itself refused. This does not include app-level
+errors surfaced after startup through the normal error dialog (a failed file load, say) -- those still show up as a
+real modal dialog, findable and dismissable through `/inspect/focus`, `/input` and `/screenshot` like any other UI
+state, exactly as a user would see them.

--- a/ux/headless_api.md
+++ b/ux/headless_api.md
@@ -84,7 +84,8 @@ over that spot instead, or outside the window entirely.
 
 The same shape as `GET /inspect`, but for whatever panel currently holds keyboard focus -- in whichever window
 currently has it, which may be a modal dialog (such as an error dialog a normal user would see and dismiss) rather
-than the main window. `404` if nothing is focused.
+than the main window. `404` if no window is focused. Purely a read: a window that nothing in has been focused into
+reports no `panel` rather than acquiring one.
 
 ## GET /screenshot
 

--- a/ux/headless_api.md
+++ b/ux/headless_api.md
@@ -25,9 +25,8 @@ tracks whatever GCS is built against, rather than being maintained by hand):
 {"keys": ["A", "B", ..., "return", "escape", ...], "modifiers": ["ctrl", "alt", "shift", "caps", "num", "cmd"]}
 ```
 
-`key` also tolerates other casings of these names (`"a"` and `"A"` both work; `"f1"` and `"F1"` both work). `mods`
-also tolerates a handful of longer aliases (`"control"`, `"option"`, `"command"`, `"capslock"`, `"numlock"`) and
-`"+"`-joined combinations of any of these names in one entry.
+`key` also tolerates other casings of these names (`"a"` and `"A"` both work; `"f1"` and `"F1"` both work). A `mods`
+entry may also be a `"+"`-joined combination of these names, e.g. `"ctrl+shift"`.
 
 ## POST /input
 

--- a/ux/headless_api.yaml
+++ b/ux/headless_api.yaml
@@ -99,7 +99,8 @@ paths:
             description: >-
                 The same shape as GET /inspect, but for whatever panel currently holds keyboard focus -- in
                 whichever window currently has it, which may be a modal dialog (such as an error dialog a normal
-                user would see and dismiss) rather than the main window.
+                user would see and dismiss) rather than the main window. Purely a read: a window that nothing in
+                has been focused into reports no "panel" rather than acquiring one.
             responses:
                 "200":
                     description: OK
@@ -108,7 +109,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/InspectResult"
                 "404":
-                    description: Nothing is focused
+                    description: No window is focused
                     content:
                         text/plain:
                             schema:

--- a/ux/headless_api.yaml
+++ b/ux/headless_api.yaml
@@ -271,7 +271,17 @@ components:
                     type: string
                     description: The Go type of the widget, e.g. "*unison.Label".
                 rect:
-                    $ref: "#/components/schemas/Rect"
+                    allOf:
+                        - $ref: "#/components/schemas/Rect"
+                    description: The widget's whole extent, which a scroll panel may show only part of.
+                visible:
+                    allOf:
+                        - $ref: "#/components/schemas/Rect"
+                    description: >-
+                        The part of "rect" that is actually on screen, after every ancestor has clipped it. Aim input
+                        here rather than at "rect": the center of a rect that is mostly clipped away lands on whatever
+                        is drawn over that spot instead, or outside the window entirely. Absent when none of the
+                        widget is showing, because it is hidden or scrolled out of sight.
                 tooltip:
                     type: string
                 enabled:

--- a/ux/headless_api.yaml
+++ b/ux/headless_api.yaml
@@ -77,9 +77,7 @@ paths:
                 along with the same for every ancestor up to the window's root.
             parameters:
                 - $ref: "#/components/parameters/X"
-                  required: true
                 - $ref: "#/components/parameters/Y"
-                  required: true
             responses:
                 "200":
                     description: OK
@@ -163,11 +161,13 @@ components:
         X:
             name: x
             in: query
+            required: true
             schema:
                 type: number
         Y:
             name: y
             in: query
+            required: true
             schema:
                 type: number
         BBOX:
@@ -244,19 +244,20 @@ components:
                         type: string
         Rect:
             type: object
+            required:
+                - x
+                - y
+                - w
+                - h
             properties:
                 x:
                     type: number
-                    required: true
                 y:
                     type: number
-                    required: true
                 w:
                     type: number
-                    required: true
                 h:
                     type: number
-                    required: true
             additionalProperties: false
         Window:
             type: object

--- a/ux/headless_api.yaml
+++ b/ux/headless_api.yaml
@@ -1,0 +1,314 @@
+openapi: 3.0.3
+info:
+    title: GCS headless debug API
+    version: "1.0.0"
+    description: >-
+        Drives and inspects a headless GCS session: no real window is visible anywhere, but the full UI is
+        running. Only exists in builds compiled with the headlessapi build tag, via the hidden -headless-api
+        command line flag. GET / serves this document itself.
+
+        Coordinates everywhere in this API -- input points, inspected rects, screenshot rects -- are in the
+        same logical, screen-absolute space: the one /inspect and /inspect/focus report a widget's rect in is
+        exactly the one a screenshot rect or an input point should be given in. Windows other than the main
+        one (such as a modal error dialog) are positioned within this same space, not at their own private
+        origin. The virtual screen's size is fixed for the life of the session; there is no live resize.
+paths:
+    /:
+        get:
+            summary: API documentation
+            description: >-
+                This API's documentation. Content-negotiated via the Accept header: Markdown
+                ("text/markdown") by default, or this specification itself as YAML ("application/yaml" or
+                "application/x-yaml") or JSON ("application/json") if that's what the Accept header asks
+                for.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        text/markdown:
+                            schema:
+                                type: string
+                        application/yaml:
+                            schema:
+                                type: string
+                        application/json:
+                            schema:
+                                type: object
+    /input:
+        get:
+            summary: Recognized key and modifier names
+            description: >-
+                The vocabulary POST /input's "key" and "mods" fields recognize, straight from unison's own
+                names. "key" is case-insensitive. "mods" also tolerates a handful of longer aliases (e.g.
+                "control", "capslock") and "+"-joined combinations in one entry (e.g. "ctrl+shift").
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/InputVocabulary"
+        post:
+            summary: Inject one input event
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/InputRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/OK"
+                "400":
+                    description: Invalid request body, unknown op, or unrecognized key
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+    /inspect:
+        get:
+            summary: The widget at a point
+            description: >-
+                Reports the widget at (x, y): its type, absolute bounding rect, tooltip, enabled state and text,
+                along with the same for every ancestor up to the window's root.
+            parameters:
+                - $ref: "#/components/parameters/X"
+                  required: true
+                - $ref: "#/components/parameters/Y"
+                  required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/InspectResult"
+                "404":
+                    description: No window at that point
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+    /inspect/focus:
+        get:
+            summary: The focused widget
+            description: >-
+                The same shape as GET /inspect, but for whatever panel currently holds keyboard focus -- in
+                whichever window currently has it, which may be a modal dialog (such as an error dialog a normal
+                user would see and dismiss) rather than the main window.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/InspectResult"
+                "404":
+                    description: Nothing is focused
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+    /screenshot:
+        get:
+            summary: A screenshot
+            description: >-
+                A PNG of the whole virtual screen, or -- with x, y, w and h all given -- a PNG cropped to that
+                absolute rectangle instead.
+            parameters:
+                - $ref: "#/components/parameters/BBOX"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        image/png:
+                            schema:
+                                type: string
+                                format: binary
+                "400":
+                    description: x, y, w and h were not all given together, as numbers
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+    /console:
+        get:
+            summary: Log output and session errors
+            description: >-
+                Entries recorded since sequence number "since" (default 0 -- everything), for polling
+                incrementally. Does not include app-level errors surfaced after startup through the normal error
+                dialog (a failed file load, say) -- those still show up as a real modal dialog, findable and
+                dismissable through /inspect/focus, /input and /screenshot like any other UI state.
+            parameters:
+                - name: since
+                  in: query
+                  required: false
+                  schema:
+                      type: integer
+                      default: 0
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ConsoleLog"
+components:
+    parameters:
+        X:
+            name: x
+            in: query
+            schema:
+                type: number
+        Y:
+            name: y
+            in: query
+            schema:
+                type: number
+        BBOX:
+            name: bbox
+            in: query
+            style: form
+            explode: true
+            schema:
+                $ref: "#/components/schemas/Rect"
+    schemas:
+        OK:
+            type: object
+            properties:
+                ok:
+                    type: boolean
+        InputRequest:
+            type: object
+            required:
+                - op
+            properties:
+                op:
+                    type: string
+                    enum: [click, doubleclick, drag, wheel, type, key]
+                    description: Which input event to inject.
+                x:
+                    type: number
+                    description: click, doubleclick, drag (from), wheel
+                y:
+                    type: number
+                    description: click, doubleclick, drag (from), wheel
+                toX:
+                    type: number
+                    description: drag (to)
+                toY:
+                    type: number
+                    description: drag (to)
+                deltaX:
+                    type: number
+                    description: wheel
+                deltaY:
+                    type: number
+                    description: wheel
+                steps:
+                    type: integer
+                    description: drag -- number of intermediate move steps (default 1)
+                button:
+                    type: string
+                    enum: [left, right, middle]
+                    description: click (default left)
+                mods:
+                    type: array
+                    items:
+                        type: string
+                    description: click, wheel, key -- see GET /input for recognized names
+                text:
+                    type: string
+                    description: type -- typed one rune at a time, the way a person at a keyboard would
+                key:
+                    type: string
+                    description: key -- see GET /input
+                code:
+                    type: integer
+                    description: key -- a raw numeric key code; takes precedence over "key" if both are given
+        InputVocabulary:
+            type: object
+            properties:
+                keys:
+                    type: array
+                    items:
+                        type: string
+                modifiers:
+                    type: array
+                    items:
+                        type: string
+        Rect:
+            type: object
+            properties:
+                x:
+                    type: number
+                    required: true
+                y:
+                    type: number
+                    required: true
+                w:
+                    type: number
+                    required: true
+                h:
+                    type: number
+                    required: true
+            additionalProperties: false
+        Window:
+            type: object
+            properties:
+                title:
+                    type: string
+                rect:
+                    $ref: "#/components/schemas/Rect"
+        Panel:
+            type: object
+            properties:
+                type:
+                    type: string
+                    description: The Go type of the widget, e.g. "*unison.Label".
+                rect:
+                    $ref: "#/components/schemas/Rect"
+                tooltip:
+                    type: string
+                enabled:
+                    type: boolean
+                text:
+                    type: string
+        InspectResult:
+            type: object
+            properties:
+                window:
+                    $ref: "#/components/schemas/Window"
+                panel:
+                    $ref: "#/components/schemas/Panel"
+                ancestors:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/Panel"
+        ConsoleEntry:
+            type: object
+            properties:
+                seq:
+                    type: integer
+                time:
+                    type: string
+                    format: date-time
+                source:
+                    type: string
+                    enum: [log, session]
+                    description: '"log" for slog output; "session" for a recovered panic or a refused request.'
+                level:
+                    type: string
+                message:
+                    type: string
+        ConsoleLog:
+            type: object
+            properties:
+                entries:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ConsoleEntry"

--- a/ux/headless_api.yaml
+++ b/ux/headless_api.yaml
@@ -39,8 +39,8 @@ paths:
             summary: Recognized key and modifier names
             description: >-
                 The vocabulary POST /input's "key" and "mods" fields recognize, straight from unison's own
-                names. "key" is case-insensitive. "mods" also tolerates a handful of longer aliases (e.g.
-                "control", "capslock") and "+"-joined combinations in one entry (e.g. "ctrl+shift").
+                names. "key" is case-insensitive. A "mods" entry may also be a "+"-joined combination of
+                these names, e.g. "ctrl+shift".
             responses:
                 "200":
                     description: OK

--- a/ux/headless_api_test.go
+++ b/ux/headless_api_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 
 	"github.com/richardwilkes/toolbox/v2/check"
+	"github.com/richardwilkes/toolbox/v2/geom"
+	"github.com/richardwilkes/unison"
 )
 
 func TestNegotiateDocFormat(t *testing.T) {
@@ -44,4 +46,40 @@ func TestNegotiateDocFormat(t *testing.T) {
 	} {
 		c.Equal(tc.want, negotiateDocFormat(tc.accept), tc.name)
 	}
+}
+
+func TestClipToVisible(t *testing.T) {
+	c := check.New(t)
+
+	// A stack of panels the size of the outermost one: nothing clips anything.
+	outer := unison.NewPanel()
+	outer.SetFrameRect(geom.NewRect(0, 0, 100, 100))
+	inner := unison.NewPanel()
+	inner.SetFrameRect(geom.NewRect(0, 0, 100, 100))
+	outer.AddChild(inner)
+	c.Equal(geom.NewRect(0, 0, 100, 100), clipToVisible(inner, inner.RectToRoot(inner.ContentRect(false))),
+		"an unclipped panel is visible in full")
+
+	// A child hanging halfway out of its parent, the way a row scrolled to the edge of a scroll panel's view port
+	// does: only the half still inside can be seen, and only that half can be clicked.
+	half := unison.NewPanel()
+	half.SetFrameRect(geom.NewRect(0, 50, 100, 100))
+	outer.AddChild(half)
+	c.Equal(geom.NewRect(0, 50, 100, 50), clipToVisible(half, half.RectToRoot(half.ContentRect(false))),
+		"a partly clipped panel reports only the part still showing")
+
+	// A child entirely past its parent's bottom edge, the way a row scrolled out of view does.
+	past := unison.NewPanel()
+	past.SetFrameRect(geom.NewRect(0, 100, 100, 100))
+	outer.AddChild(past)
+	c.True(clipToVisible(past, past.RectToRoot(past.ContentRect(false))).Empty(),
+		"a panel clipped away entirely reports nothing visible")
+
+	// Hidden panels draw nothing, whether it is the panel itself or something it sits inside that is hidden.
+	inner.Hidden = true
+	c.True(clipToVisible(inner, inner.RectToRoot(inner.ContentRect(false))).Empty(), "a hidden panel is not visible")
+	inner.Hidden = false
+	outer.Hidden = true
+	c.True(clipToVisible(inner, inner.RectToRoot(inner.ContentRect(false))).Empty(),
+		"a panel inside a hidden panel is not visible")
 }

--- a/ux/headless_api_test.go
+++ b/ux/headless_api_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 1998-2026 by Richard A. Wilkes. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, version 2.0. If a copy of the MPL was not distributed with
+// this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This Source Code Form is "Incompatible With Secondary Licenses", as
+// defined by the Mozilla Public License, version 2.0.
+
+//go:build headlessapi
+
+package ux
+
+import (
+	"testing"
+
+	"github.com/richardwilkes/toolbox/v2/check"
+)
+
+func TestNegotiateDocFormat(t *testing.T) {
+	c := check.New(t)
+	for _, tc := range []struct {
+		name   string
+		accept string
+		want   docFormat
+	}{
+		{name: "missing", want: docFormatMD},
+		{name: "anything", accept: "*/*", want: docFormatMD},
+		{name: "unknown type", accept: "text/html", want: docFormatMD},
+		{name: "json", accept: "application/json", want: docFormatJSON},
+		{name: "yaml", accept: "application/yaml", want: docFormatYAML},
+		{name: "yaml, the other spelling", accept: "application/x-yaml", want: docFormatYAML},
+		{name: "markdown", accept: "text/markdown", want: docFormatMD},
+		{name: "highest q wins", accept: "application/json;q=0.2, application/yaml;q=0.8", want: docFormatYAML},
+		{name: "a tie goes to the first listed", accept: "application/yaml, application/json", want: docFormatYAML},
+		{name: "q defaults to 1", accept: "application/json;q=0.9, application/yaml", want: docFormatYAML},
+		{name: "spaces and other params", accept: " application/json ; charset=utf-8 ; q=0.9 ", want: docFormatJSON},
+		// A q of 0 means "not acceptable", so it must not win merely by being the only format listed.
+		{name: "q of 0 is refused", accept: "application/json;q=0", want: docFormatMD},
+		{
+			name: "q of 0 loses to a lower listed format", accept: "application/json;q=0, application/yaml;q=0.1",
+			want: docFormatYAML,
+		},
+	} {
+		c.Equal(tc.want, negotiateDocFormat(tc.accept), tc.name)
+	}
+}


### PR DESCRIPTION
This run mode is build flag gated and designed to be used during local
automated integration testing. It's provided so the application can run
in a "headless" manner where it's rendered into a frame buffer that is
exposed via a simple HTTP API. This same API also provides a path for
input as well as some additional endpoints to inspect the internal UI
structures.

NOTE: This *will not* be part of a normal build. The `headlessapi` build
flag is needed to include this feature.